### PR TITLE
Added special case for Centercrop in visualize transforms

### DIFF
--- a/ivadomed/scripts/visualize_transforms.py
+++ b/ivadomed/scripts/visualize_transforms.py
@@ -147,6 +147,9 @@ def run_visualization(input, config, number, output, roi):
                 metadata = metadata[0]
                 metadata.__setitem__('data_type', 'im')
 
+            elif "CenterCrop" in training_transforms:
+                metadata.__setitem__('crop_params', (0, 0, 0, 0, 0, 0))
+
             # Apply transformations to image
             stack_im, _ = composed_transforms(sample=data,
                                               metadata=[metadata for _ in range(number)],

--- a/ivadomed/scripts/visualize_transforms.py
+++ b/ivadomed/scripts/visualize_transforms.py
@@ -139,13 +139,7 @@ def run_visualization(input, config, number, output, roi):
 
             # Apply transformations to ROI
             if "ROICrop" in training_transforms and os.path.isfile(roi):
-                roi = [roi_data[:, :, i]]
-                metadata.__setitem__('data_type', 'roi')
-                _, metadata = composed_transforms(sample=roi,
-                                                  metadata=[metadata for _ in range(number)],
-                                                  data_type="roi")
-                metadata = metadata[0]
-                metadata.__setitem__('data_type', 'im')
+                metadata.__setitem__('crop_params', {})
 
             elif "CenterCrop" in training_transforms:
                 metadata.__setitem__('crop_params', {})

--- a/ivadomed/scripts/visualize_transforms.py
+++ b/ivadomed/scripts/visualize_transforms.py
@@ -138,10 +138,7 @@ def run_visualization(input, config, number, output, roi):
             metadata = imed_loader_utils.SampleMetadata({"zooms": zooms, "data_type": "gt" if is_mask else "im"})
 
             # Apply transformations to ROI
-            if "ROICrop" in training_transforms and os.path.isfile(roi):
-                metadata.__setitem__('crop_params', {})
-
-            elif "CenterCrop" in training_transforms:
+            if "CenterCrop" in training_transforms or ("ROICrop" in training_transforms and os.path.isfile(roi)):
                 metadata.__setitem__('crop_params', {})
 
             # Apply transformations to image

--- a/ivadomed/scripts/visualize_transforms.py
+++ b/ivadomed/scripts/visualize_transforms.py
@@ -148,7 +148,7 @@ def run_visualization(input, config, number, output, roi):
                 metadata.__setitem__('data_type', 'im')
 
             elif "CenterCrop" in training_transforms:
-                metadata.__setitem__('crop_params', (0, 0, 0, 0, 0, 0))
+                metadata.__setitem__('crop_params', {})
 
             # Apply transformations to image
             stack_im, _ = composed_transforms(sample=data,


### PR DESCRIPTION
The use of CenterCrop transformation in config files caused a crash in visualize transfoms. This was due to the fact that the the metdata (which contains the transforms) did not have a 'crop_params' field. This fix initilize this field in the metadata with an empty dictionnary if needed. This solution seems to work for roi crop as well, which allow to optimize code as well. 

fix #388  