### PR TITLE
Postprocessing: Adding Conditional Random Field (CRF) interrogation mark

### DIFF
--- a/ivadomed/postprocessing.py
+++ b/ivadomed/postprocessing.py
@@ -3,6 +3,7 @@
 import functools
 import numpy as np
 import nibabel as nib
+import pydensecrf.densecrf as dcrf
 from scipy.ndimage.measurements import label
 from scipy.ndimage.morphology import binary_fill_holes
 
@@ -141,12 +142,17 @@ def mask_predictions(predictions, mask_binary):
 
 def apply_crf(predictions, image):
     """
-    Apply Conditional Random Fields to the soft predictions.
+    Apply Conditional Random Fields to the soft predictions. 2D inputs only.
 
     Args:
-        predictions (array): Input soft segmentation. Image could be 2D or 3D.
-        image (array): Input image
+        predictions (np.array): Input 2D soft segmentation.
+        image (np.array): Input 2D image.
     Returns:
         Array.
     """
-    pass
+    # Get data shape
+    height, width = predictions.shape
+    # TODO: compatible with multi label
+    n_label = 1
+    # Init DenseCRF
+    d = dcrf.DenseCRF2D(width, height, n_label)

--- a/ivadomed/postprocessing.py
+++ b/ivadomed/postprocessing.py
@@ -147,16 +147,22 @@ def apply_crf(predictions, image, eps=1e-6):
     Args:
         predictions (np.array): Input 2D soft segmentation.
         image (np.array): Input 2D image.
-        eps (float): To avoid log(0).
+        eps (float): To avoid log(0): need to clip 0 probabilities to a positive value
     Returns:
         Array.
     """
     # Get data shape
     height, width, n_label = predictions.shape
+
     # Init DenseCRF
     d = dcrf.DenseCRF2D(width, height, n_label)
-    # XX
 
-    # Get the Unary which is negative log probabilities
-    U = -np.log(predictions+eps)  # (n_label, height, width)
-
+    # Unary, negative log probabilities
+    # Transpose axes
+    predictions.transpose(2, 0, 1)
+    # Clip 0 probabilities
+    predictions = np.clip(predictions, eps, 1.0)
+    # Get Unary
+    U = -np.log(predictions).astype(np.float32)
+    # Flatten
+    U.reshape([n_label, -1])

--- a/ivadomed/postprocessing.py
+++ b/ivadomed/postprocessing.py
@@ -166,3 +166,6 @@ def apply_crf(predictions, image, eps=1e-6):
     U = -np.log(predictions).astype(np.float32)
     # Flatten
     U.reshape([n_label, -1])
+    # Set Unary potentials
+    d.setUnaryEnergy(np.ascontiguousarray(U))
+

--- a/ivadomed/postprocessing.py
+++ b/ivadomed/postprocessing.py
@@ -185,6 +185,16 @@ def apply_crf(predictions, image, n_iterations=5, eps=1e-6):
 
     # INFERENCE
     Q = d.inference(n_iterations)
+    # Get MAP predictions
+    map = np.argmax(Q, axis=0).reshape((height, width))
 
-
-
+    """
+    # STEP BY STEP INFERENCE
+    Q, tmp1, tmp2 = d.startInference()
+    for i in range(n_iterations):
+        print("KL-divergence at {}: {}".format(i, d.klDivergence(Q)))
+        d.stepInference(Q, tmp1, tmp2)
+    kl = d.klDivergence(Q) / (height * width)
+    map = np.argmax(Q, axis=0).reshape((height, width))
+    """
+    return map

--- a/ivadomed/postprocessing.py
+++ b/ivadomed/postprocessing.py
@@ -140,13 +140,14 @@ def mask_predictions(predictions, mask_binary):
     return predictions * mask_binary
 
 
-def apply_crf(predictions, image, eps=1e-6):
+def apply_crf(predictions, image, n_iterations=5, eps=1e-6):
     """
     Apply Conditional Random Fields to the soft predictions. 2D inputs, with shape: shape: n_label, height, width.
 
     Args:
         predictions (np.array): Input 2D soft segmentation.
         image (np.array): Input 2D image.
+        n_iterations (int):
         eps (float): To avoid log(0): need to clip 0 probabilities to a positive value
     Returns:
         Array.
@@ -181,6 +182,9 @@ def apply_crf(predictions, image, eps=1e-6):
     # TODO: add uncertainty as feature --> change chdim
     feature_prior = dcrf.create_pairwise_bilateral(sdims=x_y_sd, schan=scale_feature, img=image, chdim=-1)
     d.addPairwiseEnergy(feature_prior, compat=feature_potential_strength)
+
+    # INFERENCE
+    Q = d.inference(n_iterations)
 
 
 

--- a/ivadomed/postprocessing.py
+++ b/ivadomed/postprocessing.py
@@ -137,3 +137,16 @@ def mask_predictions(predictions, mask_binary):
     assert predictions.shape == mask_binary.shape
     assert np.array_equal(mask_binary, mask_binary.astype(bool))
     return predictions * mask_binary
+
+
+def apply_crf(predictions, image):
+    """
+    Apply Conditional Random Fields to the soft predictions.
+
+    Args:
+        predictions (array): Input soft segmentation. Image could be 2D or 3D.
+        image (array): Input image
+    Returns:
+        Array.
+    """
+    pass

--- a/ivadomed/postprocessing.py
+++ b/ivadomed/postprocessing.py
@@ -140,19 +140,23 @@ def mask_predictions(predictions, mask_binary):
     return predictions * mask_binary
 
 
-def apply_crf(predictions, image):
+def apply_crf(predictions, image, eps=1e-6):
     """
-    Apply Conditional Random Fields to the soft predictions. 2D inputs only.
+    Apply Conditional Random Fields to the soft predictions. 2D inputs, with shape: shape: n_label, height, width.
 
     Args:
         predictions (np.array): Input 2D soft segmentation.
         image (np.array): Input 2D image.
+        eps (float): To avoid log(0).
     Returns:
         Array.
     """
     # Get data shape
-    height, width = predictions.shape
-    # TODO: compatible with multi label
-    n_label = 1
+    height, width, n_label = predictions.shape
     # Init DenseCRF
     d = dcrf.DenseCRF2D(width, height, n_label)
+    # XX
+
+    # Get the Unary which is negative log probabilities
+    U = -np.log(predictions+eps)  # (n_label, height, width)
+

--- a/ivadomed/postprocessing.py
+++ b/ivadomed/postprocessing.py
@@ -142,13 +142,13 @@ def mask_predictions(predictions, mask_binary):
 
 def apply_crf(predictions, image, n_iterations=5, eps=1e-6):
     """
-    Apply Conditional Random Fields to the soft predictions. 2D inputs, with shape: shape: n_label, height, width.
+    Apply Conditional Random Fields to the soft predictions. 2D inputs, with shape: n_label, height, width.
 
     Args:
         predictions (np.array): Input 2D soft segmentation.
         image (np.array): Input 2D image.
         n_iterations (int):
-        eps (float): To avoid log(0): need to clip 0 probabilities to a positive value
+        eps (float): To avoid log(0), need to clip 0 probabilities to a positive value
     Returns:
         Array.
     """


### PR DESCRIPTION
### Aim
Implement Conditional Random Field (CRF) method in the code base and evaluate its benefit as postprocessing tool.

### CRF
CRF are increasingly used in combination to Deep Learning approach, eg [Ref1](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6700294/), [Ref2](https://arxiv.org/abs/1610.02177), [Ref3](https://arxiv.org/abs/1805.04777).
For a long time impracticable in segmentation tasks, their use has recently been allowed thanks to this [paper](https://arxiv.org/abs/1210.5644). This approach has been implemented in this package, [pydcrf](https://github.com/lucasb-eyer/pydensecrf).
Note to be discussed: this is a (Cython-based) Python wrapper.

### Done
- Implement CRF as a postprocessing method:
    - Unary potential: per-voxel class-probabilities (ie soft output of CNN). It doesn't account for neighborhoods at all.
    - Pairwise potential: smooth out predictions
        1. Feature --> Bilateral potential: the input image. **Prior** = voxels with a similar intensity are likely to belong to the same class.
        2. Spatial --> Gaussian potential. **Prior** =  voxels with a similar intensity are likely to belong to the same class --> enforces more spatially consistent segmentation.
     - Run inference, KL divergence et output the MAP.

```python
def apply_crf(predictions, image, n_iterations=5, eps=1e-6):
    """
    Apply Conditional Random Fields to the soft predictions. 2D inputs, with shape: n_label, height, width.

    Args:
        predictions (np.array): Input 2D soft segmentation.
        image (np.array): Input 2D image.
        n_iterations (int):
        eps (float): To avoid log(0), need to clip 0 probabilities to a positive value
    Returns:
        Array.
    """
```

### Todo
- Add uncertainty as an additional pairwise **Prior**.
- Evaluate the performances of the method.

Fixes #135. 