### PR TITLE
Enable custom config for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,17 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: documentation/source/conf.py
+
+python:
+  version: 3.6
+  install:
+    - requirements: requirements.txt
+    - method: pip
+      path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: documentation/source/conf.py
+  configuration: docs/source/conf.py
 
 python:
   version: 3.6


### PR DESCRIPTION
In this PR we introduce the file `.readthedocs.yml` to be able to set up custom build, and remove epub and pdf output. 

➤ **Built doc on RTD: https://ivadomed.org/en/jca-rtd-config**

Related to https://github.com/ivadomed/ivadomed/pull/389#issuecomment-671452666

To fix later: https://github.com/ivadomed/ivadomed/issues/394