### PR TITLE
fix lfdr

### DIFF
--- a/ivadomed/evaluation.py
+++ b/ivadomed/evaluation.py
@@ -381,7 +381,7 @@ class Evaluation3DMetrics(object):
         lfp = self._get_lfp(label_size, class_idx)
 
         denom = ltp + lfp
-        if denom == 0 or n_obj == 0:
+        if denom == 0:
             return np.nan
 
         return lfp / denom


### PR DESCRIPTION
Even if the GT has n_obj (number of objects to zero), there can still be a value of LFDR. Example: GT has no object, but the prediction has one -> LFDR = 1 (and not np.nan)