### PR TITLE
Script to mesure reproducibility

### DIFF
--- a/dev/reproducibility.py
+++ b/dev/reproducibility.py
@@ -43,7 +43,7 @@ def compute_csa(config, df_results, logdir, bids):
         # Get GT csa
         gt_path = os.path.join(bids, "derivatives", "labels", subject.split("_")[0],
                                "anat", subject + config["loader_parameters"]["target_suffix"][0] + ".nii.gz")
-        os.system(f"sct_process_segmentation  -i {gt_path} -append 1 -perslice 1 -angle-corr 0 -o csa.csv")
+        os.system(f"sct_process_segmentation  -i {gt_path} -perslice 1 -angle-corr 0 -o csa.csv")
         df = pd.read_csv("csa.csv")
         # Take only the medial slice
         csa_gt = float(df["MEAN(area)"][len(df["MEAN(area)"]) // 2])
@@ -57,7 +57,7 @@ def compute_csa(config, df_results, logdir, bids):
         single_label_pred_path = "pred_single_label.nii.gz"
         nib.save(single_label_pred, single_label_pred_path)
         os.system(
-            f"sct_process_segmentation -i {single_label_pred_path} -append 1 -perslice 1 -angle-corr 0 -o csa.csv")
+            f"sct_process_segmentation -i {single_label_pred_path} -perslice 1 -angle-corr 0 -o csa.csv")
         df = pd.read_csv("csa.csv")
         # Take only the medial slice
         csa_pred = float(df["MEAN(area)"][len(df["MEAN(area)"]) // 2])

--- a/dev/reproducibility.py
+++ b/dev/reproducibility.py
@@ -12,7 +12,7 @@ from ivadomed import main as ivado
 
 def get_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--config", required=True, nargs="+", help="Base config file path.")
+    parser.add_argument("-l", "--log-directory", required=True, nargs="+", help="Log directory of trained model.")
     parser.add_argument("-b", "--bids-path", required=True, type=str, help="Bids path where are located the GT.")
     parser.add_argument("-n", "--iterations", default=10, type=int, help="Number of Monte Carlo iterations.")
     parser.add_argument("-o", "--output-path", nargs="+", dest="output_path", required=True,

--- a/dev/reproducibility.py
+++ b/dev/reproducibility.py
@@ -10,8 +10,9 @@ from ivadomed import main as ivado
 def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("-c", "--config", required=True, help="Base config file path.")
-    parser.add_argument("-n", "--iterations", required=True, help="Number of Monte Carlo iterations.")
-    parser.add_argument("-o", "--output-path", required=True, help="Output directory to save final csv file.")
+    parser.add_argument("-n", "--iterations", default=10, type=int, help="Number of Monte Carlo iterations.")
+    parser.add_argument("-o", "--output-path", default="output_reproducibility.csv", type=str,
+                        help="Output directory to save final csv file.")
     return parser
 
 

--- a/dev/reproducibility.py
+++ b/dev/reproducibility.py
@@ -1,6 +1,8 @@
 import argparse
 import json
+import shutil
 import pandas as pd
+import os
 
 from ivadomed import main as ivado
 
@@ -18,6 +20,7 @@ def reproducibility_pipeline(config):
         context = json.load(fhandle)
 
     context["command"] = "eval"
+    shutil.rmtree(os.path.join(context["log_directory"], "pred_masks"))
     # RandomAffine will be applied during testing
     del context["transformation"]["RandomAffine"]["dataset_type"]
     return ivado.run_command(context)
@@ -38,7 +41,7 @@ def main():
     mean_metrics = all_mean.mean(axis=1)
     std_metrics = all_mean.std(axis=1)
     mean_std_results = pd.concat([mean_metrics, std_metrics], sort=False, axis=1)
-    mean_std_results.to_csv()
+    mean_std_results.to_csv(args.output_path)
 
 
 if __name__ == '__main__':

--- a/dev/reproducibility.py
+++ b/dev/reproducibility.py
@@ -27,7 +27,7 @@ def main():
     parser = get_parser()
     args = parser.parse_args()
 
-    for i in range(args.iterations):
+    for i in range(int(args.iterations)):
         df = reproducibility_pipeline(args.config)
         if i == 0:
             all_mean = df.mean(axis=0)

--- a/dev/reproducibility.py
+++ b/dev/reproducibility.py
@@ -62,8 +62,8 @@ def compute_csa(config, df_results):
         # Populate df with csa stats
         df_results.at[subject, 'csa_pred'] = csa_pred
         df_results.at[subject, 'csa_gt'] = csa_gt
-        df_results.at[subject, 'absolute_csa_diff'] = abs(csa_gt - csa_pred)
-        df_results.at[subject, 'relative_csa_diff'] = csa_gt - csa_pred
+        df_results.at[subject, 'absolute_csa_diff'] = abs(csa_gt - csa_pred) / csa_gt
+        df_results.at[subject, 'relative_csa_diff'] = (csa_gt - csa_pred) / csa_gt
 
     return df_results
 

--- a/dev/reproducibility.py
+++ b/dev/reproducibility.py
@@ -2,8 +2,8 @@ import argparse
 import json
 import os
 import shutil
-import nibabel as nib
 
+import nibabel as nib
 import numpy as np
 import pandas as pd
 
@@ -43,7 +43,7 @@ def compute_csa(config, df_results, logdir, bids):
         # Get GT csa
         gt_path = os.path.join(bids, "derivatives", "labels", subject.split("_")[0],
                                "anat", subject + config["loader_parameters"]["target_suffix"][0] + ".nii.gz")
-        os.system(f"sct_process_segmentation  -i {gt_path} -append 1 -perslice 1 -o csa.csv")
+        os.system(f"sct_process_segmentation  -i {gt_path} -append 1 -perslice 1 -angle-corr 0 -o csa.csv")
         df = pd.read_csv("csa.csv")
         # Take only the medial slice
         csa_gt = float(df["MEAN(area)"][len(df["MEAN(area)"]) // 2])
@@ -56,7 +56,8 @@ def compute_csa(config, df_results, logdir, bids):
         single_label_pred = nib.Nifti1Image(pred_nii.get_fdata()[..., 0], pred_nii.affine)
         single_label_pred_path = "pred_single_label.nii.gz"
         nib.save(single_label_pred, single_label_pred_path)
-        os.system(f"sct_process_segmentation  -i {single_label_pred_path} -append 1 -perslice 1 -o csa.csv")
+        os.system(
+            f"sct_process_segmentation -i {single_label_pred_path} -append 1 -perslice 1 -angle-corr 0 -o csa.csv")
         df = pd.read_csv("csa.csv")
         # Take only the medial slice
         csa_pred = float(df["MEAN(area)"][len(df["MEAN(area)"]) // 2])

--- a/dev/reproducibility.py
+++ b/dev/reproducibility.py
@@ -43,9 +43,10 @@ def compute_csa(config, df_results, logdir, bids):
         # Get GT csa
         gt_path = os.path.join(bids, "derivatives", "labels", subject.split("_")[0],
                                "anat", subject + config["loader_parameters"]["target_suffix"][0] + ".nii.gz")
-        os.system(f"sct_process_segmentation  -i {gt_path} -append 1 -perslice 0 -o csa.csv")
+        os.system(f"sct_process_segmentation  -i {gt_path} -append 1 -perslice 1 -o csa.csv")
         df = pd.read_csv("csa.csv")
-        csa_gt = df["MEAN(area)"][0]
+        # Take only the medial slice
+        csa_gt = df["MEAN(area)"][len(df["MEAN(area)"]) // 2]
         os.system("rm csa.csv")
 
         # Get prediction csa
@@ -55,9 +56,10 @@ def compute_csa(config, df_results, logdir, bids):
         single_label_pred = nib.Nifti1Image(pred_nii.get_fdata()[..., 0], pred_nii.affine)
         single_label_pred_path = "pred_single_label.nii.gz"
         nib.save(single_label_pred, single_label_pred_path)
-        os.system(f"sct_process_segmentation  -i {single_label_pred_path} -append 1 -perslice 0 -o csa.csv")
+        os.system(f"sct_process_segmentation  -i {single_label_pred_path} -append 1 -perslice 1 -o csa.csv")
         df = pd.read_csv("csa.csv")
-        csa_pred = df["MEAN(area)"][0]
+        # Take only the medial slice
+        csa_pred = df["MEAN(area)"][len(df["MEAN(area)"]) // 2]
 
         # Remove files
         os.system("rm csa.csv")

--- a/dev/reproducibility.py
+++ b/dev/reproducibility.py
@@ -1,0 +1,34 @@
+import argparse
+import json
+
+from ivadomed import transforms as imed_transforms
+from ivadomed.loader import utils as imed_loader_utils
+
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-c", "--config", required=True, help="Base config file path.")
+    return parser
+
+
+def reproducibility_pipeline(config):
+    with open(config, "r") as fhandle:
+        context = json.load(fhandle)
+
+    train_lst, valid_lst, test_lst = imed_loader_utils.get_subdatasets_subjects_list(context["split_dataset"],
+                                                                                     context['loader_parameters']
+                                                                                     ['bids_path'],
+                                                                                     context["log_directory"])
+    imed_transforms.RandomAffine(degrees=5, scale=[0.1, 0.1], translate=[0.03, 0.03])
+
+
+def main():
+    parser = get_parser()
+    args = parser.parse_args()
+
+    # Run automate training
+    reproducibility_pipeline(args.config)
+
+
+if __name__ == '__main__':
+    main()

--- a/dev/reproducibility.py
+++ b/dev/reproducibility.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import shutil
 import pandas as pd
+import numpy as np
 import os
 
 from ivadomed import main as ivado
@@ -10,14 +11,13 @@ from ivadomed import main as ivado
 def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("-c", "--config", required=True, help="Base config file path.")
-    parser.add_argument("-b", "--bids-path", required=True, help="Bids path where the GT are located.")
     parser.add_argument("-n", "--iterations", default=10, type=int, help="Number of Monte Carlo iterations.")
     parser.add_argument("-o", "--output-path", default="output_reproducibility.csv", type=str,
                         help="Output directory to save final csv file.")
     return parser
 
 
-def reproducibility_pipeline(config):
+def get_results(config):
     with open(config, "r") as fhandle:
         context = json.load(fhandle)
 
@@ -35,9 +35,16 @@ def main():
     args = parser.parse_args()
 
     df_list = []
+    metrics = []
     for i in range(int(args.iterations)):
-        df = reproducibility_pipeline(args.config)
-        df_list.append(df)
+        df = get_results(args.config)
+        metrics = list(df.columns)
+        df_list.append(np.array(df))
+
+    # Get average and std for each subject (intra subject), then average on all subjects
+    average = np.average(np.average(np.array(df_list), axis=0), axis=1)
+    std = np.average(np.std(np.array(df_list), axis=0), axis=1)
+    pd.DataFrame([average, std], index=metrics, columns=["mean", "std"])
 
 
 if __name__ == '__main__':

--- a/dev/reproducibility.py
+++ b/dev/reproducibility.py
@@ -10,6 +10,7 @@ from ivadomed import main as ivado
 def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("-c", "--config", required=True, help="Base config file path.")
+    parser.add_argument("-b", "--bids-path", required=True, help="Bids path where the GT are located.")
     parser.add_argument("-n", "--iterations", default=10, type=int, help="Number of Monte Carlo iterations.")
     parser.add_argument("-o", "--output-path", default="output_reproducibility.csv", type=str,
                         help="Output directory to save final csv file.")
@@ -33,18 +34,10 @@ def main():
     parser = get_parser()
     args = parser.parse_args()
 
+    df_list = []
     for i in range(int(args.iterations)):
         df = reproducibility_pipeline(args.config)
-        if i == 0:
-            all_mean = df.mean(axis=0)
-
-        else:
-            all_mean = pd.concat([all_mean, df.mean(axis=0)], sort=False, axis=1)
-
-    mean_metrics = all_mean.mean(axis=1)
-    std_metrics = all_mean.std(axis=1)
-    mean_std_results = pd.concat([mean_metrics, std_metrics], sort=False, axis=1)
-    mean_std_results.to_csv(args.output_path)
+        df_list.append(df)
 
 
 if __name__ == '__main__':

--- a/dev/reproducibility.py
+++ b/dev/reproducibility.py
@@ -46,7 +46,7 @@ def compute_csa(config, df_results, logdir, bids):
         os.system(f"sct_process_segmentation  -i {gt_path} -append 1 -perslice 1 -o csa.csv")
         df = pd.read_csv("csa.csv")
         # Take only the medial slice
-        csa_gt = df["MEAN(area)"][len(df["MEAN(area)"]) // 2]
+        csa_gt = float(df["MEAN(area)"][len(df["MEAN(area)"]) // 2])
         os.system("rm csa.csv")
 
         # Get prediction csa
@@ -59,7 +59,7 @@ def compute_csa(config, df_results, logdir, bids):
         os.system(f"sct_process_segmentation  -i {single_label_pred_path} -append 1 -perslice 1 -o csa.csv")
         df = pd.read_csv("csa.csv")
         # Take only the medial slice
-        csa_pred = df["MEAN(area)"][len(df["MEAN(area)"]) // 2]
+        csa_pred = float(df["MEAN(area)"][len(df["MEAN(area)"]) // 2])
 
         # Remove files
         os.system("rm csa.csv")

--- a/dev/reproducibility.py
+++ b/dev/reproducibility.py
@@ -12,7 +12,8 @@ from ivadomed import main as ivado
 
 def get_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-l", "--log-directory", required=True, nargs="+", help="Log directory of trained model.")
+    parser.add_argument("-l", "--log-directory", dest="logdir", required=True, nargs="+",
+                        help="Log directory of trained model.")
     parser.add_argument("-b", "--bids-path", required=True, type=str, help="Bids path where are located the GT.")
     parser.add_argument("-n", "--iterations", default=10, type=int, help="Number of Monte Carlo iterations.")
     parser.add_argument("-o", "--output-path", nargs="+", dest="output_path", required=True,
@@ -33,7 +34,7 @@ def get_results(context):
     return ivado.run_command(context)
 
 
-def compute_csa(config, df_results):
+def compute_csa(config, df_results, logdir):
     subject_list = list(df_results.index)
     df_results = df_results.assign(csa_pred="", csa_gt="", absolute_csa_diff="", relative_csa_diff="")
     for subject in subject_list:
@@ -46,7 +47,7 @@ def compute_csa(config, df_results):
         os.system("rm csa.csv")
 
         # Get prediction csa
-        pred_path = os.path.join(config["log_directory"], "pred_masks", subject + "_pred.nii.gz")
+        pred_path = os.path.join(logdir, "pred_masks", subject + "_pred.nii.gz")
         pred_nii = nib.load(pred_path)
         # Keep only first label to compute csa
         single_label_pred = nib.Nifti1Image(pred_nii.get_fdata()[..., 0], pred_nii.affine)
@@ -73,7 +74,8 @@ def main():
     parser = get_parser()
     args = parser.parse_args()
 
-    for config, output_path in zip(args.config, args.output_path):
+    for logdir, output_path in zip(args.logdir, args.output_path):
+        config = os.path.join(logdir, "config_file.json")
         with open(config, "r") as fhandle:
             context = json.load(fhandle)
 
@@ -81,7 +83,7 @@ def main():
         metrics = []
         for i in range(int(args.iterations)):
             df = get_results(context)
-            df = compute_csa(context, df)
+            df = compute_csa(context, df, logdir)
             metrics = list(df.columns)
             df_list.append(np.array(df))
 

--- a/dev/reproducibility.py
+++ b/dev/reproducibility.py
@@ -47,7 +47,7 @@ def compute_csa(config, df_results, logdir, bids):
         df = pd.read_csv("csa.csv")
         # Take only the medial slice
         csa_gt = float(df["MEAN(area)"][len(df["MEAN(area)"]) // 2])
-        os.system("rm csa.csv")
+        os.remove("csa.csv")
 
         # Get prediction csa
         pred_path = os.path.join(logdir, "pred_masks", subject + "_pred.nii.gz")
@@ -62,7 +62,7 @@ def compute_csa(config, df_results, logdir, bids):
         csa_pred = float(df["MEAN(area)"][len(df["MEAN(area)"]) // 2])
 
         # Remove files
-        os.system("rm csa.csv")
+        os.remove("csa.csv")
         os.system(f"rm {single_label_pred_path}")
 
         # Populate df with csa stats

--- a/dev/reproducibility.py
+++ b/dev/reproducibility.py
@@ -32,6 +32,8 @@ def get_results(context):
     # RandomAffine will be applied during testing
     if "dataset_type" in context["transformation"]["RandomAffine"]:
         del context["transformation"]["RandomAffine"]["dataset_type"]
+    if "scale" in context["transformation"]["RandomAffine"]:
+        del context["transformation"]["RandomAffine"]["scale"]
     return ivado.run_command(context)
 
 

--- a/dev/reproducibility.py
+++ b/dev/reproducibility.py
@@ -20,7 +20,9 @@ def reproducibility_pipeline(config):
         context = json.load(fhandle)
 
     context["command"] = "eval"
-    shutil.rmtree(os.path.join(context["log_directory"], "pred_masks"))
+    pred_mask_path = os.path.join(context["log_directory"], "pred_masks")
+    if os.path.exists(pred_mask_path):
+        shutil.rmtree(pred_mask_path)
     # RandomAffine will be applied during testing
     del context["transformation"]["RandomAffine"]["dataset_type"]
     return ivado.run_command(context)

--- a/dev/reproducibility.py
+++ b/dev/reproducibility.py
@@ -13,6 +13,7 @@ from ivadomed import main as ivado
 def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("-c", "--config", required=True, nargs="+", help="Base config file path.")
+    parser.add_argument("-b", "--bids-path", required=True, type=str, help="Bids path where are located the GT.")
     parser.add_argument("-n", "--iterations", default=10, type=int, help="Number of Monte Carlo iterations.")
     parser.add_argument("-o", "--output-path", nargs="+", dest="output_path", required=True,
                         type=str, help="Output directory name without extention to save final csv file. There should "

--- a/dev/reproducibility.py
+++ b/dev/reproducibility.py
@@ -12,7 +12,7 @@ def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("-c", "--config", required=True, help="Base config file path.")
     parser.add_argument("-n", "--iterations", default=10, type=int, help="Number of Monte Carlo iterations.")
-    parser.add_argument("-o", "--output-path", default="output_reproducibility.csv", type=str,
+    parser.add_argument("-o", "--output-path", dest="output_path", default="output_reproducibility.csv", type=str,
                         help="Output directory to save final csv file.")
     return parser
 
@@ -42,9 +42,9 @@ def main():
         df_list.append(np.array(df))
 
     # Get average and std for each subject (intra subject), then average on all subjects
-    average = np.average(np.average(np.array(df_list), axis=0), axis=1)
-    std = np.average(np.std(np.array(df_list), axis=0), axis=1)
-    pd.DataFrame([average, std], index=metrics, columns=["mean", "std"])
+    average = np.average(np.average(np.array(df_list), axis=0), axis=0)
+    std = np.average(np.std(np.array(df_list), axis=0), axis=0)
+    pd.DataFrame(np.stack([average, std], axis=1), index=metrics, columns=["mean", "std"]).to_csv(args.output_path)
 
 
 if __name__ == '__main__':

--- a/dev/reproducibility.py
+++ b/dev/reproducibility.py
@@ -15,7 +15,8 @@ def get_parser():
     parser.add_argument("-c", "--config", required=True, nargs="+", help="Base config file path.")
     parser.add_argument("-n", "--iterations", default=10, type=int, help="Number of Monte Carlo iterations.")
     parser.add_argument("-o", "--output-path", nargs="+", dest="output_path", required=True,
-                        type=str, help="Output directory name without extention to save final csv file.")
+                        type=str, help="Output directory name without extention to save final csv file. There should "
+                                       "be the same number of output files parameters as the number of config files.")
     return parser
 
 

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -1,5 +1,6 @@
 import collections
 import re
+import os
 
 import numpy as np
 import torch
@@ -101,7 +102,8 @@ def get_new_subject_split(path_folder, center_test, split_method, random_seed,
 
     # save the subject distribution
     split_dct = {'train': train_lst, 'valid': valid_lst, 'test': test_lst}
-    joblib.dump(split_dct, "./" + log_directory + "/split_datasets.joblib")
+    split_path = os.path.join(log_directory, "split_datasets.joblib")
+    joblib.dump(split_dct, split_path)
 
     return train_lst, valid_lst, test_lst
 

--- a/ivadomed/transforms.py
+++ b/ivadomed/transforms.py
@@ -738,7 +738,11 @@ class RandomAffine(ImedTransform):
             raise ValueError("Unknown axes value")
 
         scale = np.array([[1 / scale_x, 0, 0], [0, 1 / scale_y, 0], [0, 0, 1 / scale_z]])
-        transforms = rotate.dot(scale)
+        if "undo" in metadata and metadata["undo"]:
+            transforms = scale.dot(rotate)
+        else:
+            transforms = rotate.dot(scale)
+
         offset = shape - shape.dot(transforms) + translations
 
         data_out = affine_transform(sample, transforms.T, order=1, offset=offset,
@@ -758,7 +762,7 @@ class RandomAffine(ImedTransform):
         translation = - np.array(metadata['translation'])
 
         # Undo rotation
-        dict_params = {"rotation": [angle, axes], "scale": scale, "translation": [0, 0, 0]}
+        dict_params = {"rotation": [angle, axes], "scale": scale, "translation": [0, 0, 0], "undo": True}
 
         data_out, _ = self.__call__(sample, dict_params)
 

--- a/ivadomed/transforms.py
+++ b/ivadomed/transforms.py
@@ -758,8 +758,12 @@ class RandomAffine(ImedTransform):
         translation = - np.array(metadata['translation'])
 
         # Undo rotation
-        dict_params = {"rotation": [angle, axes], "scale": scale, "translation": translation}
+        dict_params = {"rotation": [angle, axes], "scale": scale, "translation": [0, 0, 0]}
+
         data_out, _ = self.__call__(sample, dict_params)
+
+        data_out = affine_transform(data_out, np.identity(3), order=1, offset=translation,
+                                    output_shape=sample.shape).astype(sample.dtype)
 
         return data_out, metadata
 


### PR DESCRIPTION
This PR introduces a script to apply data augmentation to images and recompute metrics. The output file contains the mean and standard deviation of all metrics (avd, dice, lfdr, ltpr, mse, n_gt, n_pred, precision, recall, rvd, specificity, vol_gt, vol_pred, csa_gt, csa_pred, absolute_csa_diff, relative_csa_diff). The script takes as input one or multiple config files (-c), the number of iterations (-n) and the path (or paths) to the output file containing the results.

This PR also fixes the RandomAffine undo method. When applying `affine_transform` the translation is performed followed by the rotation and scaling transforms. To undo these transforms, the scaling and rotation transforms need to be undone, then undo translation. 