### PR TITLE
Fix reproducibility issue with split per center

### DIFF
--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -48,7 +48,7 @@ def split_dataset(path_folder, center_test_lst, split_method, random_seed, train
     if split_method == 'per_center':
         # make sure that subjects coming from some centers are unseen during training
         if len(center_test_lst) == 0:
-            centers = list(set(df['institution_id']))
+            centers = sorted(df['institution_id'].unique().tolist())
             test_frac = test_frac if test_frac >= 1 / len(centers) else 1 / len(centers)
             center_test_lst, _ = train_test_split(centers, train_size=test_frac, random_state=random_seed)
 


### PR DESCRIPTION
When splitting dataset per center with same seed, we did not get the same sub datasets.

Please let me introduce you to the culprit: [here](https://github.com/ivadomed/ivadomed/blob/master/ivadomed/loader/utils.py).
This line fails to achieve its purpose: sort alphabetically the centers. Therefore, at each run, the list is sorted differently --> resulting in different split output by sklearn function.

Minor change does the job. Next.