### PR TITLE
Normalized ReLU

### DIFF
--- a/docs/source/configuration_file.rst
+++ b/docs/source/configuration_file.rst
@@ -262,7 +262,7 @@ the default parameters are merged with the parameters that are specific
 to the tailored model. - ``name``: ``Unet`` (default) -
 ``dropout_rate``: Float (e.g. 0.4). - ``batch_norm_momentum``: Float
 (e.g. 0.1). - ``depth``: Strictly positive integer. Number of
-down-sampling operations.
+down-sampling operations. - ``relu`` (optional): Bool, sets final activation to normalized ReLU (relu between 0 and 1).
 
 FiLMedUnet (Optional)
 ^^^^^^^^^^^^^^^^^^^^^
@@ -298,6 +298,8 @@ UNet3D (Optional)
    dimension and 3 voxels in the 3rd dimension at every iteration until
    the whole input matrix is covered.
 -  ``attention_unet``: Bool. Use attention gates in the Unet's decoder.
+- ``n_filters``: Int. Number of filters in the first convolution of the UNet. This number of filters will be doubled at each convolution.
+- ``relu`` (optional): Bool, sets final activation to normalized ReLU (relu between 0 and 1).
 
 Testing parameters
 ------------------

--- a/docs/source/configuration_file.rst
+++ b/docs/source/configuration_file.rst
@@ -299,7 +299,6 @@ UNet3D (Optional)
    the whole input matrix is covered.
 -  ``attention_unet`` (optional): Bool. Use attention gates in the Unet's decoder.
 - ``n_filters`` (optional): Int. Number of filters in the first convolution of the UNet. This number of filters will be doubled at each convolution.
-- ``relu`` (optional): Bool. Sets final activation to normalized ReLU (relu between 0 and 1).
 
 Testing parameters
 ------------------

--- a/docs/source/configuration_file.rst
+++ b/docs/source/configuration_file.rst
@@ -262,7 +262,7 @@ the default parameters are merged with the parameters that are specific
 to the tailored model. - ``name``: ``Unet`` (default) -
 ``dropout_rate``: Float (e.g. 0.4). - ``batch_norm_momentum``: Float
 (e.g. 0.1). - ``depth``: Strictly positive integer. Number of
-down-sampling operations. - ``relu`` (optional): Bool, sets final activation to normalized ReLU (relu between 0 and 1).
+down-sampling operations. - ``relu`` (optional): Bool. Sets final activation to normalized ReLU (relu between 0 and 1).
 
 FiLMedUnet (Optional)
 ^^^^^^^^^^^^^^^^^^^^^
@@ -297,9 +297,9 @@ UNet3D (Optional)
    translation of 1 voxel in the 1st dimension, 2 voxels in the 2nd
    dimension and 3 voxels in the 3rd dimension at every iteration until
    the whole input matrix is covered.
--  ``attention_unet``: Bool. Use attention gates in the Unet's decoder.
-- ``n_filters``: Int. Number of filters in the first convolution of the UNet. This number of filters will be doubled at each convolution.
-- ``relu`` (optional): Bool, sets final activation to normalized ReLU (relu between 0 and 1).
+-  ``attention_unet`` (optional): Bool. Use attention gates in the Unet's decoder.
+- ``n_filters`` (optional): Int. Number of filters in the first convolution of the UNet. This number of filters will be doubled at each convolution.
+- ``relu`` (optional): Bool. Sets final activation to normalized ReLU (relu between 0 and 1).
 
 Testing parameters
 ------------------

--- a/docs/source/configuration_file.rst
+++ b/docs/source/configuration_file.rst
@@ -298,7 +298,7 @@ UNet3D (Optional)
    dimension and 3 voxels in the 3rd dimension at every iteration until
    the whole input matrix is covered.
 -  ``attention_unet`` (optional): Bool. Use attention gates in the Unet's decoder.
-- ``n_filters`` (optional): Int. Number of filters in the first convolution of the UNet. This number of filters will be doubled at each convolution.
+-  ``n_filters`` (optional): Int. Number of filters in the first convolution of the UNet. This number of filters will be doubled at each convolution.
 
 Testing parameters
 ------------------

--- a/ivadomed/models.py
+++ b/ivadomed/models.py
@@ -219,7 +219,7 @@ class Decoder(Module):
             preds = preds[:, 1:, ]
         else:
             if self.relu_activation:
-                preds = nn.ReLU()(x) / nn.ReLU()(x).max()
+                preds = nn.ReLU()(x) / nn.ReLU()(x).max() if bool(nn.ReLU()(x).max()) else nn.ReLU()(x)
             else:
                 preds = torch.sigmoid(x)
         return preds
@@ -798,7 +798,7 @@ class UNet3D(nn.Module):
             out = out[:, 1:, ]
         else:
             if self.relu_activation:
-                out = nn.ReLU()(seg_layer) / nn.ReLU()(seg_layer).max()
+                out = nn.ReLU()(x) / nn.ReLU()(x).max() if bool(nn.ReLU()(x).max()) else nn.ReLU()(x)
             else:
                 out = torch.sigmoid(seg_layer)
         return out

--- a/ivadomed/models.py
+++ b/ivadomed/models.py
@@ -239,6 +239,7 @@ class Unet(Module):
         depth (int): Number of down convolutions minus bottom down convolution.
         drop_rate (float): Probability of dropout.
         bn_momentum (float): Batch normalization momentum.
+        relu (bool): If True, sets final activation to normalized ReLU (ReLU between 0 and 1).
         **kwargs:
 
     Attributes:
@@ -250,8 +251,7 @@ class Unet(Module):
         super(Unet, self).__init__()
 
         # Encoder path
-        self.encoder = Encoder(in_channel=in_channel, depth=depth, drop_rate=drop_rate, bn_momentum=bn_momentum,
-                               relu=relu)
+        self.encoder = Encoder(in_channel=in_channel, depth=depth, drop_rate=drop_rate, bn_momentum=bn_momentum)
 
         # Decoder path
         self.decoder = Decoder(out_channel=out_channel, depth=depth, drop_rate=drop_rate, bn_momentum=bn_momentum,
@@ -497,6 +497,7 @@ class UNet3D(nn.Module):
         attention (bool): Boolean indicating whether the attention module is on or not.
         drop_rate (float): Probability of dropout.
         bn_momentum (float): Batch normalization momentum.
+        relu (bool): If True, sets final activation to normalized ReLU (relu between 0 and 1).
         **kwargs:
 
     Attributes:
@@ -505,6 +506,7 @@ class UNet3D(nn.Module):
         base_n_filter (int): Number of base filters in the U-Net.
         attention (bool): Boolean indicating whether the attention module is on or not.
         momentum (float): Batch normalization momentum.
+        relu_activation (bool): If True, sets final activation to normalized ReLU (ReLU between 0 and 1).
 
     Note: All layers are defined as attributes and used in the forward method.
     """

--- a/ivadomed/models.py
+++ b/ivadomed/models.py
@@ -165,7 +165,7 @@ class Decoder(Module):
         super(Decoder, self).__init__()
         self.depth = depth
         self.out_channel = out_channel
-        self.relu = relu
+        self.relu_activation = relu
         # Up-Sampling path
         self.up_path = nn.ModuleList()
         if hemis:
@@ -218,7 +218,7 @@ class Decoder(Module):
             # Remove background class
             preds = preds[:, 1:, ]
         else:
-            if self.relu:
+            if self.relu_activation:
                 preds = nn.ReLU()(x) / nn.ReLU()(x).max()
             else:
                 preds = torch.sigmoid(x)
@@ -246,14 +246,16 @@ class Unet(Module):
         decoder (Decoder): U-net decoder.
     """
 
-    def __init__(self, in_channel=1, out_channel=1, depth=3, drop_rate=0.4, bn_momentum=0.1, **kwargs):
+    def __init__(self, in_channel=1, out_channel=1, depth=3, drop_rate=0.4, bn_momentum=0.1, relu=False, **kwargs):
         super(Unet, self).__init__()
 
         # Encoder path
-        self.encoder = Encoder(in_channel=in_channel, depth=depth, drop_rate=drop_rate, bn_momentum=bn_momentum)
+        self.encoder = Encoder(in_channel=in_channel, depth=depth, drop_rate=drop_rate, bn_momentum=bn_momentum,
+                               relu=relu)
 
         # Decoder path
-        self.decoder = Decoder(out_channel=out_channel, depth=depth, drop_rate=drop_rate, bn_momentum=bn_momentum)
+        self.decoder = Decoder(out_channel=out_channel, depth=depth, drop_rate=drop_rate, bn_momentum=bn_momentum,
+                               relu=relu)
 
     def forward(self, x):
         features, _ = self.encoder(x)

--- a/ivadomed/models.py
+++ b/ivadomed/models.py
@@ -508,13 +508,14 @@ class UNet3D(nn.Module):
     """
 
     def __init__(self, in_channel, out_channel, n_filters=16, attention=False, drop_rate=0.6, bn_momentum=0.1,
-                 **kwargs):
+                 relu=False, **kwargs):
         super(UNet3D, self).__init__()
         self.in_channels = in_channel
         self.n_classes = out_channel
         self.base_n_filter = n_filters
         self.attention = attention
         self.momentum = bn_momentum
+        self.relu_activation = relu
 
         self.lrelu = nn.LeakyReLU()
         self.dropout3d = nn.Dropout3d(p=drop_rate)
@@ -792,7 +793,10 @@ class UNet3D(nn.Module):
             # Remove background class
             out = out[:, 1:, ]
         else:
-            out = torch.sigmoid(seg_layer)
+            if self.relu_activation:
+                out = nn.ReLU()(seg_layer) / nn.ReLU()(seg_layer).max()
+            else:
+                out = torch.sigmoid(seg_layer)
         return out
 
 

--- a/ivadomed/models.py
+++ b/ivadomed/models.py
@@ -161,10 +161,11 @@ class Decoder(Module):
     """
 
     def __init__(self, out_channel=1, depth=3, drop_rate=0.4, bn_momentum=0.1,
-                 n_metadata=None, film_layers=None, hemis=False):
+                 n_metadata=None, film_layers=None, hemis=False, relu=False):
         super(Decoder, self).__init__()
         self.depth = depth
         self.out_channel = out_channel
+        self.relu = relu
         # Up-Sampling path
         self.up_path = nn.ModuleList()
         if hemis:
@@ -217,7 +218,10 @@ class Decoder(Module):
             # Remove background class
             preds = preds[:, 1:, ]
         else:
-            preds = torch.sigmoid(x)
+            if self.relu:
+                preds = nn.ReLU()(x) / nn.ReLU()(x).max()
+            else:
+                preds = torch.sigmoid(x)
         return preds
 
 

--- a/testing/test_inference.py
+++ b/testing/test_inference.py
@@ -9,6 +9,7 @@ from ivadomed import metrics as imed_metrics
 from ivadomed import transforms as imed_transforms
 from ivadomed import utils as imed_utils
 from ivadomed import testing as imed_testing
+from ivadomed import models as imed_models
 from ivadomed.loader import utils as imed_loader_utils, loader as imed_loader
 
 cudnn.benchmark = True
@@ -85,8 +86,7 @@ def test_inference(transforms_dict, test_lst, target_lst, roi_params, testing_pa
     })
 
     # Model
-    model_path = os.path.join(PATH_BIDS, "model_unet_test.pt")
-    model = torch.load(model_path, map_location=device)
+    model = imed_models.Unet()
 
     if cuda_available:
         model.cuda()


### PR DESCRIPTION
Add option to use a Normalized ReLU as final activation. To use it, the parameter "relu" can be added this way in the config file:
For 2D:
``` 
"default_model": {
        "name": "Unet",
        "dropout_rate": 0.3,
        "bn_momentum": 0.9,
        "depth": 4
        "relu": true
    }
```

For 3D:
```
    "UNet3D": {
        "applied": true,
        "length_3D": [128, 128, 128],
        "stride_3D": [64, 64, 64],
        "relu": true
    }
```

This parameter is optional, removing it will automatically apply the sigmoid activation.