### PR TITLE
Ko/format bundles

### DIFF
--- a/ivadomed/scripts/download_data.py
+++ b/ivadomed/scripts/download_data.py
@@ -130,11 +130,7 @@ def unzip(compressed, dest_folder):
 
 def format_bundles():
     def format_bundle(name, values):
-        return "`{name} <{values["
-        url
-        "]}>`_ : {values["
-        description
-        "]}"
+        return f"`{name} <{values["url"]}>`_ : {values["description"]}"
     return str.join("\n", ["* %s" % format_bundle(name, values) for name, values in DICT_URL.items()])
 
 def install_data(url, dest_folder, keep=False):

--- a/ivadomed/scripts/download_data.py
+++ b/ivadomed/scripts/download_data.py
@@ -12,6 +12,7 @@ from requests.packages.urllib3.util import Retry
 import sys
 import json
 import argparse
+import textwrap
 
 DICT_URL = {
     "data_example_spinegeneric": {
@@ -128,9 +129,9 @@ def unzip(compressed, dest_folder):
         raise
 
 
-def format_bundles():
+def _format_bundles():
     def format_bundle(name, values):
-        return f"`{name} <{values["url"]}>`_ : {values["description"]}"
+        return f'`{name} <{values["url"]}>`_ : {values["description"]}'
     return str.join("\n", ["* %s" % format_bundle(name, values) for name, values in DICT_URL.items()])
 
 def install_data(url, dest_folder, keep=False):
@@ -142,28 +143,29 @@ def install_data(url, dest_folder, keep=False):
         ivadomed_download_data -d data_testing -o ivado_testing_data
 
 
-    Existing data bundle: |br|
-     {BUNDLES}
+    Existing data bundles:
+
+{BUNDLES}
 
     .. note::
         The function tries to be smart about the data contents.
         Examples:
 
 
-        a. If the archive only contains a `README.md`, and the destination folder is `${dst}`,
-        `${dst}/README.md` will be created.
+        a. If the archive only contains a `README.md`, and the destination folder is `${{dst}}`,
+        `${{dst}}/README.md` will be created.
         Note: an archive not containing a single folder is commonly known as a "bomb" because
         it puts files anywhere in the current working directory.( see `Tarbomb
         <https://en.wikipedia.org/wiki/Tar_(computing)#Tarbomb>`_)
 
 
-        b. If the archive contains a `${dir}/README.md`, and the destination folder is `${dst}`,
-        `${dst}/README.md` will be created.
-        Note: typically the package will be called `${basename}-${revision}.zip` and contain
-        a root folder named `${basename}-${revision}/` under which all the other files will
+        b. If the archive contains a `${{dir}}/README.md`, and the destination folder is `${{dst}}`,
+        `${{dst}}/README.md` will be created.
+        Note: typically the package will be called `${{basename}}-${{revision}}.zip` and contain
+        a root folder named `${{basename}}-${{revision}}/` under which all the other files will
         be located.
         The right thing to do in this case is to take the files from there and install them
-        in `${dst}`.
+        in `${{dst}}`.
         - Uses `download_data()` to retrieve the data.
         - Uses `unzip()` to extract the bundle.
     Args:
@@ -244,7 +246,7 @@ def install_data(url, dest_folder, keep=False):
 # cannot be done in the function directly. 
 # `create_string()` is a custom function that converts our dict into a string
 # which is easier to add in the documentation.
-install_data.__doc__=install_data.__doc_.format(BUNDLES=format_bundles())
+install_data.__doc__=install_data.__doc__.format(BUNDLES=textwrap.indent(_format_bundles(), ' '*6))
 
 
 def main(args=None):


### PR DESCRIPTION
addresses https://github.com/ivadomed/ivadomed/pull/425#discussion_r481518729

here's what `help(install_data)` looks like now:

```
install_data(url, dest_folder, keep=False)
    Download a data bundle from an URL and install it in the destination folder.
    
    Usage example ::
    
        ivadomed_download_data -d data_testing -o ivado_testing_data
    
    
    Existing data bundles:
    
      * `data_example_spinegeneric <['https://github.com/ivadomed/data_example_spinegeneric/archive/r20200825.zip']>`_ : 10 randomly picked subject from `Spine Generic <https://github.com/spine-generic/data-multi-subject>`_. Used for Tutorial and example in Ivadomed.
      * `data_testing <['https://github.com/ivadomed/data-testing/archive/r20200807.zip']>`_ : Data Used for integration/unit test in Ivadomed.
      * `t2_tumor <['https://github.com/ivadomed/t2_tumor/archive/r20200621.zip']>`_ : Cord tumor segmentation model, trained on T2-weighted contrast.
      * `t2star_sc <['https://github.com/ivadomed/t2star_sc/archive/r20200622.zip']>`_ : Cord tumor segmentation model, trained on T2-weighted contrast.
      * `mice_uqueensland_gm <['https://github.com/ivadomed/mice_uqueensland_gm/archive/r20200622.zip']>`_ : Gray matter segmentation model on mouse MRI. Data from University of Queensland.
      * `mice_uqueensland_sc <['https://github.com/ivadomed/mice_uqueensland_sc/archive/r20200622.zip']>`_ : Cord segmentation model on mouse MRI. Data from University of Queensland.
      * `findcord_tumor <['https://github.com/ivadomed/findcord_tumor/archive/r20200621.zip']>`_ : Cord localisation model, trained on T2-weighted images with tumor.
    
    .. note::
        The function tries to be smart about the data contents.
        Examples:
    
    
        a. If the archive only contains a `README.md`, and the destination folder is `${dst}`,
        `${dst}/README.md` will be created.
        Note: an archive not containing a single folder is commonly known as a "bomb" because
        it puts files anywhere in the current working directory.( see `Tarbomb
        <https://en.wikipedia.org/wiki/Tar_(computing)#Tarbomb>`_)
    
    
        b. If the archive contains a `${dir}/README.md`, and the destination folder is `${dst}`,
        `${dst}/README.md` will be created.
        Note: typically the package will be called `${basename}-${revision}.zip` and contain
        a root folder named `${basename}-${revision}/` under which all the other files will
        be located.
        The right thing to do in this case is to take the files from there and install them
        in `${dst}`.
        - Uses `download_data()` to retrieve the data.
        - Uses `unzip()` to extract the bundle.
    Args:
        url (string): URL or sequence thereof (if mirrors). For this package there is a dictionnary
            listing existing data bundle with their url. Type ivadomed_download_data -h to see possible value. Flag ``-d``
        dest_folder (string): destination directory for the data (to be created). If not used the output folder
            will be the name of the data bundle. Flag ``-o``, ``--output``
        keep (bool): whether to keep existing data in the destination folder (if it exists). Flag ``-k``, ``--keep``
```