### PR TITLE
paper.bib: correct typo

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -104,7 +104,7 @@ Publisher: Nature Publishing Group},
 }
 
 
-@article{,
+@article{nair_exploring_2018,
   title={Exploring uncertainty measures in deep networks for multiple sclerosis lesion detection and segmentation},
   author={Nair, Tanya and Precup, Doina and Arnold, Douglas L and Arbel, Tal},
   journal={Medical image analysis},


### PR DESCRIPTION
Paper reference erased by mistake --> corrected in this PR.