### PR TITLE
New loader: generate dataframe

### DIFF
--- a/dev/df_new_loader.py
+++ b/dev/df_new_loader.py
@@ -25,7 +25,6 @@ loader_params = context["loader_parameters"]
 loader_params["contrast_params"]["contrast_lst"] = loader_params["contrast_params"]["training_validation"]
 
 # CHOOSE TO INDEX DERIVATIVES OR NOT
-# To discuss: depending on how derivatives availibility is checked and split is done afterwards.
 # As per pybids, the indexing of derivatives works only if a "dataset_description.json" file
 # is present in "derivatives" or "labels" folder with minimal content:
 # {"Name": "Example dataset", "BIDSVersion": "1.0.2", "PipelineDescription": {"Name": "Example pipeline"}}
@@ -35,6 +34,6 @@ derivatives = True
 df = imed_loader_utils.create_bids_dataframe(loader_params, derivatives)
 
 # SAVE DATAFRAME TO CSV FILE
-path_csv = "test.csv"
+path_csv = "test_df_new_loader.csv"
 df.to_csv(path_csv)
 print(df)

--- a/dev/df_new_loader.py
+++ b/dev/df_new_loader.py
@@ -22,11 +22,13 @@ from ivadomed.loader import utils as imed_loader_utils
 path_config_file = "ivadomed/config/config_new_loader.json"
 context = imed_config_manager.ConfigurationManager(path_config_file).get_config()
 loader_params = context["loader_parameters"]
+loader_params["contrast_params"]["contrast_lst"] = loader_params["contrast_params"]["training_validation"]
 
 # CHOOSE TO INDEX DERIVATIVES OR NOT
 # To discuss: depending on how derivatives availibility is checked and split is done afterwards.
 # As per pybids, the indexing of derivatives works only if a "dataset_description.json" file
-# is present in "derivatives" or "labels" folder.
+# is present in "derivatives" or "labels" folder with minimal content:
+# {"Name": "Example dataset", "BIDSVersion": "1.0.2", "PipelineDescription": {"Name": "Example pipeline"}}
 derivatives = True
 
 # CREATE DATAFRAME

--- a/dev/df_new_loader.py
+++ b/dev/df_new_loader.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+##############################################################
+#
+# This script is used to test the dataframe of the new loader
+#
+# Usage: python dev/df_new_loader.py
+#
+##############################################################
+
+# IMPORTS
+import os
+import pandas as pd
+from ivadomed import config_manager as imed_config_manager
+from ivadomed.loader import utils as imed_loader_utils
+import bids as pybids
+
+# GET LOADER PARAMETERS FROM IVADOMED CONFIG FILE
+# The loader parameters have 2 new fields: "bids_config" and "extensions".
+# "bids_config" is mandatory for microscopy until BEP is merged and pybids is updated, the file is
+# in ivadomed/config/config_bids.json.
+# "bids_config" is optional for anat, can be the same as microscopy or set to null.
+# "extensions" is used to filter which files are to be indexed, in case multiple file types are present.
+path_config_file = "/home/mhbourget/ivadomed/ivadomed/config/config_new_loader.json"
+context = imed_config_manager.ConfigurationManager(path_config_file).get_config()
+loader_params = context["loader_parameters"]
+
+# CHOOSE TO INDEX DERIVATIVES OR NOT
+# To discuss: depending on how derivatives availibility is checked and split is done afterwards.
+# As per pybids, the indexing of derivatives works only if a "dataset_description.json" file
+# is present in "derivatives" or "labels" folder.
+derivatives = True
+
+# CREATE DATAFRAME
+df = imed_loader_utils.create_bids_dataframe(loader_params, derivatives)
+
+# SAVE DATAFRAME TO CSV FILE
+path_csv = "./test.csv"
+df.to_csv(path_csv)

--- a/dev/df_new_loader.py
+++ b/dev/df_new_loader.py
@@ -12,15 +12,14 @@ import os
 import pandas as pd
 from ivadomed import config_manager as imed_config_manager
 from ivadomed.loader import utils as imed_loader_utils
-import bids as pybids
 
 # GET LOADER PARAMETERS FROM IVADOMED CONFIG FILE
 # The loader parameters have 2 new fields: "bids_config" and "extensions".
 # "bids_config" is mandatory for microscopy until BEP is merged and pybids is updated, the file is
 # in ivadomed/config/config_bids.json.
-# "bids_config" is optional for anat, can be the same as microscopy or set to null.
+# "bids_config" is optional for anat
 # "extensions" is used to filter which files are to be indexed, in case multiple file types are present.
-path_config_file = "/home/mhbourget/ivadomed/ivadomed/config/config_new_loader.json"
+path_config_file = "ivadomed/config/config_new_loader.json"
 context = imed_config_manager.ConfigurationManager(path_config_file).get_config()
 loader_params = context["loader_parameters"]
 
@@ -34,5 +33,6 @@ derivatives = True
 df = imed_loader_utils.create_bids_dataframe(loader_params, derivatives)
 
 # SAVE DATAFRAME TO CSV FILE
-path_csv = "./test.csv"
+path_csv = "test.csv"
 df.to_csv(path_csv)
+print(df)

--- a/docs/source/configuration_file.rst
+++ b/docs/source/configuration_file.rst
@@ -70,6 +70,12 @@ bids\_path
 
 String. Path of the BIDS folder.
 
+bids\_config
+^^^^^^^^^^^^
+
+String (Optional). Path of the custom BIDS configuration file for BIDS non-compliant modalities
+(e.g. ``"ivadomed/config/config_bids.json"``).
+
 subject\_selection
 ^^^^^^^^^^^^^^^^^^
 
@@ -91,6 +97,11 @@ interest (e.g. [``"_seg-manual"``, ``"_lesion-manual"``]). The length of
 this list controls the number of output channels of the model (i.e.
 ``out_channel``). If the list has a length greater than 1, then a
 multi-class model will be trained.
+
+extensions
+^^^^^^^^^^
+
+List. Used to specify a list of file extensions to be selected for training/testing.
 
 contrasts
 ^^^^^^^^^

--- a/ivadomed/config/config_bids.json
+++ b/ivadomed/config/config_bids.json
@@ -1,0 +1,112 @@
+{
+    "name": "config_bids",
+    "entities": [
+        {
+            "name": "subject",
+            "pattern": "[/\\\\]+sub-([a-zA-Z0-9]+)",
+            "directory": "{subject}"
+        },
+        {
+            "name": "session",
+            "pattern": "[_/\\\\]+ses-([a-zA-Z0-9]+)",
+            "mandatory": false,
+            "directory": "{subject}{session}"
+        },
+        {
+            "name": "task",
+            "pattern": "[_/\\\\]+task-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "sample",
+            "pattern": "[_/\\\\]+sample-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "acquisition",
+            "pattern": "[_/\\\\]+acq-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "ceagent",
+            "pattern": "[_/\\\\]+ce-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "reconstruction",
+            "pattern": "[_/\\\\]+rec-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "direction",
+            "pattern": "[_/\\\\]+dir-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "run",
+            "pattern": "[_/\\\\]+run-0*(\\d+)",
+            "dtype": "int"
+        },
+        {
+            "name": "proc",
+            "pattern": "[_/\\\\]+proc-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "modality",
+            "pattern": "[_/\\\\]+mod-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "echo",
+            "pattern": "[_/\\\\]+echo-([0-9]+)"
+        },
+        {
+            "name": "recording",
+            "pattern": "[_/\\\\]+recording-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "space",
+            "pattern": "[_/\\\\]+space-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "downsampling",
+            "pattern": "[_/\\\\]+down-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "suffix",
+            "pattern": "[._]*([a-zA-Z0-9]*?)\\.[^/\\\\]+$"
+        },
+        {
+            "name": "scans",
+            "pattern": "(.*\\_scans.tsv)$"
+        },
+        {
+            "name": "fmap",
+            "pattern": "(phasediff|magnitude[1-2]|phase[1-2]|fieldmap|epi)\\.nii"
+        },
+        {
+            "name": "datatype",
+            "pattern": "[/\\\\]+(func|anat|fmap|dwi|meg|eeg|microscopy)[/\\\\]+"
+        },
+        {
+            "name": "extension",
+            "pattern": "[._]*[a-zA-Z0-9]*?(\\.[^/\\\\]+)$"
+        }
+    ],
+
+    "default_path_patterns": [
+        "sub-{subject}[/ses-{session}]/{datatype<anat>|anat}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}]_{suffix<T1w|T2w|T1rho|T1map|T2map|T2star|FLAIR|FLASH|PDmap|PD|PDT2|inplaneT[12]|angio>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
+        "sub-{subject}[/ses-{session}]/{datatype<anat>|anat}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_mod-{modality}]_{suffix<defacemask>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
+        "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}]_{suffix<bold|cbv|phase|sbref>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
+        "sub-{subject}[/ses-{session}]/{datatype<dwi>|dwi}/sub-{subject}[_ses-{session}][_acq-{acquisition}]_{suffix<dwi>}{extension<.bval|.bvec|.json|.nii.gz|.nii>|.nii.gz}",
+        "sub-{subject}[/ses-{session}]/{datatype<fmap>|fmap}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_dir-{direction}][_run-{run}]_{fmap<phasediff|magnitude[12]|phase[12]|fieldmap>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
+        "sub-{subject}[/ses-{session}]/{datatype<fmap>|fmap}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}]_dir-{direction}[_run-{run}]_{fmap<epi>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
+        "sub-{subject}[/ses-{session}]/[{datatype<func|meg|beh>|func}/]sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_recording-{recording}]_{suffix<events>}{extension<.tsv|.json>|.tsv}",
+        "sub-{subject}[/ses-{session}]/[{datatype<func|beh>|func}/]sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_recording-{recording}]_{suffix<physio|stim>}{extension<.tsv.gz|.json>|.tsv.gz}",
+        "sub-{subject}[/ses-{session}]/{datatype<meg>|meg}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_run-{run}][_proc-{proc}]_{suffix<meg>}{extension}",
+        "sub-{subject}[/ses-{session}]/{datatype<meg>|meg}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_run-{run}][_proc-{proc}]_{suffix<channels>}{extension<.tsv|.json>|.tsv}",
+        "sub-{subject}[/ses-{session}]/{datatype<meg>|meg}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}]_{suffix<coordsystem>}{extension<.json>|.json}",
+        "sub-{subject}[/ses-{session}]/{datatype<meg>|meg}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}]_{suffix<photo>}{extension<.jpg>|.jpg}",
+        "[acq-{acquisition}_][ce-{ceagent}_][rec-{reconstruction}_]{suffix<T1w|T2w|T1rho|T1map|T2map|T2star|FLAIR|FLASH|PDmap|PD|PDT2|inplaneT[12]|angio>}{extension<.json>|.json}",
+        "[acq-{acquisition}_][ce-{ceagent}_][rec-{reconstruction}_][mod-{modality}_]{suffix<defacemask>}{extension<.json>|.json}",
+        "task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}]_{suffix<bold|cbv|phase|sbref>}{extension<.json>|.json}",
+        "[acq-{acquisition}_]{suffix<dwi>}{extension<.json>|.json}",
+        "[acq-{acquisition}_][dir-{direction}_][run-{run}_]{fmap<phasediff|magnitude[1-2]|phase[1-2]|fieldmap>}{extension<.json>|.json}",
+        "[acq-{acquisition}_][ce-{ceagent}_]dir-{direction}[_run-{run}]_{fmap<epi>}{extension<.json>|.json}",
+        "task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_recording-{recording}]_{suffix<events>}{extension<.json>|.json}",
+        "task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_recording-{recording}]_{suffix<physio|stim>}{extension<.json>}"
+    ]
+}

--- a/ivadomed/config/config_default.json
+++ b/ivadomed/config/config_default.json
@@ -12,6 +12,7 @@
         "bids_path": "bids_path",
         "subject_selection": {"n": [], "metadata": [], "value": []},
         "target_suffix": [],
+        "extensions": [],
         "roi_params": {
             "suffix": null,
             "slice_filter_roi": null

--- a/ivadomed/config/config_new_loader.json
+++ b/ivadomed/config/config_new_loader.json
@@ -19,7 +19,7 @@
             "slice_filter_roi": null
         },
         "contrast_params": {
-            "training_validation": [],
+            "training_validation": ["T1w", "SEM"],
             "testing": [],
             "balance": {}
         },

--- a/ivadomed/config/config_new_loader.json
+++ b/ivadomed/config/config_new_loader.json
@@ -1,7 +1,7 @@
 {
     "command": "train",
     "gpu": 0,
-    "log_directory": "/home/mhbourget/ivadomed/log_directory/new_loader",
+    "log_directory": "log_directory/new_loader",
     "model_name": "model_name",
     "debugging": false,
     "object_detection_params": {
@@ -9,8 +9,8 @@
         "safety_factor": [1.0, 1.0, 1.0]
     },
     "loader_parameters": {
-        "bids_path": "/home/mhbourget/ivadomed/data_example_microscopy_sem",
-        "bids_config": "/home/mhbourget/ivadomed/ivadomed/config/config_bids.json",
+        "bids_path": "data_example_microscopy_sem",
+        "bids_config": "ivadomed/config/config_bids.json",
         "target_suffix": ["_seg-manual", "_seg-axon-manual"],
         "extensions": [".png", ".nii.gz"],
         "roi_params": {

--- a/ivadomed/config/config_new_loader.json
+++ b/ivadomed/config/config_new_loader.json
@@ -12,7 +12,8 @@
         "bids_path": "data_example_microscopy_sem",
         "bids_config": "ivadomed/config/config_bids.json",
         "target_suffix": ["_seg-manual", "_seg-axon-manual"],
-        "extensions": [".png", ".nii.gz"],
+        "extensions": [".nii.gz", ".png"],
+        "data_types": ["anat", "microscopy"],
         "roi_params": {
             "suffix": null,
             "slice_filter_roi": null

--- a/ivadomed/config/config_new_loader.json
+++ b/ivadomed/config/config_new_loader.json
@@ -3,7 +3,7 @@
     "gpu": 0,
     "log_directory": "log_directory/new_loader",
     "model_name": "model_name",
-    "debugging": false,
+    "debugging": true,
     "object_detection_params": {
         "object_detection_path": null,
         "safety_factor": [1.0, 1.0, 1.0]

--- a/ivadomed/config/config_new_loader.json
+++ b/ivadomed/config/config_new_loader.json
@@ -1,0 +1,88 @@
+{
+    "command": "train",
+    "gpu": 0,
+    "log_directory": "/home/mhbourget/ivadomed/log_directory/new_loader",
+    "model_name": "model_name",
+    "debugging": false,
+    "object_detection_params": {
+        "object_detection_path": null,
+        "safety_factor": [1.0, 1.0, 1.0]
+    },
+    "loader_parameters": {
+        "bids_path": "/home/mhbourget/ivadomed/data_example_microscopy_sem",
+        "bids_config": "/home/mhbourget/ivadomed/ivadomed/config/config_bids.json",
+        "target_suffix": ["_seg-manual", "_seg-axon-manual"],
+        "extensions": [".png", ".nii.gz"],
+        "roi_params": {
+            "suffix": null,
+            "slice_filter_roi": null
+        },
+        "contrast_params": {
+            "training_validation": [],
+            "testing": [],
+            "balance": {}
+        },
+        "slice_filter_params": {
+            "filter_empty_mask": false,
+            "filter_empty_input": true
+        },
+        "slice_axis": "axial",
+        "multichannel": false,
+        "soft_gt": false
+    },
+    "split_dataset": {
+        "fname_split": null,
+        "random_seed": 6,
+        "center_test": [],
+        "method": "per_patient",
+        "balance": null,
+        "train_fraction": 0.6,
+        "test_fraction": 0.2
+    },
+    "training_parameters": {
+        "batch_size": 18,
+        "loss": {
+            "name": "DiceLoss"
+        },
+        "training_time": {
+            "num_epochs": 100,
+            "early_stopping_patience": 50,
+            "early_stopping_epsilon": 0.001
+        },
+        "scheduler": {
+            "initial_lr": 0.001,
+            "lr_scheduler": {
+                "name": "CosineAnnealingLR",
+                "base_lr": 1e-5,
+                "max_lr": 1e-2
+            }
+        },
+        "balance_samples": {
+            "applied": false,
+            "type": "gt"
+        },
+        "mixup_alpha": null,
+        "transfer_learning": {
+            "retrain_model": null,
+            "retrain_fraction": 1.0,
+            "reset": true
+        }
+    },
+    "default_model": {
+        "name": "Unet",
+        "dropout_rate": 0.3,
+        "bn_momentum": 0.9,
+        "depth": 3,
+        "is_2d": true
+    },
+    "uncertainty": {
+        "epistemic": false,
+        "aleatoric": false,
+        "n_it": 0
+    },
+    "postprocessing": {},
+    "evaluation_parameters": {
+    },
+    "transformation": {
+    }
+}

--- a/ivadomed/config/config_new_loader.json
+++ b/ivadomed/config/config_new_loader.json
@@ -13,7 +13,6 @@
         "bids_config": "ivadomed/config/config_bids.json",
         "target_suffix": ["_seg-manual", "_seg-axon-manual"],
         "extensions": [".nii.gz", ".png"],
-        "data_types": ["anat", "microscopy"],
         "roi_params": {
             "suffix": null,
             "slice_filter_roi": null

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -520,11 +520,12 @@ def create_bids_dataframe(loader_params, derivatives):
         df (pd.DataFrame): Dataframe containing all BIDS image files indexed and their metadata.
     """
 
-    # Get bids_path, bids_config, target_suffix and extensions from loader parameters
+    # Get bids_path, bids_config, target_suffix, extensions and data_types from loader parameters
     bids_path = loader_params['bids_path']
     bids_config = None if 'bids_config' not in loader_params else loader_params['bids_config']
     target_suffix = loader_params['target_suffix']
     extensions = loader_params['extensions']
+    data_types = loader_params['data_types']
 
     # Suppress a Future Warning from pybids about leading dot included in 'extension' from version 0.14.0
     # The config_bids.json file used matches the future behavior
@@ -547,9 +548,9 @@ def create_bids_dataframe(loader_params, derivatives):
     df['filename'] = df['path'].apply(os.path.basename)
     df['parent_path'] = df['path'].apply(os.path.dirname)
 
-    # Filter rows with chosen extensions from loader parameters
-    # We may want to filter according to data_type as well (ex: anat, microscopy, etc)
-    df = df[df['filename'].str.contains('|'.join(extensions))]
+    # Filter rows with chosen extensions and data_types from loader parameters
+    df = df[df['filename'].str.endswith(tuple(extensions))]
+    df = df[df['parent_path'].str.endswith(tuple(data_types))]
 
     # Update dataframe with files from subject folders only, and files from chosen derivatives from loader parameters
     df = df[~df['path'].str.contains('derivatives') | df['filename'].str.contains('|'.join(target_suffix))]

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -556,11 +556,12 @@ def create_bids_dataframe(loader_params, derivatives):
     # Reset index
     df.reset_index(drop=True, inplace=True)
 
-    # Add metadata from participants.tsv
+    # Add metadata from participants.tsv, if present
     fname_participants = os.path.join(bids_path, "participants.tsv")
-    df_participants = pd.read_csv(fname_participants, sep='\t')
     df['participant_id'] = "sub-" + df['subject']
-    df = pd.merge(df, df_participants, on='participant_id', suffixes=("_x", None), how='left')
+    if os.path.exists(fname_participants):
+        df_participants = pd.read_csv(fname_participants, sep='\t')
+        df = pd.merge(df, df_participants, on='participant_id', suffixes=("_x", None), how='left')
 
     # Add metadata from samples.tsv, if present
     fname_samples = os.path.join(bids_path, "samples.tsv")

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -517,7 +517,7 @@ def create_bids_dataframe(loader_params, derivatives):
 
     # Get bids_path, bids_config, target_suffix and extensions from loader parameters
     bids_path = loader_params['bids_path']
-    bids_config = loader_params['bids_config']
+    bids_config = None if 'bids_config' not in loader_params else loader_params['bids_config']
     target_suffix = loader_params['target_suffix']
     extensions = loader_params['extensions']
 

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -526,6 +526,7 @@ def create_bids_dataframe(loader_params, derivatives):
     target_suffix = loader_params['target_suffix']
     extensions = loader_params['extensions']
     data_types = loader_params['data_types']
+    contrast_lst = loader_params["contrast_params"]["contrast_lst"]
 
     # Suppress a Future Warning from pybids about leading dot included in 'extension' from version 0.14.0
     # The config_bids.json file used matches the future behavior
@@ -552,8 +553,9 @@ def create_bids_dataframe(loader_params, derivatives):
     df = df[df['filename'].str.endswith(tuple(extensions))]
     df = df[df['parent_path'].str.endswith(tuple(data_types))]
 
-    # Update dataframe with files from subject folders only, and files from chosen derivatives from loader parameters
-    df = df[~df['path'].str.contains('derivatives') | df['filename'].str.contains('|'.join(target_suffix))]
+    # Update dataframe with subject files with chosen contrast and derivative files with chosen target_suffix from loader parameters
+    df = (df[(~df['path'].str.contains('derivatives') & df['suffix'].str.contains('|'.join(contrast_lst))) |
+          df['filename'].str.contains('|'.join(target_suffix))])
 
     # Add metadata from participants.tsv file, if present
     # Uses pybids function

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -570,12 +570,14 @@ def create_bids_dataframe(loader_params, derivatives):
     df['filename'] = df['path'].apply(os.path.basename)
     df['parent_path'] = df['path'].apply(os.path.dirname)
 
-    # Filter rows with chosen extensions from loader parameters
-    df = df[df['filename'].str.endswith(tuple(extensions))]
+    # Drop rows with json, tsv and LICENSE files in case no extensions are provided in config file for filtering
+    df = df[~df['filename'].str.endswith(tuple(['.json', '.tsv', 'LICENSE']))]
 
-    # Update dataframe with subject files of chosen contrasts, and derivative files of chosen target_suffix from loader parameters
-    df = (df[(~df['path'].str.contains('derivatives') & df['suffix'].str.contains('|'.join(contrast_lst))) |
-          df['filename'].str.contains('|'.join(target_suffix))])
+    # Update dataframe with subject files of chosen contrasts and extensions,
+    # and with derivative files of chosen target_suffix from loader parameters
+    df = (df[(~df['path'].str.contains('derivatives') & df['suffix'].str.contains('|'.join(contrast_lst)) &
+          df['extension'].str.contains('|'.join(extensions))) |
+          (df['filename'].str.contains('|'.join(target_suffix)))])
 
     # Add metadata from participants.tsv file, if present
     # Uses pybids function

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -556,13 +556,13 @@ def create_bids_dataframe(loader_params, derivatives):
     print(df)
 
     # Add metadata from participants.tsv
-    fname_participants = bids_path + "/participants.tsv"
+    fname_participants = os.path.join(bids_path, "participants.tsv")
     df_participants = pd.read_csv(fname_participants, sep='\t')
     df['participant_id'] = "sub-" + df['subject']
     df = pd.merge(df, df_participants, on='participant_id', suffixes=("_x", None), how='left')
 
     # Add metadata from samples.tsv, if present
-    fname_samples = bids_path + "/samples.tsv"
+    fname_samples = os.path.join(bids_path, "samples.tsv")
     if os.path.exists(fname_samples):
         df_samples = pd.read_csv(fname_samples, sep='\t')
         df['sample_id'] = "sample-" + df['sample']

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -508,6 +508,7 @@ def reorient_image(arr, slice_axis, nib_ref, nib_ref_canonical):
     # apply transformation
     return nib.orientations.apply_orientation(arr_ras, trans_orient)
 
+
 def create_bids_dataframe(loader_params, derivatives):
     """Create a dataframe containing all BIDS image files in a bids_path and their metadata.
 

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -553,7 +553,6 @@ def create_bids_dataframe(loader_params, derivatives):
 
     # Reset index
     df.reset_index(drop=True, inplace=True)
-    print(df)
 
     # Add metadata from participants.tsv
     fname_participants = os.path.join(bids_path, "participants.tsv")

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -625,11 +625,14 @@ def create_bids_dataframe(loader_params, derivatives):
         deriv = df[df['path'].str.contains('derivatives')]['filename'].tolist()
         has_deriv = []
         for p in prefix_fnames:
-            available = [p for d in deriv if p in d]
+            available = [d for d in deriv if p in d]
             if available:
-                has_deriv.extend(available)
+                has_deriv.append(p)
+                for t in target_suffix:
+                    if t not in str(available):
+                        logger.warning("Missing target_suffix {} for subject {}.".format(t, p))
             else:
-                logger.warning("Missing derivative for subject {}. Skipping.".format(p))
+                logger.warning("Missing derivatives for subject {}. Skipping subject.".format(p))
 
         # Filter dataframe to keep subjects files with available derivatives only
         if has_deriv:

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -547,9 +547,7 @@ def create_bids_dataframe(loader_params, derivatives):
     df = df[df['filename'].str.contains('|'.join(extensions))]
 
     # Update dataframe with files from subject folders only, and files from chosen derivatives from loader parameters
-    df_derivatives = df[df['path'].str.contains('derivatives') & df['filename'].str.contains('|'.join(target_suffix))]
-    df = df[df['path'].str.startswith(bids_path + "/sub")]
-    df = pd.concat([df, df_derivatives])
+    df = df[~df['path'].str.contains('derivatives') | df['filename'].str.contains('|'.join(target_suffix))]
 
     # Reset index
     df.reset_index(drop=True, inplace=True)

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -504,7 +504,7 @@ def reorient_image(arr, slice_axis, nib_ref, nib_ref_canonical):
     # apply transformation
     return nib.orientations.apply_orientation(arr_ras, trans_orient)
 
-def create_bids_dataframe(loader_param, derivatives):
+def create_bids_dataframe(loader_params, derivatives):
     """Create a dataframe containing all BIDS image files in a bids_path and their metadata.
 
     Args:
@@ -516,10 +516,10 @@ def create_bids_dataframe(loader_param, derivatives):
     """
 
     # Get bids_path, bids_config, target_suffix and extensions from loader parameters
-    bids_path = loader_param['bids_path']
-    bids_config = loader_param['bids_config']
-    target_suffix = loader_param['target_suffix']
-    extensions = loader_param['extensions']
+    bids_path = loader_params['bids_path']
+    bids_config = loader_params['bids_config']
+    target_suffix = loader_params['target_suffix']
+    extensions = loader_params['extensions']
 
     # Suppress a Future Warning from pybids about leading dot included in 'extension' from version 0.14.0
     # The config_bids.json file used matches the future behavior

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -525,7 +525,6 @@ def create_bids_dataframe(loader_params, derivatives):
     bids_config = None if 'bids_config' not in loader_params else loader_params['bids_config']
     target_suffix = loader_params['target_suffix']
     extensions = loader_params['extensions']
-    data_types = loader_params['data_types']
     contrast_lst = loader_params["contrast_params"]["contrast_lst"]
 
     # Suppress a Future Warning from pybids about leading dot included in 'extension' from version 0.14.0
@@ -551,7 +550,6 @@ def create_bids_dataframe(loader_params, derivatives):
 
     # Filter rows with chosen extensions and data_types from loader parameters
     df = df[df['filename'].str.endswith(tuple(extensions))]
-    df = df[df['parent_path'].str.endswith(tuple(data_types))]
 
     # Update dataframe with subject files with chosen contrast and derivative files with chosen target_suffix from loader parameters
     df = (df[(~df['path'].str.contains('derivatives') & df['suffix'].str.contains('|'.join(contrast_lst))) |

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ nibabel
 onnxruntime==1.4.0
 pandas
 pillow>=7.0.0
+pybids>=0.12.4
 pytest
 scikit-learn>=0.20.3
 scikit-image


### PR DESCRIPTION
Fixes #519 
This PR is part of the loader refactoring project to include microscopy data (#304) and to migrate to HDF5 loader (#474).
It may also include changes to support EEG modality (#525).

It aims to generate a dataframe by indexing filenames and metadata in a bids path.

Changes have been tested with `anat` and `microscopy` datasets.

The changes are:
1 new function `create_bids_dataframe` in `ivadomed/loader/utils.py`.
1 new requirement: `pybids>=0.12.4`
3 new files:
`ivadomed/config/config_bids.json` : custom bids_config file needed for dealing with additional microscopy entities in `pybids`.
`ivadomed/config/config_new_loader.json` : ivadomed config file with 2 new `loader parameters`:  `bids_config` and `extensions`.
`dev/df_new_loader.py` : Script used to test the new `create_bids_dataframe` function.

I left a lot of comments in the code to explain the different steps and choices made.

I was able to keep the validation (by the BIDS-validator) by forcing the indexing of files in `sub-*` folders at the root of the bids path and of files specific to microscopy (`samples.tsv`, `samples.json`).

To discuss:
- Do we want to index derivatives? (depends on where and when we want to check for availability and do the dataset split)
- Currently, the files are indexed and filtered by `extensions` and `target_suffix`. We could also filter by `data_type` (anat, microscopy, etc) and/or modality suffix (ex: T1w, SEM, etc) in case multiple data type are available in a dataset.

TODO:
- Include parsing of `sessions.tsv` and `scans.tsv` files (not done at the moment, only `participants.tsv` and `samples.tsv`)
- Read appropriate metadata from image file and add to dataframe. Is it pertinent at this stage? Could also be done after the split when loading images to numpy arrays.
- Evaluate changes to make to include EEG.