### PR TITLE
Optimize binarization

### DIFF
--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -473,9 +473,8 @@ class MRI2DSegmentationDataset(Dataset):
                                                    data_type="gt")
             # Make sure stack_gt is binarized
             if stack_gt is not None and not self.soft_gt:
-                stack_gt = torch.as_tensor(
-                    [imed_postpro.threshold_predictions(stack_gt[i_label, :], thr=0.1) for i_label in
-                     range(len(stack_gt))])
+                stack_gt = imed_postpro.threshold_predictions(stack_gt, thr=0.1)
+
         else:
             # Force no transformation on labels for classification task
             # stack_gt is a list of length n_label, values: 0 or 1
@@ -615,8 +614,7 @@ class MRI3DSubVolumeSegmentationDataset(Dataset):
                                                data_type="gt")
         # Make sure stack_gt is binarized
         if stack_gt is not None and not self.soft_gt:
-            stack_gt = torch.as_tensor(
-                [imed_postpro.threshold_predictions(stack_gt[i_label, :], thr=0.1) for i_label in range(len(stack_gt))])
+            stack_gt = imed_postpro.threshold_predictions(stack_gt, thr=0.1)
 
         shape_x = coord["x_max"] - coord["x_min"]
         shape_y = coord["y_max"] - coord["y_min"]

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -473,7 +473,7 @@ class MRI2DSegmentationDataset(Dataset):
                                                    data_type="gt")
             # Make sure stack_gt is binarized
             if stack_gt is not None and not self.soft_gt:
-                stack_gt = imed_postpro.threshold_predictions(stack_gt, thr=0.1)
+                stack_gt = imed_postpro.threshold_predictions(stack_gt, thr=0.5)
 
         else:
             # Force no transformation on labels for classification task
@@ -614,7 +614,7 @@ class MRI3DSubVolumeSegmentationDataset(Dataset):
                                                data_type="gt")
         # Make sure stack_gt is binarized
         if stack_gt is not None and not self.soft_gt:
-            stack_gt = imed_postpro.threshold_predictions(stack_gt, thr=0.1)
+            stack_gt = imed_postpro.threshold_predictions(stack_gt, thr=0.5)
 
         shape_x = coord["x_max"] - coord["x_min"]
         shape_y = coord["y_max"] - coord["y_min"]


### PR DESCRIPTION
Following a time profiling, of soft vs hard labels, the [function `as_tensor`](https://github.com/ivadomed/ivadomed/blob/master/ivadomed/loader/loader.py#L476) showed to be time-consuming. 
![image](https://user-images.githubusercontent.com/49137243/87821023-1fc84400-c83d-11ea-96ca-fd4af1a6d6f9.png)

This PR optimize this operation, to reduce training time. 