### PR TITLE
Fix bug in resampling of testing data

### DIFF
--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -149,7 +149,7 @@ def cmd_train(context):
     scheduler = optim.lr_scheduler.CosineAnnealingLR(optimizer, num_epochs)
 
     # Write the metrics, images, etc to TensorBoard format
-    writer = SummaryWriter(logdir=context["log_directory"])
+    writer = SummaryWriter(log_dir=context["log_directory"])
 
     # Create dict containing gammas and betas after each FiLM layer.
     gammas_dict = {i:[] for i in range(1,9)}
@@ -413,7 +413,7 @@ def cmd_test(context):
 
     # These are the validation/testing transformations
     val_transform = transforms.Compose([
-        mt_transforms.Resample(wspace=0.75, hspace=0.75, labeled=False),
+        mt_transforms.Resample(wspace=0.75, hspace=0.75),
         mt_transforms.CenterCrop2D((128, 128)),
         mt_transforms.ToTensor(),
         mt_transforms.NormalizeInstance(),


### PR DESCRIPTION
This PR (minor) fixes a bug in the resampling of testing data.
Bug reported by @Valentine-LL.

Observed curious low results on the testing dataset. For instance while running `ivadomed config/config.json` on `master`:
```
{'dice_score': 45.59562929752584, 'precision_score': 97.27674828042987, 'recall_score': 30.023394819931063, 'specificity_score': 99.98723065760511, 'intersection_over_union': 29.87641267323213, 'accuracy_score': 98.78022528022264}
```

It was due to an error in the parameters of the resampling transformation (my bad): [here](https://github.com/neuropoly/ivado-medical-imaging/blob/master/ivadomed/main.py#L416).
The parameter `labeled` should be set to `True` otherwise the ground-truth is not resampled (see [here](https://github.com/perone/medicaltorch/blob/master/medicaltorch/transforms.py#L658)).

By correcting this, we obtained expected results:
```
{'dice_score': 80.48784457432399, 'precision_score': 98.03924702901338, 'recall_score': 69.36005744779943, 'specificity_score': 99.99054643053445, 'intersection_over_union': 68.53612784193764, 'accuracy_score': 99.75648829466695}
```
(still low-ish but nothing scary here: I just did a quick test with 10 epochs)