### PR TITLE
Removing support for Python 3.9 (for now)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The technical documentation is available [here](https://ivadomed.org).
 
 ## Installation
 
-``ivadomed`` requires Python >= 3.6 and PyTorch >= 1.5.0. We recommend working under a virtual environment, which could be set as follows:
+``ivadomed`` requires Python >= 3.6 and Python < 3.9 as well as PyTorch == 1.5.0. We recommend working under a virtual environment, which could be set as follows:
 
 ```bash
 virtualenv venv-ivadomed --python=python3.6

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The technical documentation is available [here](https://ivadomed.org).
 
 ## Installation
 
-``ivadomed`` requires Python >= 3.6 and Python < 3.9 as well as PyTorch == 1.5.0. We recommend working under a virtual environment, which could be set as follows:
+``ivadomed`` requires Python >= 3.6 and < 3.9 as well as PyTorch == 1.5.0. We recommend working under a virtual environment, which could be set as follows:
 
 ```bash
 virtualenv venv-ivadomed --python=python3.6

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-``ivadomed`` requires Python >= 3.6 and PyTorch >= 1.5.0. We recommend
+``ivadomed`` requires Python >= 3.6 and <3.9  as well as PyTorch == 1.5.0. We recommend
 working under a virtual environment, which could be set as follows:
 
 ::


### PR DESCRIPTION
fix #556 

This PR also specify the version of pytorch since 1.7.0 is not compatible yet. 
