### PR TITLE
Automate training seed

### DIFF
--- a/ivadomed/scripts/automate_training.py
+++ b/ivadomed/scripts/automate_training.py
@@ -231,7 +231,7 @@ def automate_training(config, param, fixed_split, all_combin, n_iterations=1, ru
             # Set seed for iteration
             seed = random.randint(1, 10001)
             for config in config_list:
-                config["random_seed"] = seed
+                config["split_dataset"]["random_seed"] = seed
                 if all_logs:
                     if i:
                         config["log_directory"] = config["log_directory"].replace("_n=" + str(i - 1).zfill(2),

--- a/ivadomed/scripts/automate_training.py
+++ b/ivadomed/scripts/automate_training.py
@@ -273,9 +273,8 @@ def automate_training(config, param, fixed_split, all_combin, n_iterations=1, ru
 
             # Init or add eval results to dataframe
             if i != 0:
-                eval_df = (eval_df * n_iterations + pd.concat(df_lst, sort=False, axis=1)) / (n_iterations + 1)
+                eval_df = (eval_df * i + pd.concat(df_lst, sort=False, axis=1)) / (i + 1)
             else:
-
                 eval_df = pd.concat(df_lst, sort=False, axis=1)
 
             test_df = pd.DataFrame(test_results, columns=['log_directory', 'test_dice'])


### PR DESCRIPTION
In the script `automate_training.py` the seed was modified at each experiment, but it was not done correctly, so all trainings had the same split. This PR also modifies the average metrics for all training with this format:
![image](https://user-images.githubusercontent.com/49137243/87830009-27441900-c84e-11ea-8f81-5872bf97d694.png)

Mean: mean of all test subjects over all experiments
Std: Std of a metric is measured over all subjects and is then average over all experiments.