### PR TITLE
split from right instead of left

### DIFF
--- a/ivadomed/testing.py
+++ b/ivadomed/testing.py
@@ -170,7 +170,7 @@ def run_inference(test_loader, model, model_params, testing_params, ofolder, cud
                     # save the completely processed file as a nifti file
                     if ofolder:
                         fname_pred = os.path.join(ofolder, fname_tmp.split('/')[-1])
-                        fname_pred = fname_pred.split(testing_params['target_suffix'][0])[0] + '_pred.nii.gz'
+                        fname_pred = fname_pred.rsplit(testing_params['target_suffix'][0],1)[0] + '_pred.nii.gz'
                         # If Uncertainty running, then we save each simulation result
                         if testing_params['uncertainty']['applied']:
                             fname_pred = fname_pred.split('.nii.gz')[0] + '_' + str(i_monte_carlo).zfill(2) + '.nii.gz'


### PR DESCRIPTION
Changes nothings for most use cases, but when using `automate_training` to vary `target_suffix`, fixes a bug were uncertainty predictions are saved in the wrong folder due to the fact that the `target_suffix` is present twice in the path and therefore the split was done at the first occurence instead of the last