### PR TITLE
Missing {} in automate_training example

### DIFF
--- a/ivadomed/scripts/automate_training.py
+++ b/ivadomed/scripts/automate_training.py
@@ -148,7 +148,7 @@ def automate_training(config, param, fixed_split, all_combin, n_iterations=1, ru
             need to match the parameter "keys" of `config` file. Parameter "values" are in a list. Flag: --param, -p
             Example::
 
-                "default_model": {"depth": [2, 3, 4]}
+                {"default_model": {"depth": [2, 3, 4]}}
 
         fixed_split (bool): If True, all the experiments are run on the same training/validation/testing subdatasets.
                             Flag: --fixed-split


### PR DESCRIPTION
Added some brackets, the example gave me the following without them

```
  File "ivadomed/scripts/automate_training.py", line 170, in automate_training
    hyperparams = json.load(fhandle)
  File "/usr/lib/python3.6/json/__init__.py", line 299, in load
    parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
  File "/usr/lib/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.6/json/decoder.py", line 342, in decode
    raise JSONDecodeError("Extra data", s, end)
json.decoder.JSONDecodeError: Extra data: line 1 column 20 (char 19)
```