### PR TITLE
Refactoring: Changing print and exit to raise error

### DIFF
--- a/ivadomed/loader/adaptative.py
+++ b/ivadomed/loader/adaptative.py
@@ -703,7 +703,7 @@ def HDF5_to_Bids(HDF5, subjects, path_dir):
     hdf5 = h5py.File(HDF5, "r")
     # check the dir exists:
     if not path.exists(path_dir):
-        raise FileNotFoundError("Directory doesn't exist. Stopping process.")
+        raise FileNotFoundError("Directory {} doesn't exist. Stopping process.".format(path_dir))
 
     # loop over all subjects
     for sub in subjects:

--- a/ivadomed/loader/adaptative.py
+++ b/ivadomed/loader/adaptative.py
@@ -703,8 +703,8 @@ def HDF5_to_Bids(HDF5, subjects, path_dir):
     hdf5 = h5py.File(HDF5, "r")
     # check the dir exists:
     if not path.exists(path_dir):
-        print("Directory doesn't exist. Stopping process.")
-        exit(0)
+        raise FileNotFoundError("Directory doesn't exist. Stopping process.")
+
     # loop over all subjects
     for sub in subjects:
         path_sub = path_dir + '/' + sub + '/anat/'

--- a/ivadomed/models.py
+++ b/ivadomed/models.py
@@ -1379,13 +1379,10 @@ def get_model_filenames(folder_model):
         if not os.path.isfile(fname_model):
             fname_model = os.path.join(folder_model, prefix_model + '.pt')
             if not os.path.exists(fname_model):
-                print('Model file not found: {}'.format(fname_model))
-                exit()
+                raise FileNotFoundError(fname_model)
         fname_model_metadata = os.path.join(folder_model, prefix_model + '.json')
         if not os.path.isfile(fname_model_metadata):
-            print('Model metadata file not found: {}'.format(fname_model_metadata))
-            exit()
+            raise FileNotFoundError(fname_model)
     else:
-        print('Model folder not found: {}'.format(folder_model))
-        exit()
+        raise FileNotFoundError(fname_model)
     return fname_model, fname_model_metadata

--- a/ivadomed/scripts/visualize_transforms.py
+++ b/ivadomed/scripts/visualize_transforms.py
@@ -113,8 +113,7 @@ def run_visualization(input, config, number, output, roi):
         if roi and os.path.isfile(roi):
             roi_img, roi_data = get_data(roi, axis)
         else:
-            print("\nPlease provide ROI image (-r) in order to apply ROICrop transformation.")
-            exit()
+            raise ValueError("\nPlease provide ROI image (-r) in order to apply ROICrop transformation.")
 
     # Compose transforms
     dict_transforms = {}

--- a/ivadomed/testing.py
+++ b/ivadomed/testing.py
@@ -276,8 +276,7 @@ def threshold_analysis(model_path, ds_lst, model_params, testing_params, metric=
         float: optimal threshold.
     """
     if metric not in ["dice", "recall_specificity"]:
-        print('\nChoice of metric for threshold analysis: dice, recall_specificity.')
-        exit()
+        raise ValueError('\nChoice of metric for threshold analysis: dice, recall_specificity.')
 
     # Adjust some testing parameters
     testing_params["binarize_prediction"] = -1

--- a/ivadomed/training.py
+++ b/ivadomed/training.py
@@ -405,10 +405,10 @@ def get_scheduler(params, optimizer, num_epochs=0):
         scheduler = optim.lr_scheduler.CyclicLR(optimizer, **params, mode="triangular2", cycle_momentum=False)
         step_scheduler_batch = True
     else:
-        print(
+        raise ValueError(
             "Unknown LR Scheduler name, please choose between 'CosineAnnealingLR', 'CosineAnnealingWarmRestarts',"
             "or 'CyclicLR'")
-        exit()
+
     return scheduler, step_scheduler_batch
 
 
@@ -430,8 +430,7 @@ def get_loss_function(params):
                                "BinaryCrossEntropyLoss", "TverskyLoss", "FocalTverskyLoss", "AdapWingLoss", "L2loss",
                                "LossCombination"]
     if loss_name not in loss_function_available:
-        print("Unknown Loss function, please choose between {}".format(loss_function_available))
-        exit()
+        raise ValueError("Unknown Loss function, please choose between {}".format(loss_function_available))
 
     loss_class = getattr(imed_losses, loss_name)
     loss_fct = loss_class(**params)

--- a/ivadomed/training.py
+++ b/ivadomed/training.py
@@ -406,8 +406,8 @@ def get_scheduler(params, optimizer, num_epochs=0):
         step_scheduler_batch = True
     else:
         raise ValueError(
-            "Unknown LR Scheduler name, please choose between 'CosineAnnealingLR', 'CosineAnnealingWarmRestarts',"
-            "or 'CyclicLR'")
+            "{} is an unknown LR Scheduler name, please choose between 'CosineAnnealingLR', "
+            "'CosineAnnealingWarmRestarts', or 'CyclicLR'".format(scheduler_name))
 
     return scheduler, step_scheduler_batch
 
@@ -430,7 +430,7 @@ def get_loss_function(params):
                                "BinaryCrossEntropyLoss", "TverskyLoss", "FocalTverskyLoss", "AdapWingLoss", "L2loss",
                                "LossCombination"]
     if loss_name not in loss_function_available:
-        raise ValueError("Unknown Loss function, please choose between {}".format(loss_function_available))
+        raise ValueError("Unknown Loss function: {}, please choose between {}".format(loss_name, loss_function_available))
 
     loss_class = getattr(imed_losses, loss_name)
     loss_fct = loss_class(**params)

--- a/ivadomed/transforms.py
+++ b/ivadomed/transforms.py
@@ -115,7 +115,7 @@ class Compose(object):
                 params_cur = {k: parameters[k] for k in parameters if k != "applied_to" and k != "preprocessing"}
                 transform_obj = globals()[transform](**params_cur)
             else:
-                raise ValueError('ERROR: {} transform is not available in your ivadomed package. '
+                raise ValueError('ERROR: {} transform is not available. '
                       'Please check its compatibility with your model json file.'.format(transform))
 
             # check if undo_transform method is implemented

--- a/ivadomed/transforms.py
+++ b/ivadomed/transforms.py
@@ -115,9 +115,8 @@ class Compose(object):
                 params_cur = {k: parameters[k] for k in parameters if k != "applied_to" and k != "preprocessing"}
                 transform_obj = globals()[transform](**params_cur)
             else:
-                print('ERROR: {} transform is not available in your ivadomed package. '
+                raise ValueError('ERROR: {} transform is not available in your ivadomed package. '
                       'Please check its compatibility with your model json file.'.format(transform))
-                exit()
 
             # check if undo_transform method is implemented
             if requires_undo:


### PR DESCRIPTION
Changing old print and exit for "raise *Error*". This was found in a few files and is now fixed. 
fix #330 