### PR TITLE
Transformations at test time: minor fixes

### DIFF
--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -189,9 +189,9 @@ def run_main(config=None):
         # Aleatoric uncertainty
         if context['testing_parameters']['uncertainty']['aleatoric'] and \
                 context['testing_parameters']['uncertainty']['n_it'] > 0:
-            transformation_dict = transform_test_params
-        else:
             transformation_dict = transform_valid_params
+        else:
+            transformation_dict = transform_test_params
 
         # UNDO TRANSFORMS
         undo_transforms = imed_transforms.UndoCompose(imed_transforms.Compose(transformation_dict))

--- a/ivadomed/transforms.py
+++ b/ivadomed/transforms.py
@@ -983,6 +983,7 @@ def get_subdatasets_transforms(transform_params):
     Returns:
         dict, dict, dict: Training, Validation and Testing transformations.
     """
+    transform_params = copy.deepcopy(transform_params)
     train, valid, test = {}, {}, {}
     subdataset_default = ["training", "validation", "testing"]
     # Loop across transformations


### PR DESCRIPTION
Minor fixes:
- When `command == eval` in the config file, we go through [get_subdatasets_transforms](https://github.com/ivadomed/ivadomed/blob/3ad50e7630ebd61b75024f8f9e4e0aadd739c1f2/ivadomed/transforms.py#L977) a first time. If `pred_masks` folder does not exist then `run_main` is called and we then go through [get_subdatasets_transforms](https://github.com/ivadomed/ivadomed/blob/3ad50e7630ebd61b75024f8f9e4e0aadd739c1f2/ivadomed/transforms.py#L977) a second time. The problem is: `dataset_type` is [deleted](https://github.com/ivadomed/ivadomed/blob/3ad50e7630ebd61b75024f8f9e4e0aadd739c1f2/ivadomed/transforms.py#L977) during the first pass. Which causes problems.
- Typo [here](https://github.com/ivadomed/ivadomed/blob/master/ivadomed/main.py#L190): that's the opposite: we want the transformations of the validation dataset when we want to estimate the aleatoric uncertainty.