### PR TITLE
Implementation of max pooling

### DIFF
--- a/docs/source/configuration_file.rst
+++ b/docs/source/configuration_file.rst
@@ -442,6 +442,11 @@ predictions above or equal to threshold become 1.
 - ``thr``: Float. Threshold is between 0 and 1. To use soft predictions
   (i.e. no binarisation, float between 0 and 1) for metric computation, indicate -1.
 
+binarize\_maxpooling
+^^^^^^^^^^^^^^^^^^^^
+Dict. Binarize by setting to 1 the voxel having the maximum prediction across all classes. Useful for multiclass models.
+No parameters required (i.e., {}).
+
 fill\_holes
 ^^^^^^^^^^^
 Dict. Fill holes in the predictions. No parameters required (i.e., {}).

--- a/ivadomed/postprocessing.py
+++ b/ivadomed/postprocessing.py
@@ -280,6 +280,24 @@ class Postprocessing(object):
         if thr >= 0:
             self.data_pred = threshold_predictions(self.data_pred, thr)
 
+    def binarize_maxpooling(self):
+        """Binarize by setting to 1 the voxel having the max prediction across all classes.
+        """
+        # Generate background class
+        background = np.ones(self.data_pred[..., 0].shape)
+        n_class = self.data_pred.shape[-1]
+        for c in range(n_class):
+            background -= self.data_pred[..., c]
+
+        # Concatenate background class
+        pred_with_background = np.concatenate((background[..., None], self.data_pred), axis=-1)
+
+        # Find class with max pred
+        class_pred = np.argmax(pred_with_background, axis=-1)
+        self.data_pred = np.zeros_like(self.data_pred)
+        for c in range(n_class):
+            self.data_pred[..., c] = class_pred == c + 1
+
     def uncertainty(self, thr, suffix):
         """Removes the most uncertain predictions.
 


### PR DESCRIPTION
Binarization adapted to multiclass models. Takes the maximum prediction across classes to binarize. This was the sum of all classes (including the background) is always 1.

Apply it this way in the config file:
"postprocessing": {"binarize_maxpooling": {}}