### PR TITLE
Set torchvision==0.2.1 to prevent error with torch==1.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 torch==1.2.0
+torchvision==0.2.1
 bids-neuropoly>=0.1
 medicaltorch>=0.2
 tensorboard


### PR DESCRIPTION
As experienced by @andreanne-lemay setting `torch=1.2.0` causes a problem with the latest torchvision (supposed to work according to their doc, but in reality it works only with `1.3.0`). A  temporary fix is to set `torchvision==0.2.1` until we decide out what to do with `CUDA 10.1` vs `torch 1.3.0` (#69)