### PR TITLE
paper.md: overview_title.png path

### DIFF
--- a/paper.md
+++ b/paper.md
@@ -49,7 +49,7 @@ Deep learning applied to medical imaging presents many challenges: datasets are 
 
 Another challenge of medical imaging is the heterogeneity of the data across hospitals (e.g., contrast, resolution), making it difficult to create models that can generalize well. Recent cutting-edge methods address this problem, such as FiLM [@perez2017film] and HeMis [@havaei2016hemis], however they are usually not implemented within a comprehensive framework. In addition to providing these architectures, `ivadomed` features losses adapted to imbalanced classes and non-binary predictions.
 
-![Overview of `ivadomed` main features.\label{fig:overview}](https://raw.githubusercontent.com/ivadomed/doc-figures/main/overview_title.png)
+![Overview of `ivadomed` main features.\label{fig:overview}](https://raw.githubusercontent.com/ivadomed/doc-figures/main/index/overview_title.png)
 
 ## Loader
 


### PR DESCRIPTION
Latex generation error:
```
Looks like we failed to compile the PDF with the following error: [WARNING] Could not convert image '/tmp/tex2pdf.-24d0e926137c3187/78fb38f212fa49029aff24c669a39648d9b4e68b.vs': Cannot load file Jpeg Invalid marker used PNG Invalid PNG file, signature broken Bitmap Invalid Bitmap magic identifier GIF Invalid Gif signature : 404: N HDR Invalid radiance file signature Tiff Invalid endian tag value TGA not enough bytes Error producing PDF. ! LaTeX Error: Cannot determine size of graphic in /tmp/tex2pdf.-24d0e926137c31 87/78fb38f212fa49029aff24c669a39648d9b4e68b.vs (no BoundingBox). See the LaTeX manual or LaTeX Companion for explanation. Type H for immediate help. ... l.392 ...b38f212fa49029aff24c669a39648d9b4e68b.vs} 
```

Fixed by changing path of figure.