### PR TITLE
Retrain model without resetting weights

### DIFF
--- a/docs/source/configuration_file.rst
+++ b/docs/source/configuration_file.rst
@@ -247,6 +247,8 @@ transfer\_learning
    of the pre-trained model that will be fine-tuned. For instance, if
    set to 0.5, the second half of the model will be fine-tuned while the
    first layers will be frozen.
+-  ``reset``: boolean. if true, the weights of the layers that are not frozen
+   are reset. If false, they are kept as loaded.
 
 Architecture
 ------------

--- a/docs/source/configuration_file.rst
+++ b/docs/source/configuration_file.rst
@@ -95,22 +95,25 @@ slice\_filter
 ^^^^^^^^^^^^^
 
 Dict. Discard a slice from the dataset if it meets a condition, see
-below. - ``filter_empty_input``: Bool. Discard slices where all voxel
-intensities are zeros. - ``filter_empty_mask``: Bool. Discard slices
-where all voxel labels are zeros.
+below. 
+
+-  ``filter_empty_input``: Bool. Discard slices where all voxel
+   intensities are zeros. 
+-  ``filter_empty_mask``: Bool. Discard slices
+   where all voxel labels are zeros.
 
 roi
 ^^^
 
-Dict. of parameters about the region of interest - ``suffix``: String.
-Suffix of the derivative file containing the ROI used to crop (e.g.
-``"_seg-manual"``) with ``ROICrop`` as transform. Please use ``null`` if
-you do not want to use an ROI to crop. - ``slice_filter_roi``: int. If
-the ROI mask contains less than ``slice_filter_roi`` non-zero voxels,
-the slice will be discarded from the dataset. This feature helps with
-noisy labels, e.g., if a slice contains only 2-3 labeled voxels, we do
-not want to use these labels to crop the image. This parameter is only
-considered when using ``"ROICrop"``.
+Dict. of parameters about the region of interest 
+
+-  ``suffix``: String. Suffix of the derivative file containing the ROI used to crop (e.g. ``"_seg-manual"``) with ``ROICrop`` as transform. Please use ``null`` if
+   you do not want to use an ROI to crop. 
+-  ``slice_filter_roi``: int. If the ROI mask contains less than ``slice_filter_roi`` non-zero voxels,
+   the slice will be discarded from the dataset. This feature helps with
+   noisy labels, e.g., if a slice contains only 2-3 labeled voxels, we do
+   not want to use these labels to crop the image. This parameter is only
+   considered when using ``"ROICrop"``.
 
 soft_gt
 ^^^^^^^^^^
@@ -265,10 +268,12 @@ Dict. Define the default model (``Unet``) and mandatory parameters that
 are common to all available architectures (listed in the
 :ref:`models:Models` section). For more specific models (see below),
 the default parameters are merged with the parameters that are specific
-to the tailored model. - ``name``: ``Unet`` (default) -
-``dropout_rate``: Float (e.g. 0.4). - ``batch_norm_momentum``: Float
-(e.g. 0.1). - ``depth``: Strictly positive integer. Number of
-down-sampling operations. - ``relu`` (optional): Bool. Sets final activation to normalized ReLU (relu between 0 and 1).
+to the tailored model.
+
+- ``name``: ``Unet`` (default) 
+- ``dropout_rate``: Float (e.g. 0.4). 
+- ``batch_norm_momentum``: Float (e.g. 0.1).
+- ``depth``: Strictly positive integer. Number of down-sampling operations. - ``relu`` (optional): Bool. Sets final activation to normalized ReLU (relu between 0 and 1).
 
 FiLMedUnet (Optional)
 ^^^^^^^^^^^^^^^^^^^^^
@@ -310,21 +315,20 @@ Testing parameters
 ------------------
 
 - ``binarize_prediction``: Float. Threshold (between 0 and 1) used to binarize
-    the predictions before computing the validation metrics. To use soft predictions
-    (i.e. no binarisation, float between 0 and 1) for metric computation, indicate -1.
+  the predictions before computing the validation metrics. To use soft predictions
+  (i.e. no binarisation, float between 0 and 1) for metric computation, indicate -1.
 
 uncertainty
 ^^^^^^^^^^^
 
 Uncertainty computation is performed if ``n_it>0`` and at least
 ``epistemic`` or ``aleatoric`` is ``true``. Note: both ``epistemic`` and
-``aleatoric`` can be ``true``. - ``epistemic``: Bool. Model-based
-uncertainty with `Monte Carlo
-Dropout <https://arxiv.org/abs/1506.02142>`__. - ``aleatoric``: Bool.
-Image-based uncertainty with `test-time
-augmentation <https://doi.org/10.1016/j.neucom.2019.01.103>`__. -
-``n_it``: Integer. Number of Monte Carlo iterations. Set to 0 for no
-uncertainty computation.
+``aleatoric`` can be ``true``.
+ 
+- ``epistemic``: Bool. Model-based uncertainty with `Monte Carlo Dropout <https://arxiv.org/abs/1506.02142>`__. 
+- ``aleatoric``: Bool. Image-based uncertainty with `test-time augmentation <https://doi.org/10.1016/j.neucom.2019.01.103>`__.
+- ``n_it``: Integer. Number of Monte Carlo iterations. Set to 0 for no
+  uncertainty computation.
 
 Cascaded Architecture Features
 ------------------------------

--- a/ivadomed/config/config.json
+++ b/ivadomed/config/config.json
@@ -58,7 +58,8 @@
         "mixup_alpha": null,
         "transfer_learning": {
             "retrain_model": null,
-            "retrain_fraction": 1.0
+            "retrain_fraction": 1.0,
+            "reset": true
         }
     },
     "default_model": {

--- a/ivadomed/config/config_classification.json
+++ b/ivadomed/config/config_classification.json
@@ -55,7 +55,8 @@
         "mixup_alpha": null,
         "transfer_learning": {
             "retrain_model": null,
-            "retrain_fraction": 1.0
+            "retrain_fraction": 1.0,
+            "reset": true
         }
     },
     "default_model": {

--- a/ivadomed/config/config_sctTesting.json
+++ b/ivadomed/config/config_sctTesting.json
@@ -57,7 +57,8 @@
         "mixup_alpha": null,
         "transfer_learning": {
             "retrain_model": null,
-            "retrain_fraction": 1.0
+            "retrain_fraction": 1.0,
+            "reset": true
         }
     },
     "default_model": {

--- a/ivadomed/config/config_small.json
+++ b/ivadomed/config/config_small.json
@@ -55,7 +55,8 @@
         "mixup_alpha": null,
         "transfer_learning": {
             "retrain_model": null,
-            "retrain_fraction": 1.0
+            "retrain_fraction": 1.0,
+            "reset": true
         }
     },
     "default_model": {

--- a/ivadomed/config/config_spineGeHemis.json
+++ b/ivadomed/config/config_spineGeHemis.json
@@ -55,7 +55,8 @@
         "mixup_alpha": null,
         "transfer_learning": {
             "retrain_model": null,
-            "retrain_fraction": 1.0
+            "retrain_fraction": 1.0,
+            "reset": true
         }
     },
     "default_model": {

--- a/ivadomed/config/config_tumorSeg.json
+++ b/ivadomed/config/config_tumorSeg.json
@@ -59,7 +59,8 @@
         "mixup_alpha": null,
         "transfer_learning": {
             "retrain_model": null,
-            "retrain_fraction": 1.0
+            "retrain_fraction": 1.0,
+            "reset": true
         }
     },
     "default_model": {

--- a/ivadomed/config/config_vertebral_labeling.json
+++ b/ivadomed/config/config_vertebral_labeling.json
@@ -57,7 +57,8 @@
         "mixup_alpha": null,
         "transfer_learning": {
             "retrain_model": "labeling_t2test/best_model.pt",
-            "retrain_fraction": 1.0
+            "retrain_fraction": 1.0,
+            "reset": true
         }
     },
     "default_model": {

--- a/ivadomed/models.py
+++ b/ivadomed/models.py
@@ -1319,6 +1319,7 @@ def set_model_for_retrain(model_path, retrain_fraction, map_location, reset=True
         retrain_fraction (float): Fraction of the model that will be retrained, between 0 and 1. If set to 0.3,
             then the 30% last fraction of the model will be re-initalised and retrained.
         map_location (str): Device.
+        reset (bool): if the un-frozen weight should be reset or kept as loaded.
 
     Returns:
         torch.Module: Model ready for retrain.
@@ -1345,7 +1346,7 @@ def set_model_for_retrain(model_path, retrain_fraction, map_location, reset=True
         for name, layer in model.named_modules():
             if name in layer_names[n_freeze:]:
                 layer.reset_parameters()
-        
+
     return model
 
 

--- a/ivadomed/models.py
+++ b/ivadomed/models.py
@@ -1341,10 +1341,11 @@ def set_model_for_retrain(model_path, retrain_fraction, map_location, reset=True
             break
 
     # Reset weights of the last layers
-    for name, layer in model.named_modules():
-        if name in layer_names[n_freeze:]:
-            layer.reset_parameters()
-
+    if reset:
+        for name, layer in model.named_modules():
+            if name in layer_names[n_freeze:]:
+                layer.reset_parameters()
+        
     return model
 
 

--- a/ivadomed/models.py
+++ b/ivadomed/models.py
@@ -1308,11 +1308,11 @@ class Countception(Module):
         return net
 
 
-def set_model_for_retrain(model_path, retrain_fraction, map_location):
+def set_model_for_retrain(model_path, retrain_fraction, map_location, reset=True):
     """Set model for transfer learning.
 
     The first layers (defined by 1-retrain_fraction) are frozen (i.e. requires_grad=False).
-    The weights of the last layers (defined by retrain_fraction) are reset.
+    The weights of the last layers (defined by retrain_fraction) are reset unless reset option is False.
 
     Args:
         model_path (str): Pretrained model path.

--- a/ivadomed/training.py
+++ b/ivadomed/training.py
@@ -87,8 +87,13 @@ def train(model_params, dataset_train, dataset_val, training_params, log_directo
             100 - training_params["transfer_learning"]['retrain_fraction'] * 100.))
         old_model_path = training_params["transfer_learning"]["retrain_model"]
         fraction = training_params["transfer_learning"]['retrain_fraction']
+        if 'reset' in training_params["transfer_learning"]:
+            reset = training_params["transfer_learning"]['reset']
+        else :
+            reset = True
         # Freeze first layers and reset last layers
-        model = imed_models.set_model_for_retrain(old_model_path, retrain_fraction=fraction, map_location=device)
+        model = imed_models.set_model_for_retrain(old_model_path, retrain_fraction=fraction, map_location=device,
+                                                  reset=reset)
     else:
         print("\nInitialising model's weights from scratch.")
         model_class = getattr(imed_models, model_params["name"])


### PR DESCRIPTION
This PR aims at adding an option to retrain a model without resetting any weights.
This could be useful if you think you need to add more epochs to an ongoing training for example. This is designed as an optional field. 