### PR TITLE
set h5py version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bids-neuropoly>=0.2
-h5py
+h5py==2.10.0
 joblib
 matplotlib>=3.3.0
 nibabel


### PR DESCRIPTION
New release from h5py (v3.0.0) cause some crash in the adaptative loader (hemis). 
This Pr fixed the package at version 2.10.0 to avoid this issue. 

fix #499 