### PR TITLE
Random sampling of expert annotations

### DIFF
--- a/docs/source/configuration_file.rst
+++ b/docs/source/configuration_file.rst
@@ -90,7 +90,12 @@ List. Suffix list of the derivative file containing the ground-truth of
 interest (e.g. [``"_seg-manual"``, ``"_lesion-manual"``]). The length of
 this list controls the number of output channels of the model (i.e.
 ``out_channel``). If the list has a length greater than 1, then a
-multi-class model will be trained.
+multi-class model will be trained. If a list of list(s) is input for a
+training, (e.g. [[``"_seg-manual-rater1"``, ``"_seg-manual-rater2"``],
+[``"_lesion-manual-rater1"``, ``"_lesion-manual-rater2"``]), then each
+sublist is associated with one class but contains the annotations from
+different experts: at each training iteration, one of these annotations
+will be randomly chosen.
 
 contrasts
 ^^^^^^^^^

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -781,7 +781,7 @@ class BidsDataset(MRI2DSegmentationDataset):
                     print("Subject without derivative, skipping.")
                     continue
                 derivatives = subject.get_derivatives("labels")
-                target_filename, roi_filename = [[]] * len(target_suffix), None
+                target_filename, roi_filename = [[] for _ in range(len(target_suffix))], None
 
                 for deriv in derivatives:
                     for idx, suffix_list in enumerate(target_suffix):

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -848,11 +848,6 @@ class BidsDataset(MRI2DSegmentationDataset):
                                 if deriv.endswith(subject.record["modality"] + suffix + ".nii.gz"):
                                     target_filename[idx].append(deriv)
                         elif deriv.endswith(subject.record["modality"] + suffix_list + ".nii.gz"):
-                        #if isinstance(suffix_list, str):
-                        #    suffix_list = [suffix_list]
-                        #for suffix in suffix_list:
-                        #    if deriv.endswith(subject.record["modality"] + suffix + ".nii.gz"):
-                        #        target_filename[idx].append(deriv)
                             target_filename[idx] = deriv
 
                     if not (self.roi_params["suffix"] is None) and \

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -168,7 +168,10 @@ class SegmentationPair(object):
                 self.gt_filenames = [self.gt_filenames]
             for gt in self.gt_filenames:
                 if gt is not None:
-                    self.gt_handle.append(nib.load(gt))
+                    if isinstance(gt, str):
+                        self.gt_handle.append(nib.load(gt))
+                    else:  # type == list, when multiple annotations for same tissue
+                        self.gt_handle.append([nib.load(gt_rater) for gt_rater in gt])
                 else:
                     self.gt_handle.append(None)
 
@@ -787,7 +790,7 @@ class BidsDataset(MRI2DSegmentationDataset):
                     for idx, suffix_list in enumerate(target_suffix):
                         # If suffix_list is a string, then only one rater annotation per class is available.
                         # Otherwise, multiple raters segmented the same class.
-                        if type(suffix_list) == str:
+                        if isinstance(suffix_list, str):
                             suffix_list = [suffix_list]
                         for suffix in suffix_list:
                             if deriv.endswith(subject.record["modality"] + suffix + ".nii.gz"):

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -188,7 +188,7 @@ class SegmentationPair(object):
         if self.gt_filenames is not None:
             for idx, gt in enumerate(self.gt_handle):
                 if gt is not None:
-                    self.gt_handle[idx] = nib.as_closest_canonical(gt)
+                    self.gt_handle[idx] = [nib.as_closest_canonical(gt_rater) for gt_rater in gt]
 
         # If binary classification, then extract labels from GT mask
 

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -355,13 +355,6 @@ class SegmentationPair(object):
                     gt_slices.append(np.asarray(gt_obj[..., slice_index],
                                                 dtype=np.float32))
                 else:
-                    # TODO: rm when Anne replies
-                    # Assert that there is only one non_zero_label in the current slice
-                    # labels_in_slice = np.unique(gt_obj[..., slice_index][np.nonzero(gt_obj[..., slice_index])]).tolist()
-                    # if len(labels_in_slice) > 1:
-                    #    print(metadata["gt_metadata"][0]["gt_filenames"])
-                    # TODO: uncomment when Anne replies
-                    # assert int(np.max(labels_in_slice)) <= 1
                     gt_slices.append(np.asarray(int(np.any(gt_obj[..., slice_index]))))
         dreturn = {
             "input": input_slices,

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -481,7 +481,7 @@ class MRI2DSegmentationDataset(Dataset):
         seg_pair_slice, roi_pair_slice = self.indexes[index]
 
         # In case multiple raters
-        if isinstance(seg_pair_slice['gt'][0], list):
+        if seg_pair_slice['gt'] is not None and isinstance(seg_pair_slice['gt'][0], list):
             # Randomly pick a rater
             idx_rater = random.randint(0, len(seg_pair_slice['gt'][0]) - 1)
             # Use it as ground truth for this iteration
@@ -646,7 +646,7 @@ class MRI3DSubVolumeSegmentationDataset(Dataset):
         seg_pair, _ = self.handlers[coord['handler_index']]
 
         # In case multiple raters
-        if isinstance(seg_pair['gt'][0], list):
+        if seg_pair['gt'] is not None and isinstance(seg_pair['gt'][0], list):
             # Randomly pick a rater
             idx_rater = random.randint(0, len(seg_pair['gt'][0]) - 1)
             # Use it as ground truth for this iteration

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -1,5 +1,5 @@
 import copy
-
+import random
 import nibabel as nib
 import numpy as np
 import torch
@@ -477,13 +477,14 @@ class MRI2DSegmentationDataset(Dataset):
         seg_pair_slice, roi_pair_slice = self.indexes[index]
 
         # In case multiple raters
-        if isintance(seg_pair_slice['gt'][0], list):
+        if isinstance(seg_pair_slice['gt'][0], list):
             # Randomly pick a rater
-            idx_rater = random.randint(0, len(seg_pair_slice['gt'][0]))
+            idx_rater = random.randint(0, len(seg_pair_slice['gt'][0])-1)
             # Use it as ground truth for this iteration
             # Note: in case of multi-class: the same rater is used across classes
             for idx_class in range(len(seg_pair_slice['gt'])):
                 seg_pair_slice['gt'][idx_class] = seg_pair_slice['gt'][idx_class][idx_rater]
+                seg_pair_slice['gt_metadata'][idx_class] = seg_pair_slice['gt_metadata'][idx_class][idx_rater]
 
         # Clean transforms params from previous transforms
         # i.e. remove params from previous iterations so that the coming transforms are different

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -213,8 +213,9 @@ class SegmentationPair(object):
 
         for gt in self.gt_handle:
             if gt is not None:
-                shape = imed_loader_utils.orient_shapes_hwd(gt.header.get_data_shape(), self.slice_axis)
-                gt_shape.append(tuple(shape))
+                for gt_rater in gt:
+                    shape = imed_loader_utils.orient_shapes_hwd(gt_rater.header.get_data_shape(), self.slice_axis)
+                    gt_shape.append(tuple(shape))
 
                 if not len(set(gt_shape)):
                     raise RuntimeError('Labels have different dimensions.')

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -640,6 +640,16 @@ class MRI3DSubVolumeSegmentationDataset(Dataset):
         coord = self.indexes[index]
         seg_pair, _ = self.handlers[coord['handler_index']]
 
+        # In case multiple raters
+        if isinstance(seg_pair['gt'][0], list):
+            # Randomly pick a rater
+            idx_rater = random.randint(0, len(seg_pair['gt'][0])-1)
+            # Use it as ground truth for this iteration
+            # Note: in case of multi-class: the same rater is used across classes
+            for idx_class in range(len(seg_pair['gt'])):
+                seg_pair['gt'][idx_class] = seg_pair['gt'][idx_class][idx_rater]
+                seg_pair['gt_metadata'][idx_class] = seg_pair['gt_metadata'][idx_class][idx_rater]
+
         # Clean transforms params from previous transforms
         # i.e. remove params from previous iterations so that the coming transforms are different
         # Use copy to have different coordinates for reconstruction for a given handler

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -168,10 +168,9 @@ class SegmentationPair(object):
                 self.gt_filenames = [self.gt_filenames]
             for gt in self.gt_filenames:
                 if gt is not None:
-                    if isinstance(gt, str):
-                        self.gt_handle.append(nib.load(gt))
-                    else:  # type == list, when multiple annotations for same tissue
-                        self.gt_handle.append([nib.load(gt_rater) for gt_rater in gt])
+                    if not isinstance(gt, list):  # this tissue has annotation from only one rater
+                        gt = [gt]
+                    self.gt_handle.append([nib.load(gt_rater) for gt_rater in gt])
                 else:
                     self.gt_handle.append(None)
 

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -290,7 +290,7 @@ class SegmentationPair(object):
                         "bounding_box": self.metadata[0]["bounding_box"] if 'bounding_box' in self.metadata[0] else None,
                         "data_type": 'gt',
                         "crop_params": {}
-                    }) for idx, gt_rater in gt])
+                    }) for idx, gt_rater in enumerate(gt)])
 
             else:
                 # Temporarily append null metadata to null gt

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -781,12 +781,17 @@ class BidsDataset(MRI2DSegmentationDataset):
                     print("Subject without derivative, skipping.")
                     continue
                 derivatives = subject.get_derivatives("labels")
-                target_filename, roi_filename = [None] * len(target_suffix), None
+                target_filename, roi_filename = [[]] * len(target_suffix), None
 
                 for deriv in derivatives:
-                    for idx, suffix in enumerate(target_suffix):
-                        if deriv.endswith(subject.record["modality"] + suffix + ".nii.gz"):
-                            target_filename[idx] = deriv
+                    for idx, suffix_list in enumerate(target_suffix):
+                        # If suffix_list is a string, then only one rater annotation per class is available.
+                        # Otherwise, multiple raters segmented the same class.
+                        if type(suffix_list) == str:
+                            suffix_list = [suffix_list]
+                        for suffix in suffix_list:
+                            if deriv.endswith(subject.record["modality"] + suffix + ".nii.gz"):
+                                target_filename[idx].append(deriv)
 
                     if not (self.roi_params["suffix"] is None) and \
                             deriv.endswith(subject.record["modality"] + self.roi_params["suffix"] + ".nii.gz"):

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -78,15 +78,15 @@ def load_dataset(data_list, bids_path, transforms_params, model_params, target_s
                                               slice_axis=imed_utils.AXIS_DCT[slice_axis],
                                               transform=tranform_lst,
                                               metadata_choice=metadata_type,
-                                              slice_filter_fn=imed_loader_utils.SliceFilter(**slice_filter_params, device=device,
-                                              cuda_available=cuda_available),
+                                              slice_filter_fn=imed_loader_utils.SliceFilter(**slice_filter_params,
+                                                                                            device=device,
+                                                                                            cuda_available=cuda_available),
                                               roi_params=roi_params,
                                               object_detection_params=object_detection_params,
                                               soft_gt=soft_gt)
     else:
         # Task selection
         task = imed_utils.get_task(model_params["name"])
-
 
         dataset = BidsDataset(bids_path,
                               subject_lst=data_list,
@@ -98,7 +98,7 @@ def load_dataset(data_list, bids_path, transforms_params, model_params, target_s
                               transform=tranform_lst,
                               multichannel=multichannel,
                               slice_filter_fn=imed_loader_utils.SliceFilter(**slice_filter_params, device=device,
-                              cuda_available=cuda_available),
+                                                                            cuda_available=cuda_available),
                               soft_gt=soft_gt,
                               object_detection_params=object_detection_params,
                               task=task)
@@ -247,11 +247,12 @@ class SegmentationPair(object):
                 data_type = np.float32 if self.soft_gt else np.uint8
                 if not isinstance(gt, list):  # this tissue has annotation from only one rater
                     hwd_oriented = imed_loader_utils.orient_img_hwd(gt.get_fdata(cache_mode, dtype=np.float32),
-                                                                   self.slice_axis)
+                                                                    self.slice_axis)
                     gt_data.append(hwd_oriented.astype(data_type))
                 else:  # this tissue has annotation from several raters
-                    hwd_oriented_list = [imed_loader_utils.orient_img_hwd(gt_rater.get_fdata(cache_mode, dtype=np.float32),
-                                                                   self.slice_axis) for gt_rater in gt]
+                    hwd_oriented_list = [
+                        imed_loader_utils.orient_img_hwd(gt_rater.get_fdata(cache_mode, dtype=np.float32),
+                                                         self.slice_axis) for gt_rater in gt]
                     gt_data.append([hwd_oriented.astype(data_type) for hwd_oriented in hwd_oriented_list])
             else:
                 gt_data.append(
@@ -278,16 +279,19 @@ class SegmentationPair(object):
                         "zooms": imed_loader_utils.orient_shapes_hwd(gt.header.get_zooms(), self.slice_axis),
                         "data_shape": imed_loader_utils.orient_shapes_hwd(gt.header.get_data_shape(), self.slice_axis),
                         "gt_filenames": self.metadata[0]["gt_filenames"],
-                        "bounding_box": self.metadata[0]["bounding_box"] if 'bounding_box' in self.metadata[0] else None,
+                        "bounding_box": self.metadata[0]["bounding_box"] if 'bounding_box' in self.metadata[
+                            0] else None,
                         "data_type": 'gt',
                         "crop_params": {}
                     }))
                 else:
                     gt_meta_dict.append([imed_loader_utils.SampleMetadata({
                         "zooms": imed_loader_utils.orient_shapes_hwd(gt_rater.header.get_zooms(), self.slice_axis),
-                        "data_shape": imed_loader_utils.orient_shapes_hwd(gt_rater.header.get_data_shape(), self.slice_axis),
+                        "data_shape": imed_loader_utils.orient_shapes_hwd(gt_rater.header.get_data_shape(),
+                                                                          self.slice_axis),
                         "gt_filenames": self.metadata[0]["gt_filenames"][idx_class][idx_rater],
-                        "bounding_box": self.metadata[0]["bounding_box"] if 'bounding_box' in self.metadata[0] else None,
+                        "bounding_box": self.metadata[0]["bounding_box"] if 'bounding_box' in self.metadata[
+                            0] else None,
                         "data_type": 'gt',
                         "crop_params": {}
                     }) for idx_rater, gt_rater in enumerate(gt)])
@@ -357,13 +361,13 @@ class SegmentationPair(object):
                                                     dtype=np.float32))
                     else:  # annotations from several raters
                         gt_slices.append([np.asarray(gt_obj_rater[..., slice_index],
-                                                    dtype=np.float32) for gt_obj_rater in gt_obj])
+                                                     dtype=np.float32) for gt_obj_rater in gt_obj])
                 else:
                     if not isinstance(gt_obj, list):  # annotation from only one rater
                         gt_slices.append(np.asarray(int(np.any(gt_obj[..., slice_index]))))
                     else:  # annotations from several raters
                         gt_slices.append([np.asarray(int(np.any(gt_obj_rater[..., slice_index])))
-                                            for gt_obj_rater in gt_obj])
+                                          for gt_obj_rater in gt_obj])
         dreturn = {
             "input": input_slices,
             "gt": gt_slices,
@@ -479,7 +483,7 @@ class MRI2DSegmentationDataset(Dataset):
         # In case multiple raters
         if isinstance(seg_pair_slice['gt'][0], list):
             # Randomly pick a rater
-            idx_rater = random.randint(0, len(seg_pair_slice['gt'][0])-1)
+            idx_rater = random.randint(0, len(seg_pair_slice['gt'][0]) - 1)
             # Use it as ground truth for this iteration
             # Note: in case of multi-class: the same rater is used across classes
             for idx_class in range(len(seg_pair_slice['gt'])):
@@ -557,7 +561,8 @@ class MRI3DSubVolumeSegmentationDataset(Dataset):
             space.
     """
 
-    def __init__(self, filename_pairs, transform=None, length=(64, 64, 64), stride=(0, 0, 0),  slice_axis=0, task="segmentation",
+    def __init__(self, filename_pairs, transform=None, length=(64, 64, 64), stride=(0, 0, 0), slice_axis=0,
+                 task="segmentation",
                  soft_gt=False):
         self.filename_pairs = filename_pairs
         self.handlers = []
@@ -643,7 +648,7 @@ class MRI3DSubVolumeSegmentationDataset(Dataset):
         # In case multiple raters
         if isinstance(seg_pair['gt'][0], list):
             # Randomly pick a rater
-            idx_rater = random.randint(0, len(seg_pair['gt'][0])-1)
+            idx_rater = random.randint(0, len(seg_pair['gt'][0]) - 1)
             # Use it as ground truth for this iteration
             # Note: in case of multi-class: the same rater is used across classes
             for idx_class in range(len(seg_pair['gt'])):
@@ -722,6 +727,7 @@ class Bids3DDataset(MRI3DSubVolumeSegmentationDataset):
             contrast is processed individually (ie different sample / tensor).
         object_detection_params (dict): Object dection parameters.
     """
+
     def __init__(self, root_dir, subject_lst, target_suffix, model_params, contrast_params, slice_axis=2,
                  cache=True, transform=None, metadata_choice=False, roi_params=None,
                  multichannel=False, object_detection_params=None, task="segmentation", soft_gt=False):
@@ -771,6 +777,7 @@ class BidsDataset(MRI2DSegmentationDataset):
         metadata (dict): Dictionary containing FiLM metadata.
 
     """
+
     def __init__(self, root_dir, subject_lst, target_suffix, contrast_params, slice_axis=2,
                  cache=True, transform=None, metadata_choice=False, slice_filter_fn=None, roi_params=None,
                  multichannel=False, object_detection_params=None, task="segmentation", soft_gt=False):

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -352,10 +352,18 @@ class SegmentationPair(object):
             gt_slices = []
             for gt_obj in gt_dataobj:
                 if gt_type == "segmentation":
-                    gt_slices.append(np.asarray(gt_obj[..., slice_index],
-                                                dtype=np.float32))
+                    if not isinstance(gt_obj, list):  # annotation from only one rater
+                        gt_slices.append(np.asarray(gt_obj[..., slice_index],
+                                                    dtype=np.float32))
+                    else:  # annotations from several raters
+                        gt_slices.append([np.asarray(gt_obj_rater[..., slice_index],
+                                                    dtype=np.float32) for gt_obj_rater in gt_obj])
                 else:
-                    gt_slices.append(np.asarray(int(np.any(gt_obj[..., slice_index]))))
+                    if not isinstance(gt_obj, list):  # annotation from only one rater
+                        gt_slices.append(np.asarray(int(np.any(gt_obj[..., slice_index]))))
+                    else:  # annotations from several raters
+                        gt_slices.append([np.asarray(int(np.any(gt_obj_rater[..., slice_index])))
+                                            for gt_obj_rater in gt_obj])
         dreturn = {
             "input": input_slices,
             "gt": gt_slices,

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -271,7 +271,7 @@ class SegmentationPair(object):
             dict: Input and gt metadata.
         """
         gt_meta_dict = []
-        for gt in self.gt_handle:
+        for idx_tissue, gt in enumerate(self.gt_handle):
             if gt is not None:
                 if not isinstance(gt, list):  # this tissue has annotation from only one rater
                     gt_meta_dict.append(imed_loader_utils.SampleMetadata({
@@ -286,11 +286,11 @@ class SegmentationPair(object):
                     gt_meta_dict.append([imed_loader_utils.SampleMetadata({
                         "zooms": imed_loader_utils.orient_shapes_hwd(gt_rater.header.get_zooms(), self.slice_axis),
                         "data_shape": imed_loader_utils.orient_shapes_hwd(gt_rater.header.get_data_shape(), self.slice_axis),
-                        "gt_filenames": self.metadata[0]["gt_filenames"][idx],
+                        "gt_filenames": self.metadata[0]["gt_filenames"][idx_tissue][idx_rater],
                         "bounding_box": self.metadata[0]["bounding_box"] if 'bounding_box' in self.metadata[0] else None,
                         "data_type": 'gt',
                         "crop_params": {}
-                    }) for idx, gt_rater in enumerate(gt)])
+                    }) for idx_rater, gt_rater in enumerate(gt)])
 
             else:
                 # Temporarily append null metadata to null gt

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -834,17 +834,19 @@ class BidsDataset(MRI2DSegmentationDataset):
                     print("Subject without derivative, skipping.")
                     continue
                 derivatives = subject.get_derivatives("labels")
-                target_filename, roi_filename = [[] for _ in range(len(target_suffix))], None
+                target_filename, roi_filename = [None] * len(target_suffix), None
 
                 for deriv in derivatives:
                     for idx, suffix_list in enumerate(target_suffix):
                         # If suffix_list is a string, then only one rater annotation per class is available.
                         # Otherwise, multiple raters segmented the same class.
-                        if isinstance(suffix_list, str):
-                            suffix_list = [suffix_list]
-                        for suffix in suffix_list:
-                            if deriv.endswith(subject.record["modality"] + suffix + ".nii.gz"):
-                                target_filename[idx].append(deriv)
+                        if isinstance(suffix_list, list):
+                            target_filename[idx] = []
+                            for suffix in suffix_list:
+                                if deriv.endswith(subject.record["modality"] + suffix + ".nii.gz"):
+                                    target_filename[idx].append(deriv)
+                        elif deriv.endswith(subject.record["modality"] + suffix_list + ".nii.gz"):
+                            target_filename[idx] = deriv
 
                     if not (self.roi_params["suffix"] is None) and \
                             deriv.endswith(subject.record["modality"] + self.roi_params["suffix"] + ".nii.gz"):

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -834,18 +834,25 @@ class BidsDataset(MRI2DSegmentationDataset):
                     print("Subject without derivative, skipping.")
                     continue
                 derivatives = subject.get_derivatives("labels")
-                target_filename, roi_filename = [None] * len(target_suffix), None
+                if isinstance(target_suffix[0], str):
+                    target_filename, roi_filename = [None] * len(target_suffix), None
+                else:
+                    target_filename, roi_filename = [[] for _ in range(len(target_suffix))], None
 
                 for deriv in derivatives:
                     for idx, suffix_list in enumerate(target_suffix):
                         # If suffix_list is a string, then only one rater annotation per class is available.
                         # Otherwise, multiple raters segmented the same class.
                         if isinstance(suffix_list, list):
-                            target_filename[idx] = []
                             for suffix in suffix_list:
                                 if deriv.endswith(subject.record["modality"] + suffix + ".nii.gz"):
                                     target_filename[idx].append(deriv)
                         elif deriv.endswith(subject.record["modality"] + suffix_list + ".nii.gz"):
+                        #if isinstance(suffix_list, str):
+                        #    suffix_list = [suffix_list]
+                        #for suffix in suffix_list:
+                        #    if deriv.endswith(subject.record["modality"] + suffix + ".nii.gz"):
+                        #        target_filename[idx].append(deriv)
                             target_filename[idx] = deriv
 
                     if not (self.roi_params["suffix"] is None) and \

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -162,7 +162,7 @@ class SegmentationPair(object):
         # list of GT for multiclass segmentation
         self.gt_handle = []
 
-        # Unlabeled data (inference time)
+        # Labeled data (ie not inference time)
         if self.gt_filenames is not None:
             if not isinstance(self.gt_filenames, list):
                 self.gt_filenames = [self.gt_filenames]
@@ -182,7 +182,7 @@ class SegmentationPair(object):
         for idx, handle in enumerate(self.input_handle):
             self.input_handle[idx] = nib.as_closest_canonical(handle)
 
-        # Unlabeled data
+        # Labeled data (ie not inference time)
         if self.gt_filenames is not None:
             for idx, gt in enumerate(self.gt_handle):
                 if gt is not None:

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -445,7 +445,11 @@ def update_metadata(metadata_src_lst, metadata_dest_lst):
         list: updated metadata list.
     """
     if metadata_src_lst and metadata_dest_lst:
-        metadata_dest_lst[0]._update(metadata_src_lst[0], TRANSFORM_PARAMS)
+        if not isinstance(metadata_dest_lst[0], list):
+            metadata_dest_lst[0]._update(metadata_src_lst[0], TRANSFORM_PARAMS)
+        else:
+            for idx, _ in enumerate(metadata_dest_lst[0]):
+                metadata_dest_lst[0][idx]._update(metadata_src_lst[0][idx], TRANSFORM_PARAMS)
     return metadata_dest_lst
 
 

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -445,11 +445,11 @@ def update_metadata(metadata_src_lst, metadata_dest_lst):
         list: updated metadata list.
     """
     if metadata_src_lst and metadata_dest_lst:
-        if not isinstance(metadata_dest_lst[0], list):
+        if not isinstance(metadata_dest_lst[0], list):  # annotation from one rater only
             metadata_dest_lst[0]._update(metadata_src_lst[0], TRANSFORM_PARAMS)
-        else:
+        else:  # annotations from several raters
             for idx, _ in enumerate(metadata_dest_lst[0]):
-                metadata_dest_lst[0][idx]._update(metadata_src_lst[0][idx], TRANSFORM_PARAMS)
+                metadata_dest_lst[0][idx]._update(metadata_src_lst[0], TRANSFORM_PARAMS)
     return metadata_dest_lst
 
 

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -310,6 +310,7 @@ class SampleMetadata(object):
     Attributes:
         metadata (dict): Image metadata.
     """
+
     def __init__(self, d=None):
         self.metadata = {} or d
 
@@ -496,8 +497,9 @@ class SliceFilter(object):
 
         if self.filter_classification:
             if not np.all([int(
-                    self.classifier(imed_utils.cuda(torch.from_numpy(img.copy()).unsqueeze(0).unsqueeze(0), self.cuda_available)))
-                           for img in input_data]):
+                    self.classifier(
+                        imed_utils.cuda(torch.from_numpy(img.copy()).unsqueeze(0).unsqueeze(0), self.cuda_available)))
+                for img in input_data]):
                 return False
 
         return True

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -177,9 +177,10 @@ def run_command(context, n_gif=0, thr_increment=None, resume_training=False):
         imed_utils.display_selected_transfoms(transformation_dict, dataset_type=["testing"])
 
     # Check if multiple raters
-    if any([class_suffix for class_suffix in loader_params["target_suffix"]]):
+    if any([isinstance(class_suffix, list) for class_suffix in loader_params["target_suffix"]]):
         print(
-            "\nAnnotations from multiple raters will be used during model training, one annotation from one rater randomly selected at each iteration.\n")
+            "\nAnnotations from multiple raters will be used during model training, one annotation from one rater "
+            "randomly selected at each iteration.\n")
         if command != "train":
             print(
                 "\nERROR: Please provide only one annotation per class in 'target_suffix' when not training a model.\n")

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -176,6 +176,13 @@ def run_command(context, n_gif=0, thr_increment=None, resume_training=False):
     elif command == "test":
         imed_utils.display_selected_transfoms(transformation_dict, dataset_type=["testing"])
 
+    # Check if multiple raters
+    if any([class_suffix for class_suffix in loader_params["target_suffix"]]):
+        print("\nAnnotations from multiple raters will be used during model training, one annotation from one rater randomly selected at each iteration.\n")
+        if command != "train":
+            print("\nERROR: Please provide only one annotation per class in 'target_suffix' when not training a model.\n")
+            exit()
+
     if command == 'train':
         # LOAD DATASET
         # Get Validation dataset

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -178,9 +178,11 @@ def run_command(context, n_gif=0, thr_increment=None, resume_training=False):
 
     # Check if multiple raters
     if any([class_suffix for class_suffix in loader_params["target_suffix"]]):
-        print("\nAnnotations from multiple raters will be used during model training, one annotation from one rater randomly selected at each iteration.\n")
+        print(
+            "\nAnnotations from multiple raters will be used during model training, one annotation from one rater randomly selected at each iteration.\n")
         if command != "train":
-            print("\nERROR: Please provide only one annotation per class in 'target_suffix' when not training a model.\n")
+            print(
+                "\nERROR: Please provide only one annotation per class in 'target_suffix' when not training a model.\n")
             exit()
 
     if command == 'train':
@@ -245,7 +247,8 @@ def run_command(context, n_gif=0, thr_increment=None, resume_training=False):
         if command != 'train':  # If command == train, then ds_valid already load
             # Get Validation dataset
             ds_valid = imed_loader.load_dataset(**{**loader_params,
-                                                   **{'data_list': valid_lst, 'transforms_params': transform_valid_params,
+                                                   **{'data_list': valid_lst,
+                                                      'transforms_params': transform_valid_params,
                                                       'dataset_type': 'validation'}}, device=device,
                                                 cuda_available=cuda_available)
         # Get Training dataset with no Data Augmentation
@@ -287,7 +290,7 @@ def run_command(context, n_gif=0, thr_increment=None, resume_training=False):
                                                                   'transforms_params': transformation_dict,
                                                                   'dataset_type': 'testing',
                                                                   'requires_undo': True}}, device=device,
-                                                                  cuda_available=cuda_available)
+                                           cuda_available=cuda_available)
 
         metric_fns = imed_metrics.get_metric_fns(ds_test.task)
 

--- a/ivadomed/transforms.py
+++ b/ivadomed/transforms.py
@@ -32,7 +32,10 @@ def multichannel_capable(wrapped):
             list_data, list_metadata = [], []
             for s_cur, m_cur in zip(sample, metadata):
                 if len(list_metadata) > 0:
-                    imed_loader_utils.update_metadata([list_metadata[-1]], [m_cur])
+                    if not isinstance(list_metadata[-1], list):
+                    	imed_loader_utils.update_metadata([list_metadata[-1]], [m_cur])
+                    else:
+                        imed_loader_utils.update_metadata(list_metadata[-1], [m_cur])
                 # Run function for each sample of the list
                 data_cur, metadata_cur = wrapped(self, s_cur, m_cur)
                 list_data.append(data_cur)
@@ -242,6 +245,7 @@ class Resample(ImedTransform):
         return data_out, metadata
 
     @multichannel_capable
+    @multichannel_capable  # for multiple raters during training/preprocessing
     @two_dim_compatible
     def __call__(self, sample, metadata=None):
         """Resample to a given resolution, in millimeters."""
@@ -388,6 +392,7 @@ class Crop(ImedTransform):
         return npad_out_tuple, sample
 
     @multichannel_capable
+    @multichannel_capable  # for multiple raters during training/preprocessing
     def __call__(self, sample, metadata):
         # Get params
         is_2d = sample.shape[-1] == 1
@@ -437,6 +442,7 @@ class CenterCrop(Crop):
     """Make a centered crop of a specified size."""
 
     @multichannel_capable
+    @multichannel_capable  # for multiple raters during training/preprocessing
     @two_dim_compatible
     def __call__(self, sample, metadata=None):
         # Crop parameters
@@ -456,6 +462,7 @@ class ROICrop(Crop):
     """Make a crop of a specified size around a Region of Interest (ROI)."""
 
     @multichannel_capable
+    @multichannel_capable  # for multiple raters during training/preprocessing
     @two_dim_compatible
     def __call__(self, sample, metadata=None):
         # If crop_params are not in metadata,

--- a/ivadomed/transforms.py
+++ b/ivadomed/transforms.py
@@ -26,6 +26,7 @@ def multichannel_capable(wrapped):
     Returns:
         Functions' return.
     """
+
     @functools.wraps(wrapped)
     def wrapper(self, sample, metadata):
         if isinstance(sample, list):
@@ -33,7 +34,7 @@ def multichannel_capable(wrapped):
             for s_cur, m_cur in zip(sample, metadata):
                 if len(list_metadata) > 0:
                     if not isinstance(list_metadata[-1], list):
-                    	imed_loader_utils.update_metadata([list_metadata[-1]], [m_cur])
+                        imed_loader_utils.update_metadata([list_metadata[-1]], [m_cur])
                     else:
                         imed_loader_utils.update_metadata(list_metadata[-1], [m_cur])
                 # Run function for each sample of the list
@@ -59,6 +60,7 @@ def two_dim_compatible(wrapped):
     Returns:
         Functions' return.
     """
+
     @functools.wraps(wrapped)
     def wrapper(self, sample, metadata):
         # Check if sample is 2D
@@ -119,7 +121,7 @@ class Compose(object):
                 transform_obj = globals()[transform](**params_cur)
             else:
                 raise ValueError('ERROR: {} transform is not available. '
-                      'Please check its compatibility with your model json file.'.format(transform))
+                                 'Please check its compatibility with your model json file.'.format(transform))
 
             # check if undo_transform method is implemented
             if requires_undo:
@@ -160,6 +162,7 @@ class UndoCompose(object):
     Args:
         transforms (torchvision_transforms.Compose):
     """
+
     def __init__(self, compose):
         self.transforms = compose
 
@@ -182,6 +185,7 @@ class UndoTransform(object):
     Args:
         transform (ImedTransform):
     """
+
     def __init__(self, transform):
         self.transform = transform
 
@@ -363,6 +367,7 @@ class Crop(ImedTransform):
     Attributes:
         size (tuple of int): Size of the output sample. Tuple of size 3.
     """
+
     def __init__(self, size):
         self.size = size if len(size) == 3 else size + [0]
 
@@ -647,6 +652,7 @@ class RandomAffine(ImedTransform):
         translate (list of float):
         scale (list of float):
     """
+
     def __init__(self, degrees=0, translate=None, scale=None):
         # Rotation
         if isinstance(degrees, numbers.Number):
@@ -814,6 +820,7 @@ class RandomShiftIntensity(ImedTransform):
             randomly selected from.
         prob (float): Between 0 and 1. Probability of occurence of this transformation.
     """
+
     def __init__(self, shift_range, prob=0.1):
         self.shift_range = shift_range
         self.prob = prob
@@ -954,6 +961,7 @@ class Clahe(ImedTransform):
         kernel_size (tuple of int): Defines the shape of contextual regions used in the algorithm. Length equals image
         dimension (ie 2 or 3 for 2D or 3D, respectively).
     """
+
     def __init__(self, clip_limit=3.0, kernel_size=(8, 8)):
         self.clip_limit = clip_limit
         self.kernel_size = kernel_size
@@ -976,6 +984,7 @@ class HistogramClipping(ImedTransform):
         min_percentile (float): Between 0 and 100. Lower clipping limit.
         max_percentile (float): Between 0 and 100. Higher clipping limit.
     """
+
     def __init__(self, min_percentile=5.0, max_percentile=95.0):
         self.min_percentile = min_percentile
         self.max_percentile = max_percentile


### PR DESCRIPTION
This PR implements a way to randomly sample experts' annotation to be used as GT during the training. Has application with datasets where annotations from several experts are available.

## Rationale

This new feature supports different on-going projects playing with datasets with annotations from multiple experts (e.g., look at inter-rater variability effect on DL model training, alternatives to label fusion techniques).

Our hypothesis is that this sampling method could lead to a better model generalisation to expert variability, than label fusion techniques (e.g., STAPLE) which are commonly used.

## Behaviour

In simple words, let's say we have 3 experts that segmented the same tissue, i.e., for each slice, we have 3 different annotations of the same tissue. At each epoch, the model will be trained on one of the 3 available annotations of the same slice, randomly picked.

## Specific needs

- Compatible with single- or multi-class tasks.

## Implementation

- in the config file: if a list is provided for `target_suffix` instead of a string, then this sampling method is triggered among the provided annotations:
```json
        "target_suffix": [["_gmseg-manual-ucl", "_gmseg-manual-unf", "_gmseg-manual-vanderbilt", "_gmseg-manual-zurich"],
                            ["_wmseg-manual-ucl", "_wmseg-manual-unf", "_wmseg-manual-vanderbilt", "_wmseg-manual-zurich"]],
```
instead of:
```json
        "target_suffix": ["_gmseg-manual-ucl", "_wmseg-manual-ucl"],
```

- XX

