### PR TITLE
Modify the target's suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The `config.json` is a configuration example.
 Please find below a description of each parameter:
 - `command`: run the specified command (choice: "train", "test").
 - `gpu`: ID of the used GPU.
-- `gt_prefixe`: suffixe of the derivative file containing the ground-truth of interest (e.g. "_seg-manual", "_lesin-manual").
+- `gt_suffix`: suffix of the derivative file containing the ground-truth of interest (e.g. "_seg-manual", "_lesin-manual").
 - `bids_path`: relative path of the BIDS folder.
 - `random_seed`: seed used by the random number generator to split the dataset between training/validation/testing.
 - `contrast_train_validation`: list of image modalities included in the training and validation datasets.

--- a/config/config.json
+++ b/config/config.json
@@ -1,7 +1,7 @@
 {
 	"command": "train",
 	"gpu": 5,
-        "gt_prefixe": "_seg-manual",
+        "gt_suffix": "_seg-manual",
 	"bids_path": "../duke/projects/ivado-medical-imaging/spineGeneric_201907041011/result/",
         "random_seed": 1313,
         "contrast_train_validation": ["T1w", "T2w", "T2star", "acq-MToff_MTS", "acq-MTon_MTS", "acq-T1w_MTS"],

--- a/config/config_gm.json
+++ b/config/config_gm.json
@@ -1,7 +1,7 @@
 {
 	"command": "train",
 	"gpu": 4,
-        "gt_prefixe": "_seg-manual",
+        "gt_suffix": "_seg-manual",
 	"bids_path": "../duke/projects/ivado-medical-imaging/gm_challenge_16",
         "random_seed": 1313,
         "contrast_train_validation": ["T2star"],

--- a/config/config_sctTesting.json
+++ b/config/config_sctTesting.json
@@ -1,7 +1,7 @@
 {
 	"command": "train",
 	"gpu": 4,
-        "gt_prefixe": "_lesion-manual",
+        "gt_suffix": "_lesion-manual",
 	"bids_path": "../duke/sct_testing/large/",
         "random_seed": 1313,
         "contrast_train_validation": ["T2w", "T1w", "acq-axmid00100_T2w", "acq-axbottom_T2w", "acq-sagtsp_T2w", "acq-sagstir_T2w", "acq-axtop_T2w", "acq-ax00014_T2w", "acq-axtsp_T2w", "acq-axtop00100_T2w", "acq-axcsp_T2w", "acq-sup_T2star", "acq-ax_T2w", "acq-sagcsp_T2w", "acq-axmid00005_T2w", "acq-sagstirtsp_T2w", "acq-ax00012_T2w", "acq-axlow_T2w", "T2star", "acq-sagstircsp_T2w", "acq-sag_T2w", "acq-sag00015_T2w", "acq-inf_T2star"],

--- a/config/config_small.json
+++ b/config/config_small.json
@@ -1,7 +1,7 @@
 {
 	"command": "train",
 	"gpu": 4,
-        "gt_prefixe": "_seg-manual",
+        "gt_suffix": "_seg-manual",
 	"bids_path_train": "../duke/projects/ivado-medical-imaging/spineGeneric_201907041011/result/",
 	"random_seed": 1313,
 	"contrast_train_validation": ["T1w", "T2w", "T2star", "acq-MToff_MTS", "acq-MTon_MTS", "acq-T1w_MTS"],

--- a/ivadomed/loader.py
+++ b/ivadomed/loader.py
@@ -18,6 +18,7 @@ MANUFACTURER_CATEGORY = {'Siemens': 0, 'Philips': 1, 'GE': 2}
 
 class BIDSSegPair2D(mt_datasets.SegmentationPair2D):
     def __init__(self, input_filename, gt_filename, metadata, contrast, cache=True, canonical=True):
+        print(input_filename)
         super().__init__(input_filename, gt_filename, canonical=canonical)
 
         self.metadata = metadata
@@ -41,7 +42,7 @@ class MRI2DBidsSegDataset(mt_datasets.MRI2DSegmentationDataset):
 
 
 class BidsDataset(MRI2DBidsSegDataset):
-    def __init__(self, root_dir, subject_lst, gt_prefixe, contrast_lst, contrast_balance={}, slice_axis=2, cache=True,
+    def __init__(self, root_dir, subject_lst, gt_suffix, contrast_lst, contrast_balance={}, slice_axis=2, cache=True,
                  transform=None, metadata_bool=True, slice_filter_fn=None,
                  canonical=True, labeled=True):
 
@@ -78,7 +79,7 @@ class BidsDataset(MRI2DBidsSegDataset):
                 cord_label_filename = None
 
                 for deriv in derivatives:
-                    if deriv.endswith(subject.record["modality"]+gt_prefixe+".nii.gz"):
+                    if deriv.endswith(subject.record["modality"]+gt_suffix+".nii.gz"):
                         cord_label_filename = deriv
 
                 if cord_label_filename is None:

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -94,7 +94,7 @@ def cmd_train(context):
     # the slices without labels and then concatenating all the datasets together
     ds_train = loader.BidsDataset(context["bids_path"],
                                   subject_lst=train_lst,
-                                  gt_prefixe=context["gt_prefixe"],
+                                  gt_suffix=context["gt_suffix"],
                                   contrast_lst=context["contrast_train_validation"],
                                   metadata_bool=metadata_bool,
                                   contrast_balance=context["contrast_balance"],
@@ -114,7 +114,7 @@ def cmd_train(context):
     # Validation dataset ------------------------------------------------------
     ds_val = loader.BidsDataset(context["bids_path"],
                                 subject_lst=valid_lst,
-                                gt_prefixe=context["gt_prefixe"],
+                                gt_suffix=context["gt_suffix"],
                                 contrast_lst=context["contrast_train_validation"],
                                 metadata_bool=metadata_bool,
                                 transform=val_transform,
@@ -424,7 +424,7 @@ def cmd_test(context):
     test_lst = joblib.load("./"+context["log_directory"]+"/split_datasets.joblib")['test']
     ds_test = loader.BidsDataset(context["bids_path"],
                                  subject_lst=test_lst,
-                                 gt_prefixe=context["gt_prefixe"],
+                                 gt_suffix=context["gt_suffix"],
                                  contrast_lst=context["contrast_test"],
                                  metadata_bool=bool(context["metadata_bool"]),
                                  transform=val_transform,


### PR DESCRIPTION
This PR aims at allowing the user to choose the ground truth's suffix (e.g. `_seg-manual`, `_lesion-manual`). We can then select the appropriate derivative file / mask of the tissue of interest (i.e. to segment).

#### Implementation:
Add a field `gt_prefix` in the config files so that the `loader` can import the files of interest.

Tested it on sct_testing/large.


(Update 29/08/2019: Found an issue "Input and ground truth with different dimensions." on `sub-bwh024`.
Update 03/09/2019: The above issue will be discussed on Slack)