### PR TITLE
Resume training

### DIFF
--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -203,6 +203,7 @@ def run_command(context, n_gif=0, thr_increment=None, resume_training=False):
             cuda_available=cuda_available,
             metric_fns=metric_fns,
             n_gif=n_gif,
+            resume_training=resume_training,
             debugging=context["debugging"])
 
     if thr_increment:

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -51,7 +51,7 @@ def get_parser():
     return parser
 
 
-def run_command(context, n_gif=0, thr_increment=None):
+def run_command(context, n_gif=0, thr_increment=None, resume_training=False):
     """Run main command.
 
     This function is central in the ivadomed project as training / testing / evaluation commands are run via this
@@ -66,6 +66,9 @@ def run_command(context, n_gif=0, thr_increment=None):
         thr_increment (float): A threshold analysis is performed at the end of the training using the trained model and
             the training + validation sub-dataset to find the optimal binarization threshold. The specified value
             indicates the increment between 0 and 1 used during the ROC analysis (e.g. 0.1).
+        resume_training (bool): Load a saved model ("checkpoint.pth.tar" in the log_directory) for resume
+                                training. This training state is saved everytime a new best model is saved in the log
+                                directory.
     Returns:
         If "train" command: Returns floats: best loss score for both training and validation.
         If "test" command: Returns dict: of averaged metrics computed on the testing sub dataset.
@@ -307,7 +310,8 @@ def run_main():
     # Run command
     run_command(context=context,
                 n_gif=args.gif if args.gif is not None else 0,
-                thr_increment=args.thr_increment if args.thr_increment else None)
+                thr_increment=args.thr_increment if args.thr_increment else None,
+                resume_training=bool(args.resume_training))
 
 
 if __name__ == "__main__":

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -41,6 +41,10 @@ def get_parser():
                                     'the analysis (e.g. 0.1). Plot is saved under "log_directory/thr.png" and the '
                                     'optimal threshold in "log_directory/config_file.json as "binarize_prediction" '
                                     'parameter.')
+    optional_args.add_argument('--resume-training', dest="resume_training", required=False, action='store_true',
+                               help='Load a saved model ("checkpoint.pth.tar" in the log_directory) for resume '
+                                    'training. This training state is saved everytime a new best model is saved in the'
+                                    'log directory.')
     optional_args.add_argument('-h', '--help', action='help', default=argparse.SUPPRESS,
                                help='Shows function documentation.')
 

--- a/ivadomed/training.py
+++ b/ivadomed/training.py
@@ -320,18 +320,19 @@ def train(model_params, dataset_train, dataset_val, training_params, log_directo
     if os.path.isfile(resume_path):
         state = torch.load(resume_path)
         model_path = os.path.join(log_directory, "best_model.pt")
-        torch.save(model.load_state_dict(state['state_dict']), model_path)
+        best_model = model.load_state_dict(state['state_dict'])
+        torch.save(best_model, model_path)
         # Save best model as ONNX in the model directory
         try:
             # Convert best model to ONNX and save it in model directory
             best_model_path = os.path.join(log_directory, model_params["folder_name"],
                                            model_params["folder_name"] + ".onnx")
-            imed_utils.save_onnx_model(torch.load(model_path), input_samples, best_model_path)
+            imed_utils.save_onnx_model(best_model, input_samples, best_model_path)
         except:
             # Save best model in model directory
             best_model_path = os.path.join(log_directory, model_params["folder_name"],
                                            model_params["folder_name"] + ".pt")
-            torch.save(torch.load(best_model_path), best_model_path)
+            torch.save(best_model, best_model_path)
             logger.warning("Failed to save the model as '.onnx', saved it as '.pt': {}".format(best_model_path))
 
     # Save GIFs

--- a/ivadomed/training.py
+++ b/ivadomed/training.py
@@ -320,7 +320,7 @@ def train(model_params, dataset_train, dataset_val, training_params, log_directo
     if os.path.isfile(resume_path):
         state = torch.load(resume_path)
         model_path = os.path.join(log_directory, "best_model.pt")
-        torch.save(model.load_state_dict(checkpoint['state_dict']), model_path)
+        torch.save(model.load_state_dict(state['state_dict']), model_path)
         # Save best model as ONNX in the model directory
         try:
             # Convert best model to ONNX and save it in model directory

--- a/ivadomed/training.py
+++ b/ivadomed/training.py
@@ -121,6 +121,12 @@ def train(model_params, dataset_train, dataset_val, training_params, log_directo
                                                                           writer=writer,
                                                                           gif_dict=gif_dict,
                                                                           fname=resume_path)
+        # Individually transfer the optimizer parts
+        # TODO: check if following lines are needed
+        for state in optimizer.state.values():
+            for k, v in state.items():
+                if torch.is_tensor(v):
+                    state[k] = v.to(device)
 
     # LOSS
     print("\nSelected Loss: {}".format(training_params["loss"]["name"]))

--- a/ivadomed/training.py
+++ b/ivadomed/training.py
@@ -320,7 +320,7 @@ def train(model_params, dataset_train, dataset_val, training_params, log_directo
     if os.path.isfile(resume_path):
         state = torch.load(resume_path)
         model_path = os.path.join(log_directory, "best_model.pt")
-        torch.save(state["model"], model_path)
+        torch.save(model.load_state_dict(checkpoint['state_dict']), model_path)
         # Save best model as ONNX in the model directory
         try:
             # Convert best model to ONNX and save it in model directory

--- a/ivadomed/training.py
+++ b/ivadomed/training.py
@@ -141,7 +141,7 @@ def train(model_params, dataset_train, dataset_val, training_params, log_directo
     begin_time = time.time()
 
     # EPOCH LOOP
-    for epoch in tqdm(range(start_epoch, num_epochs + 1), desc="Training"):
+    for epoch in tqdm(range(num_epochs), desc="Training", initial=start_epoch):
         start_time = time.time()
 
         lr = scheduler.get_last_lr()[0]

--- a/ivadomed/training.py
+++ b/ivadomed/training.py
@@ -320,19 +320,19 @@ def train(model_params, dataset_train, dataset_val, training_params, log_directo
     if os.path.isfile(resume_path):
         state = torch.load(resume_path)
         model_path = os.path.join(log_directory, "best_model.pt")
-        best_model = model.load_state_dict(state['state_dict'])
-        torch.save(best_model, model_path)
+        model.load_state_dict(state['state_dict'])
+        torch.save(model, model_path)
         # Save best model as ONNX in the model directory
         try:
             # Convert best model to ONNX and save it in model directory
             best_model_path = os.path.join(log_directory, model_params["folder_name"],
                                            model_params["folder_name"] + ".onnx")
-            imed_utils.save_onnx_model(best_model, input_samples, best_model_path)
+            imed_utils.save_onnx_model(model, input_samples, best_model_path)
         except:
             # Save best model in model directory
             best_model_path = os.path.join(log_directory, model_params["folder_name"],
                                            model_params["folder_name"] + ".pt")
-            torch.save(best_model, best_model_path)
+            torch.save(model, best_model_path)
             logger.warning("Failed to save the model as '.onnx', saved it as '.pt': {}".format(best_model_path))
 
     # Save GIFs

--- a/ivadomed/training.py
+++ b/ivadomed/training.py
@@ -265,7 +265,8 @@ def train(model_params, dataset_train, dataset_val, training_params, log_directo
             if val_loss_total_avg < best_validation_loss:
                 # Save checkpoint
                 state = {'epoch': epoch + 1, 'state_dict': model.state_dict(),
-                         'optimizer': optimizer.state_dict(), 'tensorboard_logger': writer}
+                         'optimizer': optimizer.state_dict(), 'tensorboard_logger': writer,
+                         'gif_dict': gif_dict}
                 torch.save(state, os.path.join(log_directory, "checkpoint.pth.tar"))
 
                 # Save new best model

--- a/ivadomed/training.py
+++ b/ivadomed/training.py
@@ -492,3 +492,17 @@ def load_checkpoint(model, optimizer, writer, gif_dict, fname):
     Return:
         nn.Module, torch, SummaryWriter, dict, int
     """
+    start_epoch = 0
+    try:
+        print("\nLoading checkpoint: {}".format(fname))
+        checkpoint = torch.load(fname)
+        start_epoch = checkpoint['epoch']
+        model.load_state_dict(checkpoint['state_dict'])
+        optimizer.load_state_dict(checkpoint['optimizer'])
+        writer = checkpoint['tensorboard_logger']
+        gif_dict = checkpoint['gif_dict']
+        print("... Resume training from epoch #{}".format(start_epoch))
+    except:
+        logger.warning("\nNo checkpoint found at: {}".format(fname))
+
+    return model, optimizer, writer, gif_dict, start_epoch

--- a/ivadomed/training.py
+++ b/ivadomed/training.py
@@ -475,3 +475,20 @@ def save_film_params(gammas, betas, contrasts, depth, ofolder):
     contrast_images = np.array(contrasts)
     contrast_path = os.path.join(ofolder, "contrast_image.npy")
     np.save(contrast_path, contrast_images)
+
+
+def load_checkpoint(model, optimizer, writer, gif_dict, fname):
+    """Load checkpoint.
+
+    This function check if a checkpoint is available. If so, it updates the state of the input objects.
+
+    Args:
+        model (nn.Module): Init model.
+        optimizer (torch):
+        writer (SummaryWriter):
+        gif_dict (dict):
+        fname (str): Checkpoint filename.
+
+    Return:
+        nn.Module, torch, SummaryWriter, dict, int
+    """

--- a/ivadomed/training.py
+++ b/ivadomed/training.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 def train(model_params, dataset_train, dataset_val, training_params, log_directory, device,
-          cuda_available=True, metric_fns=None, n_gif=0, debugging=False):
+          cuda_available=True, metric_fns=None, n_gif=0, resume_training=False, debugging=False):
     """Main command to train the network.
 
     Args:
@@ -39,6 +39,9 @@ def train(model_params, dataset_train, dataset_val, training_params, log_directo
         n_gif (int): Generates a GIF during training if larger than zero, one frame per epoch for a given slice. The
             parameter indicates the number of 2D slices used to generate GIFs, one GIF per slice. A GIF shows
             predictions of a given slice from the validation sub-dataset. They are saved within the log directory.
+        resume_training (bool): Load a saved model ("checkpoint.pth.tar" in the log_directory) for resume
+                                training. This training state is saved everytime a new best model is saved in the log
+                                directory.
         debugging (bool): If True, extended verbosity and intermediate outputs.
 
     Returns:

--- a/ivadomed/training.py
+++ b/ivadomed/training.py
@@ -516,13 +516,13 @@ def load_checkpoint(model, optimizer, gif_dict, scheduler, fname):
 
     Args:
         model (nn.Module): Init model.
-        optimizer (torch.optim):
-        writer (SummaryWriter):
-        gif_dict (dict):
+        optimizer (torch.optim): Model's optimizer.
+        gif_dict (dict): Dictionary containing a GIF of the training.
+        scheduler (_LRScheduler): Learning rate scheduler.
         fname (str): Checkpoint filename.
 
     Return:
-        nn.Module, torch, SummaryWriter, dict, int
+        nn.Module, torch, dict, int, float, _LRScheduler, int
     """
     start_epoch = 1
     validation_loss = 0

--- a/ivadomed/training.py
+++ b/ivadomed/training.py
@@ -142,6 +142,7 @@ def train(model_params, dataset_train, dataset_val, training_params, log_directo
 
     # EPOCH LOOP
     for epoch in tqdm(range(num_epochs), desc="Training", initial=start_epoch):
+        epoch = epoch + start_epoch
         start_time = time.time()
 
         lr = scheduler.get_last_lr()[0]

--- a/ivadomed/training.py
+++ b/ivadomed/training.py
@@ -263,6 +263,12 @@ def train(model_params, dataset_train, dataset_val, training_params, log_directo
 
             # UPDATE BEST RESULTS
             if val_loss_total_avg < best_validation_loss:
+                # Save checkpoint
+                state = {'epoch': epoch + 1, 'state_dict': model.state_dict(),
+                         'optimizer': optimizer.state_dict(), 'tensorboard_logger': writer}
+                torch.save(state, os.path.join(log_directory, "checkpoint.pth.tar"))
+
+                # Save new best model
                 best_validation_loss, best_training_loss = val_loss_total_avg, train_loss_total_avg
                 best_validation_dice, best_training_dice = val_dice_loss_total_avg, train_dice_loss_total_avg
                 model_path = os.path.join(log_directory, "best_model.pt")

--- a/testing/test_script.py
+++ b/testing/test_script.py
@@ -346,3 +346,19 @@ def test_film_contrast():
     # Run command
     command = "ivadomed -c " + film_config
     subprocess.check_output(command, shell=True)
+
+
+def test_resume_training():
+    # Train config
+    subprocess.check_output(["ivadomed -c testing_data/model_config.json"], shell=True)
+
+    # Add few epochs copy
+    base_config = "testing_data/model_config.json"
+    with open(base_config, "r") as fhandle:
+        context = json.load(fhandle)
+    context["training_parameters"]["training_time"]["num_epochs"] += 2
+    with open(base_config, 'w') as fp:
+        json.dump(context, fp, indent=4)
+
+    # Resume training
+    subprocess.check_output(["ivadomed -c testing_data/model_config.json --resume"], shell=True)


### PR DESCRIPTION
When your 3-days training is suddenly killed by a fd:bmaer;hbùmrq,gqgj,qg error... it would be really really nice to resume it! This PR makes this dream come true!

DONE:
- add a flag `--resume` --> to use it: `ivadomed -c <config_file> --resume` --> will open the more recent checkpoint and update model, optimizer etc to resume the training
- this checkpoint file is saved when the validation loss is best than the current best validation loss
- `best_model.pt` is extracted from the last checkpoint and saved

TODO:
- add a test, otherwise @lrouhier would not be happy
- add this option to `automate_training` to be able to... resume it as well!
- test it on a real case scenario... and for this... sadly... rosenberg looks like in a mood to help us... :-(