### PR TITLE
Remove python version in virtualenv command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The technical documentation is available [here](https://ivadomed.org).
 ``ivadomed`` requires Python >= 3.6 and < 3.9 as well as PyTorch == 1.5.0. We recommend working under a virtual environment, which could be set as follows:
 
 ```bash
-virtualenv venv-ivadomed --python=python3.6
+virtualenv venv-ivadomed
 source venv-ivadomed/bin/activate
 ```
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -6,7 +6,7 @@ working under a virtual environment, which could be set as follows:
 
 ::
 
-    virtualenv venv-ivadomed --python=python3.6
+    virtualenv venv-ivadomed
     source venv-ivadomed/bin/activate
 
 Install from release (recommended)


### PR DESCRIPTION
## Description
This PR removes the python version in the `virtualenv` command because it causes an error if a different Python is installed. It is clear in both `README.md` and `installation.rst` that Python >= 3.6 and < 3.9 is required: the Python version in the virtual env command can then be omitted.

## Linked issues
Fixes #574 
