### PR TITLE
Fix missing version.txt in wheels package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include ivadomed/config/*.json
+include ivadomed/version.txt

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from os import path
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()
 
-#Get README
+# Get README
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
@@ -34,11 +34,11 @@ setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require={
-        'docs': [ # pin sphinx to match what RTD uses:
-                  # https://github.com/readthedocs/readthedocs.org/blob/ecac31de54bbb2c100f933e86eb22b0f4389ba84/requirements/pip.txt#L16
-                 'sphinx<2',
-                 'sphinx-rtd-theme<0.5',
-                ],
+        'docs': [  # pin sphinx to match what RTD uses:
+            # https://github.com/readthedocs/readthedocs.org/blob/ecac31de54bbb2c100f933e86eb22b0f4389ba84/requirements/pip.txt#L16
+            'sphinx<2',
+            'sphinx-rtd-theme<0.5',
+        ],
     },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Closes #487 

Test with locally built wheel:
```
docker run -v --interactive --tty --entrypoint /bin/bash --net=host python:3.6
root@drupad-p1:/# pip install https://pypi.drulex.com/packages/ivadomed-2.3.1-py3-none-any.whl
[...]
root@drupad-p1:/# python
Python 3.6.12 (default, Sep 10 2020, 17:53:20) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import ivadomed
>>> ivadomed.__version__
'2.3.1'
>>> 
```
