### PR TITLE
Split_dataset: consider center_list when per_patient is used

### DIFF
--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -68,13 +68,17 @@ def split_dataset(df, center_test_lst, split_method, random_seed, train_frac=0.8
     elif split_method == 'per_patient':
         # Separate dataset in test, train and validation using sklearn function
         # In case we want to use the entire dataset for testing purposes
-        if test_frac == 1:
+        X_remain = df['participant_id'].tolist()
+        if len(center_test_lst):
+            X_test = df[df['institution_id'].isin(center_test_lst)]['participant_id'].tolist()
+            X_remain = df[~df['institution_id'].isin(center_test_lst)]['participant_id'].tolist()
+
+        if test_frac == 1 and not len(center_test_lst):
             X_test = df['participant_id'].tolist()
         else:
-            X_train, X_remain = train_test_split(df['participant_id'].tolist(), train_size=train_frac,
-                                                 random_state=random_seed)
+            X_train, X_remain = train_test_split(X_remain, train_size=train_frac, random_state=random_seed)
             # In case the entire dataset is used to train / validate the model
-            if test_frac == 0:
+            if test_frac == 0 or len(center_test_lst):
                 X_val = X_remain
             else:
                 X_test, X_val = train_test_split(X_remain, train_size=test_frac / (1 - train_frac),


### PR DESCRIPTION
The splitting method `per_center` overwrites the use of `center_test`. This PR allows using the `per_patient` splitting method with the parameter `center_test`.