### PR TITLE
Soft training: minor fixes

### DIFF
--- a/docs/source/configuration_file.rst
+++ b/docs/source/configuration_file.rst
@@ -98,8 +98,10 @@ considered when using ``"ROICrop"``.
 soft_gt
 ^^^^^^^^^^
 
-Bool. Indicated if usage of soft mask. Ground truth will be non-binarized 
-images with float32 encoding.  
+Bool. Indicates if a soft mask will be used as ground-truth to train
+and / or evaluate a model. In particular, the masks are not binarized
+after interpolations implied by preprocessing or data-augmentation operations.
+
 
 Split dataset
 -------------

--- a/ivadomed/config/config.json
+++ b/ivadomed/config/config.json
@@ -24,7 +24,7 @@
         },
         "slice_axis": "axial",
         "multichannel": false,
-        "soft_input": false
+        "soft_gt": false
     },
     "split_dataset": {
         "fname_split": null,

--- a/ivadomed/config/config_sctTesting.json
+++ b/ivadomed/config/config_sctTesting.json
@@ -21,7 +21,7 @@
         },
         "slice_axis": "axial",
         "multichannel": false,
-        "soft_input": false
+        "soft_gt": false
     },
     "split_dataset": {
         "fname_split": null,

--- a/ivadomed/models.py
+++ b/ivadomed/models.py
@@ -1027,7 +1027,7 @@ class Countception(Module):
         name (str): model's name used for call in configuration file.
     """
 
-    def __init__(self, in_channel=3, out_channel=1, use_logits=False, logits_per_output=12, name='CC'):
+    def __init__(self, in_channel=3, out_channel=1, use_logits=False, logits_per_output=12, name='CC', **kwargs):
         super(Countception, self).__init__()
 
         # params


### PR DESCRIPTION
Minor fixes:
- Add documentation about `soft_gt`
- Correct inconsistencies between config files: `soft_gt` instead of `soft_input`.