### PR TITLE
Fix loader/adaptative.py code with reading/writing HDF5 files

### DIFF
--- a/ivadomed/loader/adaptative.py
+++ b/ivadomed/loader/adaptative.py
@@ -17,11 +17,12 @@ from ivadomed.object_detection import utils as imed_obj_detect
 class Dataframe:
     """
     This class aims to create a dataset using an HDF5 file, which can be used by an adapative loader
-    to perform curriculum learning, Active Learning or any other strategy that needs to load samples in a specific way.
+    to perform curriculum learning, Active Learning or any other strategy that needs to load samples
+    in a specific way.
     It works on RAM or on the fly and can be saved for later.
 
     Args:
-        hdf5 (hdf5): hdf5 file containing dataset information
+        hdf5_file (hdf5): hdf5 file containing dataset information
         contrasts (list of str): List of the contrasts of interest.
         path (str): Dataframe path.
         target_suffix (list of str): List of suffix of targetted structures.
@@ -36,7 +37,7 @@ class Dataframe:
         df (pd.Dataframe): Dataframe containing dataset information
     """
 
-    def __init__(self, hdf5, contrasts, path, target_suffix=None, roi_suffix=None,
+    def __init__(self, hdf5_file, contrasts, path, target_suffix=None, roi_suffix=None,
                  filter_slices=False, dim=2):
         # Number of dimension
         self.dim = dim
@@ -62,7 +63,7 @@ class Dataframe:
         if os.path.exists(path):
             self.load_dataframe(path)
         else:
-            self.create_df(hdf5)
+            self.create_df(hdf5_file)
 
     def shuffle(self):
         """Shuffle the whole data frame."""
@@ -92,11 +93,11 @@ class Dataframe:
         except FileNotFoundError:
             print("Wrong path.")
 
-    def create_df(self, hdf5):
+    def create_df(self, hdf5_file):
         """Generate the Data frame using the hdf5 file.
 
         Args:
-            hdf5 (hdf5): File containing dataset information
+            hdf5_file (hdf5): File containing dataset information
         """
         # Template of a line
         empty_line = {col: 'None' for col in self.contrasts}
@@ -106,11 +107,11 @@ class Dataframe:
         col_names = [col for col in empty_line.keys()]
         col_names.append('Subjects')
         df = pd.DataFrame(columns=col_names)
-        print(hdf5.attrs['patients_id'])
+        print(hdf5_file.attrs['patients_id'])
         # Filling the data frame
-        for subject in hdf5.attrs['patients_id']:
+        for subject in hdf5_file.attrs['patients_id']:
             # Getting the Group the corresponding patient
-            grp = hdf5[subject]
+            grp = hdf5_file[subject]
             line = copy.deepcopy(empty_line)
             line['Subjects'] = subject
 
@@ -180,7 +181,7 @@ class Bids_to_hdf5:
         target_suffix (list): List of suffixes for target masks.
         roi_params (dict): Dictionary containing parameters related to ROI image processing.
         contrast_lst (list): List of the contrasts.
-        hdf5_name (str): Path and name of the hdf5 file.
+        hdf5_path (str): Path and name of the hdf5 file.
         contrast_balance (dict): Dictionary controlling image contrasts balance.
         slice_axis (int): Indicates the axis used to extract slices: "axial": 2, "sagittal": 0, "coronal": 1.
         metadata_choice (str): Choice between "mri_params", "contrasts", None or False, related to FiLM.
@@ -191,7 +192,7 @@ class Bids_to_hdf5:
     Attributes:
         bids_ds (BIDS): BIDS dataset.
         dt (dtype): hdf5 special dtype.
-        hdf5_file (hdf5): hdf5 file containing dataset information.
+        hdf5_path (str): path to hdf5 file containing dataset information.
         filename_pairs (list): A list of tuples in the format (input filename list containing all modalities,ground \
             truth filename, ROI filename, metadata).
         metadata (dict): Dictionary containing metadata of input and gt.
@@ -202,7 +203,7 @@ class Bids_to_hdf5:
         slice_filter_fn (SliceFilter): Object that filters slices according to their content.
     """
 
-    def __init__(self, root_dir, subject_lst, target_suffix, contrast_lst, hdf5_name, contrast_balance=None,
+    def __init__(self, root_dir, subject_lst, target_suffix, contrast_lst, hdf5_path, contrast_balance=None,
                  slice_axis=2, metadata_choice=False, slice_filter_fn=None, roi_params=None, transform=None,
                  object_detection_params=None, soft_gt=False):
         print("Starting conversion")
@@ -212,8 +213,8 @@ class Bids_to_hdf5:
         self.soft_gt = soft_gt
         self.dt = h5py.special_dtype(vlen=str)
         # opening an hdf5 file with write access and writing metadata
-        self.hdf5_file = h5py.File(hdf5_name, "w")
-
+        # self.hdf5_file = h5py.File(hdf5_name, "w")
+        self.hdf5_path = hdf5_path
         list_patients = []
 
         self.filename_pairs = []
@@ -296,11 +297,12 @@ class Bids_to_hdf5:
         self.slice_filter_fn = slice_filter_fn
 
         # Update HDF5 metadata
-        self.hdf5_file.attrs.create('patients_id', list(set(list_patients)), dtype=self.dt)
-        self.hdf5_file.attrs['slice_axis'] = slice_axis
+        with h5py.File(self.hdf5_path, "w") as hdf5_file:
+            hdf5_file.attrs.create('patients_id', list(set(list_patients)), dtype=self.dt)
+            hdf5_file.attrs['slice_axis'] = slice_axis
 
-        self.hdf5_file.attrs['slice_filter_fn'] = [('filter_empty_input', True), ('filter_empty_mask', False)]
-        self.hdf5_file.attrs['metadata_choice'] = metadata_choice
+            hdf5_file.attrs['slice_filter_fn'] = [('filter_empty_input', True), ('filter_empty_mask', False)]
+            hdf5_file.attrs['metadata_choice'] = metadata_choice
 
         # Save images into HDF5 file
         self._load_filenames()
@@ -308,156 +310,157 @@ class Bids_to_hdf5:
 
     def _load_filenames(self):
         """Load preprocessed pair data (input and gt) in handler."""
-        for subject_id, input_filename, gt_filename, roi_filename, metadata in self.filename_pairs:
-            # Creating/ getting the subject group
-            if str(subject_id) in self.hdf5_file.keys():
-                grp = self.hdf5_file[str(subject_id)]
-            else:
-                grp = self.hdf5_file.create_group(str(subject_id))
-
-            roi_pair = imed_loader.SegmentationPair(input_filename, roi_filename, metadata=metadata,
-                                                    slice_axis=self.slice_axis, cache=False, soft_gt=self.soft_gt)
-
-            seg_pair = imed_loader.SegmentationPair(input_filename, gt_filename, metadata=metadata,
-                                                    slice_axis=self.slice_axis, cache=False, soft_gt=self.soft_gt)
-            print("gt filename", gt_filename)
-            input_data_shape, _ = seg_pair.get_pair_shapes()
-
-            useful_slices = []
-            input_volumes = []
-            gt_volume = []
-            roi_volume = []
-
-            for idx_pair_slice in range(input_data_shape[-1]):
-
-                slice_seg_pair = seg_pair.get_pair_slice(idx_pair_slice)
-
-                self.has_bounding_box = imed_obj_detect.verify_metadata(slice_seg_pair, self.has_bounding_box)
-                if self.has_bounding_box:
-                    imed_obj_detect.adjust_transforms(self.prepro_transforms, slice_seg_pair)
-
-                # keeping idx of slices with gt
-                if self.slice_filter_fn:
-                    filter_fn_ret_seg = self.slice_filter_fn(slice_seg_pair)
-                if self.slice_filter_fn and filter_fn_ret_seg:
-                    useful_slices.append(idx_pair_slice)
-
-                roi_pair_slice = roi_pair.get_pair_slice(idx_pair_slice)
-                slice_seg_pair, roi_pair_slice = imed_transforms.apply_preprocessing_transforms(self.prepro_transforms,
-                                                                                                slice_seg_pair,
-                                                                                                roi_pair_slice)
-
-                input_volumes.append(slice_seg_pair["input"][0])
-
-                # Handle unlabeled data
-                if not len(slice_seg_pair["gt"]):
-                    gt_volume = []
+        with h5py.File(self.hdf5_path, "a") as hdf5_file:
+            for subject_id, input_filename, gt_filename, roi_filename, metadata in self.filename_pairs:
+                # Creating/ getting the subject group
+                if str(subject_id) in hdf5_file.keys():
+                    grp = hdf5_file[str(subject_id)]
                 else:
-                    gt_volume.append((slice_seg_pair["gt"][0] * 255).astype(np.uint8) / 255.)
+                    grp = hdf5_file.create_group(str(subject_id))
 
-                # Handle data with no ROI provided
-                if not len(roi_pair_slice["gt"]):
-                    roi_volume = []
+                roi_pair = imed_loader.SegmentationPair(input_filename, roi_filename, metadata=metadata,
+                                                        slice_axis=self.slice_axis, cache=False, soft_gt=self.soft_gt)
+
+                seg_pair = imed_loader.SegmentationPair(input_filename, gt_filename, metadata=metadata,
+                                                        slice_axis=self.slice_axis, cache=False, soft_gt=self.soft_gt)
+                print("gt filename", gt_filename)
+                input_data_shape, _ = seg_pair.get_pair_shapes()
+
+                useful_slices = []
+                input_volumes = []
+                gt_volume = []
+                roi_volume = []
+
+                for idx_pair_slice in range(input_data_shape[-1]):
+
+                    slice_seg_pair = seg_pair.get_pair_slice(idx_pair_slice)
+
+                    self.has_bounding_box = imed_obj_detect.verify_metadata(slice_seg_pair, self.has_bounding_box)
+                    if self.has_bounding_box:
+                        imed_obj_detect.adjust_transforms(self.prepro_transforms, slice_seg_pair)
+
+                    # keeping idx of slices with gt
+                    if self.slice_filter_fn:
+                        filter_fn_ret_seg = self.slice_filter_fn(slice_seg_pair)
+                    if self.slice_filter_fn and filter_fn_ret_seg:
+                        useful_slices.append(idx_pair_slice)
+
+                    roi_pair_slice = roi_pair.get_pair_slice(idx_pair_slice)
+                    slice_seg_pair, roi_pair_slice = imed_transforms.apply_preprocessing_transforms(self.prepro_transforms,
+                                                                                                    slice_seg_pair,
+                                                                                                    roi_pair_slice)
+
+                    input_volumes.append(slice_seg_pair["input"][0])
+
+                    # Handle unlabeled data
+                    if not len(slice_seg_pair["gt"]):
+                        gt_volume = []
+                    else:
+                        gt_volume.append((slice_seg_pair["gt"][0] * 255).astype(np.uint8) / 255.)
+
+                    # Handle data with no ROI provided
+                    if not len(roi_pair_slice["gt"]):
+                        roi_volume = []
+                    else:
+                        roi_volume.append((roi_pair_slice["gt"][0] * 255).astype(np.uint8) / 255.)
+
+                # Getting metadata using the one from the last slice
+                input_metadata = slice_seg_pair['input_metadata'][0]
+                gt_metadata = slice_seg_pair['gt_metadata'][0]
+                roi_metadata = roi_pair_slice['input_metadata'][0]
+
+                if grp.attrs.__contains__('slices'):
+                    grp.attrs['slices'] = list(set(np.concatenate((grp.attrs['slices'], useful_slices))))
                 else:
-                    roi_volume.append((roi_pair_slice["gt"][0] * 255).astype(np.uint8) / 255.)
+                    grp.attrs['slices'] = useful_slices
 
-            # Getting metadata using the one from the last slice
-            input_metadata = slice_seg_pair['input_metadata'][0]
-            gt_metadata = slice_seg_pair['gt_metadata'][0]
-            roi_metadata = roi_pair_slice['input_metadata'][0]
+                # Creating datasets and metadata
+                contrast = input_metadata['contrast']
+                # Inputs
+                print(len(input_volumes))
+                print("grp= ", str(subject_id))
+                key = "inputs/{}".format(contrast)
+                print("key = ", key)
+                if len(input_volumes) < 1:
+                    print("list empty")
+                    continue
+                grp.create_dataset(key, data=input_volumes)
+                # Sub-group metadata
+                if grp['inputs'].attrs.__contains__('contrast'):
+                    attr = grp['inputs'].attrs['contrast']
+                    new_attr = [c for c in attr]
+                    new_attr.append(contrast)
+                    grp['inputs'].attrs.create('contrast', new_attr, dtype=self.dt)
 
-            if grp.attrs.__contains__('slices'):
-                grp.attrs['slices'] = list(set(np.concatenate((grp.attrs['slices'], useful_slices))))
-            else:
-                grp.attrs['slices'] = useful_slices
+                else:
+                    grp['inputs'].attrs.create('contrast', [contrast], dtype=self.dt)
 
-            # Creating datasets and metadata
-            contrast = input_metadata['contrast']
-            # Inputs
-            print(len(input_volumes))
-            print("grp= ", str(subject_id))
-            key = "inputs/{}".format(contrast)
-            print("key = ", key)
-            if len(input_volumes) < 1:
-                print("list empty")
-                continue
-            grp.create_dataset(key, data=input_volumes)
-            # Sub-group metadata
-            if grp['inputs'].attrs.__contains__('contrast'):
-                attr = grp['inputs'].attrs['contrast']
-                new_attr = [c for c in attr]
-                new_attr.append(contrast)
-                grp['inputs'].attrs.create('contrast', new_attr, dtype=self.dt)
+                # dataset metadata
+                grp[key].attrs['input_filenames'] = input_metadata['input_filenames']
+                grp[key].attrs['data_type'] = input_metadata['data_type']
 
-            else:
-                grp['inputs'].attrs.create('contrast', [contrast], dtype=self.dt)
+                if "zooms" in input_metadata.keys():
+                    grp[key].attrs["zooms"] = input_metadata['zooms']
+                if "data_shape" in input_metadata.keys():
+                    grp[key].attrs["data_shape"] = input_metadata['data_shape']
+                if "bounding_box" in input_metadata.keys():
+                    grp[key].attrs["bounding_box"] = input_metadata['bounding_box']
 
-            # dataset metadata
-            grp[key].attrs['input_filenames'] = input_metadata['input_filenames']
-            grp[key].attrs['data_type'] = input_metadata['data_type']
+                # GT
+                key = "gt/{}".format(contrast)
+                grp.create_dataset(key, data=gt_volume)
+                # Sub-group metadata
+                if grp['gt'].attrs.__contains__('contrast'):
+                    attr = grp['gt'].attrs['contrast']
+                    new_attr = [c for c in attr]
+                    new_attr.append(contrast)
+                    grp['gt'].attrs.create('contrast', new_attr, dtype=self.dt)
 
-            if "zooms" in input_metadata.keys():
-                grp[key].attrs["zooms"] = input_metadata['zooms']
-            if "data_shape" in input_metadata.keys():
-                grp[key].attrs["data_shape"] = input_metadata['data_shape']
-            if "bounding_box" in input_metadata.keys():
-                grp[key].attrs["bounding_box"] = input_metadata['bounding_box']
+                else:
+                    grp['gt'].attrs.create('contrast', [contrast], dtype=self.dt)
 
-            # GT
-            key = "gt/{}".format(contrast)
-            grp.create_dataset(key, data=gt_volume)
-            # Sub-group metadata
-            if grp['gt'].attrs.__contains__('contrast'):
-                attr = grp['gt'].attrs['contrast']
-                new_attr = [c for c in attr]
-                new_attr.append(contrast)
-                grp['gt'].attrs.create('contrast', new_attr, dtype=self.dt)
+                # dataset metadata
+                grp[key].attrs['gt_filenames'] = input_metadata['gt_filenames']
+                grp[key].attrs['data_type'] = gt_metadata['data_type']
 
-            else:
-                grp['gt'].attrs.create('contrast', [contrast], dtype=self.dt)
+                if "zooms" in gt_metadata.keys():
+                    grp[key].attrs["zooms"] = gt_metadata['zooms']
+                if "data_shape" in gt_metadata.keys():
+                    grp[key].attrs["data_shape"] = gt_metadata['data_shape']
+                if gt_metadata['bounding_box'] is not None:
+                    grp[key].attrs["bounding_box"] = gt_metadata['bounding_box']
 
-            # dataset metadata
-            grp[key].attrs['gt_filenames'] = input_metadata['gt_filenames']
-            grp[key].attrs['data_type'] = gt_metadata['data_type']
+                # ROI
+                key = "roi/{}".format(contrast)
+                grp.create_dataset(key, data=roi_volume)
+                # Sub-group metadata
+                if grp['roi'].attrs.__contains__('contrast'):
+                    attr = grp['roi'].attrs['contrast']
+                    new_attr = [c for c in attr]
+                    new_attr.append(contrast)
+                    grp['roi'].attrs.create('contrast', new_attr, dtype=self.dt)
 
-            if "zooms" in gt_metadata.keys():
-                grp[key].attrs["zooms"] = gt_metadata['zooms']
-            if "data_shape" in gt_metadata.keys():
-                grp[key].attrs["data_shape"] = gt_metadata['data_shape']
-            if gt_metadata['bounding_box'] is not None:
-                grp[key].attrs["bounding_box"] = gt_metadata['bounding_box']
+                else:
+                    grp['roi'].attrs.create('contrast', [contrast], dtype=self.dt)
 
-            # ROI
-            key = "roi/{}".format(contrast)
-            grp.create_dataset(key, data=roi_volume)
-            # Sub-group metadata
-            if grp['roi'].attrs.__contains__('contrast'):
-                attr = grp['roi'].attrs['contrast']
-                new_attr = [c for c in attr]
-                new_attr.append(contrast)
-                grp['roi'].attrs.create('contrast', new_attr, dtype=self.dt)
+                # dataset metadata
+                grp[key].attrs['roi_filename'] = roi_metadata['gt_filenames']
+                grp[key].attrs['data_type'] = roi_metadata['data_type']
 
-            else:
-                grp['roi'].attrs.create('contrast', [contrast], dtype=self.dt)
+                if "zooms" in roi_metadata.keys():
+                    grp[key].attrs["zooms"] = roi_metadata['zooms']
+                if "data_shape" in roi_metadata.keys():
+                    grp[key].attrs["data_shape"] = roi_metadata['data_shape']
 
-            # dataset metadata
-            grp[key].attrs['roi_filename'] = roi_metadata['gt_filenames']
-            grp[key].attrs['data_type'] = roi_metadata['data_type']
+                # Adding contrast to group metadata
+                if grp.attrs.__contains__('contrast'):
+                    attr = grp.attrs['contrast']
+                    new_attr = [c for c in attr]
+                    new_attr.append(contrast)
+                    grp.attrs.create('contrast', new_attr, dtype=self.dt)
 
-            if "zooms" in roi_metadata.keys():
-                grp[key].attrs["zooms"] = roi_metadata['zooms']
-            if "data_shape" in roi_metadata.keys():
-                grp[key].attrs["data_shape"] = roi_metadata['data_shape']
-
-            # Adding contrast to group metadata
-            if grp.attrs.__contains__('contrast'):
-                attr = grp.attrs['contrast']
-                new_attr = [c for c in attr]
-                new_attr.append(contrast)
-                grp.attrs.create('contrast', new_attr, dtype=self.dt)
-
-            else:
-                grp.attrs.create('contrast', [contrast], dtype=self.dt)
+                else:
+                    grp.attrs.create('contrast', [contrast], dtype=self.dt)
 
 
 class HDF5Dataset:
@@ -505,43 +508,45 @@ class HDF5Dataset:
         # Getting HDS5 dataset file
         if not os.path.exists(model_params["hdf5_path"]):
             print("Computing hdf5 file of the data")
-            hdf5_file = Bids_to_hdf5(root_dir,
-                                     subject_lst=subject_lst,
-                                     hdf5_name=model_params["hdf5_path"],
-                                     target_suffix=target_suffix,
-                                     roi_params=self.roi_params,
-                                     contrast_lst=self.cst_lst,
-                                     metadata_choice=metadata_choice,
-                                     contrast_balance=contrast_params["balance"],
-                                     slice_axis=slice_axis,
-                                     slice_filter_fn=slice_filter_fn,
-                                     transform=transform,
-                                     object_detection_params=object_detection_params,
-                                     soft_gt=soft_gt)
-            self.hdf5_file = hdf5_file.hdf5_file
+            bids_to_hdf5 = Bids_to_hdf5(root_dir,
+                                        subject_lst=subject_lst,
+                                        hdf5_path=model_params["hdf5_path"],
+                                        target_suffix=target_suffix,
+                                        roi_params=self.roi_params,
+                                        contrast_lst=self.cst_lst,
+                                        metadata_choice=metadata_choice,
+                                        contrast_balance=contrast_params["balance"],
+                                        slice_axis=slice_axis,
+                                        slice_filter_fn=slice_filter_fn,
+                                        transform=transform,
+                                        object_detection_params=object_detection_params,
+                                        soft_gt=soft_gt)
+            self.hdf5_path = bids_to_hdf5.hdf5_path
         else:
-            self.hdf5_file = h5py.File(model_params["hdf5_path"], "r")
+            self.hdf5_path = model_params["hdf5_path"]
+
         # Loading dataframe object
-        self.df_object = Dataframe(self.hdf5_file, self.cst_lst, model_params["csv_path"],
-                                   target_suffix=self.gt_lst, roi_suffix=self.roi_lst, dim=self.dim,
-                                   filter_slices=slice_filter_fn)
-        if complet:
-            self.df_object.clean(self.cst_lst)
-        print("after cleaning")
-        print(self.df_object.df.head())
+        with h5py.File(self.hdf5_path, "r") as hdf5_file:
+            self.df_object = Dataframe(hdf5_file, self.cst_lst, model_params["csv_path"],
+                                       target_suffix=self.gt_lst, roi_suffix=self.roi_lst,
+                                       dim=self.dim, filter_slices=slice_filter_fn)
+            if complet:
+                self.df_object.clean(self.cst_lst)
+            print("after cleaning")
+            print(self.df_object.df.head())
 
-        self.initial_dataframe = self.df_object.df
+            self.initial_dataframe = self.df_object.df
 
-        self.dataframe = copy.deepcopy(self.df_object.df)
+            self.dataframe = copy.deepcopy(self.df_object.df)
 
-        self.cst_matrix = np.ones([len(self.dataframe), len(self.cst_lst)], dtype=int)
+            self.cst_matrix = np.ones([len(self.dataframe), len(self.cst_lst)], dtype=int)
 
-        # RAM status
-        self.status = {ct: False for ct in self.df_object.contrasts}
+            # RAM status
+            self.status = {ct: False for ct in self.df_object.contrasts}
 
-        ram = model_params["ram"] if "ram" in model_params else True
-        if ram:
-            self.load_into_ram(self.cst_lst)
+            ram = model_params["ram"] if "ram" in model_params else True
+            if ram:
+                self.load_into_ram(self.cst_lst)
 
     def load_into_ram(self, contrast_lst=None):
         """Aims to load into RAM the contrasts from the list.
@@ -550,20 +555,21 @@ class HDF5Dataset:
             contrast_lst (list of str): List of contrasts of interest.
         """
         keys = self.status.keys()
-        for ct in contrast_lst:
-            if ct not in keys:
-                print("Key error: status has no key {}".format(ct))
-                continue
-            if self.status[ct]:
-                print("Contrast {} already in RAM".format(ct))
-            else:
-                print("Loading contrast {} in RAM...".format(ct), end='')
-                for sub in self.dataframe.index:
-                    if self.filter_slices:
-                        slices = self.dataframe.at[sub, 'Slices']
-                        self.dataframe.at[sub, ct] = self.hdf5_file[self.dataframe.at[sub, ct]][np.array(slices)]
-                print("Done.")
-            self.status[ct] = True
+        with h5py.File(self.hdf5_path, "r") as hdf5_file:
+            for ct in contrast_lst:
+                if ct not in keys:
+                    print("Key error: status has no key {}".format(ct))
+                    continue
+                if self.status[ct]:
+                    print("Contrast {} already in RAM".format(ct))
+                else:
+                    print("Loading contrast {} in RAM...".format(ct), end='')
+                    for sub in self.dataframe.index:
+                        if self.filter_slices:
+                            slices = self.dataframe.at[sub, 'Slices']
+                            self.dataframe.at[sub, ct] = hdf5_file[self.dataframe.at[sub, ct]][np.array(slices)]
+                    print("Done.")
+                self.status[ct] = True
 
     def set_transform(self, transform):
         """Set the transforms."""
@@ -592,82 +598,83 @@ class HDF5Dataset:
         input_tensors = []
 
         # Inputs
-        for i, ct in enumerate(self.cst_lst):
-            if self.status[ct]:
-                input_tensor = line[ct] * missing_modalities[i]
-            else:
-                input_tensor = self.hdf5_file[line[ct]][line['Slices']] * missing_modalities[i]
+        with h5py.File(self.hdf5_path, "r") as f:
+            for i, ct in enumerate(self.cst_lst):
+                if self.status[ct]:
+                    input_tensor = line[ct] * missing_modalities[i]
+                else:
+                    input_tensor = f[line[ct]][line['Slices']] * missing_modalities[i]
 
-            input_tensors.append(input_tensor)
-            # input Metadata
-            metadata = imed_loader_utils.SampleMetadata({key: value for key, value in self.hdf5_file['{}/inputs/{}'
-                                                        .format(line['Subjects'], ct)].attrs.items()})
-            metadata['slice_index'] = line["Slices"]
-            metadata['missing_mod'] = missing_modalities
-            metadata['crop_params'] = {}
-            input_metadata.append(metadata)
+                input_tensors.append(input_tensor)
+                # input Metadata
+                metadata = imed_loader_utils.SampleMetadata({key: value for key, value in f['{}/inputs/{}'
+                                                            .format(line['Subjects'], ct)].attrs.items()})
+                metadata['slice_index'] = line["Slices"]
+                metadata['missing_mod'] = missing_modalities
+                metadata['crop_params'] = {}
+                input_metadata.append(metadata)
 
-        # GT
-        gt_img = []
-        gt_metadata = []
-        for idx, gt in enumerate(self.gt_lst):
-            if self.status['gt/' + gt]:
-                gt_data = line['gt/' + gt]
-            else:
-                gt_data = self.hdf5_file[line['gt/' + gt]][line['Slices']]
+            # GT
+            gt_img = []
+            gt_metadata = []
+            for idx, gt in enumerate(self.gt_lst):
+                if self.status['gt/' + gt]:
+                    gt_data = line['gt/' + gt]
+                else:
+                    gt_data = f[line['gt/' + gt]][line['Slices']]
 
-            gt_data = gt_data.astype(np.uint8)
-            gt_img.append(gt_data)
-            gt_metadata.append(imed_loader_utils.SampleMetadata({key: value for key, value in
-                                                                 self.hdf5_file[line['gt/' + gt]].attrs.items()}))
-            gt_metadata[idx]['crop_params'] = {}
+                gt_data = gt_data.astype(np.uint8)
+                gt_img.append(gt_data)
+                gt_metadata.append(imed_loader_utils.SampleMetadata({key: value for key, value in
+                                                                     f[line['gt/' + gt]].attrs.items()}))
+                gt_metadata[idx]['crop_params'] = {}
 
-        # ROI
-        roi_img = []
-        roi_metadata = []
-        if self.roi_lst:
-            if self.status['roi/' + self.roi_lst[0]]:
-                roi_data = line['roi/' + self.roi_lst[0]]
-            else:
-                roi_data = self.hdf5_file[line['roi/' + self.roi_lst[0]]][line['Slices']]
+            # ROI
+            roi_img = []
+            roi_metadata = []
+            if self.roi_lst:
+                if self.status['roi/' + self.roi_lst[0]]:
+                    roi_data = line['roi/' + self.roi_lst[0]]
+                else:
+                    roi_data = f[line['roi/' + self.roi_lst[0]]][line['Slices']]
 
-            roi_data = roi_data.astype(np.uint8)
-            roi_img.append(roi_data)
+                roi_data = roi_data.astype(np.uint8)
+                roi_img.append(roi_data)
 
-            roi_metadata.append(imed_loader_utils.SampleMetadata({key: value for key, value in
-                                                                  self.hdf5_file[
-                                                                      line['roi/' + self.roi_lst[0]]].attrs.items()}))
-            roi_metadata[0]['crop_params'] = {}
+                roi_metadata.append(imed_loader_utils.SampleMetadata({key: value for key, value in
+                                                                      f[
+                                                                          line['roi/' + self.roi_lst[0]]].attrs.items()}))
+                roi_metadata[0]['crop_params'] = {}
 
-        # Run transforms on ROI
-        # ROI goes first because params of ROICrop are needed for the followings
-        stack_roi, metadata_roi = self.transform(sample=roi_img,
-                                                 metadata=roi_metadata,
-                                                 data_type="roi")
-        # Update metadata_input with metadata_roi
-        metadata_input = imed_loader_utils.update_metadata(metadata_roi, input_metadata)
+            # Run transforms on ROI
+            # ROI goes first because params of ROICrop are needed for the followings
+            stack_roi, metadata_roi = self.transform(sample=roi_img,
+                                                     metadata=roi_metadata,
+                                                     data_type="roi")
+            # Update metadata_input with metadata_roi
+            metadata_input = imed_loader_utils.update_metadata(metadata_roi, input_metadata)
 
-        # Run transforms on images
-        stack_input, metadata_input = self.transform(sample=input_tensors,
-                                                     metadata=metadata_input,
-                                                     data_type="im")
-        # Update metadata_input with metadata_roi
-        metadata_gt = imed_loader_utils.update_metadata(metadata_input, gt_metadata)
+            # Run transforms on images
+            stack_input, metadata_input = self.transform(sample=input_tensors,
+                                                         metadata=metadata_input,
+                                                         data_type="im")
+            # Update metadata_input with metadata_roi
+            metadata_gt = imed_loader_utils.update_metadata(metadata_input, gt_metadata)
 
-        # Run transforms on images
-        stack_gt, metadata_gt = self.transform(sample=gt_img,
-                                               metadata=metadata_gt,
-                                               data_type="gt")
-        data_dict = {
-            'input': stack_input,
-            'gt': stack_gt,
-            'roi': stack_roi,
-            'input_metadata': metadata_input,
-            'gt_metadata': metadata_gt,
-            'roi_metadata': metadata_roi
-        }
+            # Run transforms on images
+            stack_gt, metadata_gt = self.transform(sample=gt_img,
+                                                   metadata=metadata_gt,
+                                                   data_type="gt")
+            data_dict = {
+                'input': stack_input,
+                'gt': stack_gt,
+                'roi': stack_roi,
+                'input_metadata': metadata_input,
+                'gt_metadata': metadata_gt,
+                'roi_metadata': metadata_roi
+            }
 
-        return data_dict
+            return data_dict
 
     def update(self, strategy="Missing", p=0.0001):
         """Update the Dataframe itself.
@@ -686,66 +693,67 @@ class HDF5Dataset:
                 if not np.any(missing_mod):
                     missing_mod = np.zeros((len(self.cst_lst)))
                     missing_mod[np.random.randint(2, size=1)] = 1
-                self.cst_matrix[idx,] = missing_mod
+                self.cst_matrix[idx, ] = missing_mod
 
             print("Missing contrasts = {}".format(self.cst_matrix.size - self.cst_matrix.sum()))
 
 
-def HDF5_to_Bids(HDF5, subjects, path_dir):
+def HDF5_to_Bids(hdf5_path, subjects, path_dir):
     """Convert HDF5 file to BIDS dataset.
 
     Args:
-        HDF5 (str): Path to the HDF5 file.
+        hdf5_path (str): Path to the HDF5 file.
         subjects (list): List of subject names.
         path_dir (str): Output folder path, already existing.
     """
     # Open FDH5 file
-    hdf5 = h5py.File(HDF5, "r")
-    # check the dir exists:
-    if not path.exists(path_dir):
-        raise FileNotFoundError("Directory {} doesn't exist. Stopping process.".format(path_dir))
+    with h5py.File(hdf5_path, "r") as hdf5_file:
+        # check the dir exists:
+        if not path.exists(path_dir):
+            raise FileNotFoundError("Directory {} doesn't exist. Stopping process.".format(path_dir))
 
-    # loop over all subjects
-    for sub in subjects:
-        path_sub = path_dir + '/' + sub + '/anat/'
-        path_label = path_dir + '/derivatives/labels/' + sub + '/anat/'
+        # loop over all subjects
+        for sub in subjects:
+            path_sub = path_dir + '/' + sub + '/anat/'
+            path_label = path_dir + '/derivatives/labels/' + sub + '/anat/'
 
-        if not path.exists(path_sub):
-            os.makedirs(path_sub)
+            if not path.exists(path_sub):
+                os.makedirs(path_sub)
 
-        if not path.exists(path_label):
-            os.makedirs(path_label)
+            if not path.exists(path_label):
+                os.makedirs(path_label)
 
-        # Get Subject Group
-        try:
-            grp = hdf5[sub]
-        except:
-            continue
-        # inputs
-        cts = grp['inputs'].attrs['contrast']
+            # Get Subject Group
+            try:
+                grp = hdf5_file[sub]
+            except Exception:
+                continue
+            # inputs
+            cts = grp['inputs'].attrs['contrast']
 
-        # Relation between voxel and world coordinates is not available
-        for ct in cts:
-            input_data = np.array(grp['inputs/{}'.format(ct)])
-            nib_image = nib.Nifti1Image(input_data, np.eye(4))
-            filename = os.path.join(path_sub, sub + "_" + ct + ".nii.gz")
-            nib.save(nib_image, filename)
-
-        # GT
-        cts = grp['gt'].attrs['contrast']
-
-        for ct in cts:
-            for filename in grp['gt/{}'.format(ct)].attrs['gt_filenames']:
-                gt_data = grp['gt/{}'.format(ct)]
-                nib_image = nib.Nifti1Image(gt_data, np.eye(4))
-                filename = os.path.join(path_label, filename.split("/")[-1])
+            # Relation between voxel and world coordinates is not available
+            for ct in cts:
+                input_data = np.array(grp['inputs/{}'.format(ct)])
+                nib_image = nib.Nifti1Image(input_data, np.eye(4))
+                filename = os.path.join(path_sub, sub + "_" + ct + ".nii.gz")
                 nib.save(nib_image, filename)
 
-        cts = grp['roi'].attrs['contrast']
+            # GT
+            cts = grp['gt'].attrs['contrast']
 
-        for ct in cts:
-            roi_data = grp['roi/{}'.format(ct)]
-            if np.any(roi_data.shape):
-                nib_image = nib.Nifti1Image(roi_data, np.eye(4))
-                filename = os.path.join(path_label, grp['roi/{}'.format(ct)].attrs['roi_filename'][0].split("/")[-1])
-                nib.save(nib_image, filename)
+            for ct in cts:
+                for filename in grp['gt/{}'.format(ct)].attrs['gt_filenames']:
+                    gt_data = grp['gt/{}'.format(ct)]
+                    nib_image = nib.Nifti1Image(gt_data, np.eye(4))
+                    filename = os.path.join(path_label, filename.split("/")[-1])
+                    nib.save(nib_image, filename)
+
+            cts = grp['roi'].attrs['contrast']
+
+            for ct in cts:
+                roi_data = grp['roi/{}'.format(ct)]
+                if np.any(roi_data.shape):
+                    nib_image = nib.Nifti1Image(roi_data, np.eye(4))
+                    filename = os.path.join(path_label,
+                                            grp['roi/{}'.format(ct)].attrs['roi_filename'][0].split("/")[-1])
+                    nib.save(nib_image, filename)

--- a/ivadomed/loader/adaptative.py
+++ b/ivadomed/loader/adaptative.py
@@ -172,7 +172,7 @@ class Dataframe:
         self.df = self.df.dropna()
 
 
-class Bids_to_hdf5:
+class BIDStoHDF5:
     """Converts a BIDS dataset to a HDF5 file.
 
     Args:
@@ -508,7 +508,7 @@ class HDF5Dataset:
         # Getting HDS5 dataset file
         if not os.path.exists(model_params["hdf5_path"]):
             print("Computing hdf5 file of the data")
-            bids_to_hdf5 = Bids_to_hdf5(root_dir,
+            bids_to_hdf5 = BIDStoHDF5(root_dir,
                                         subject_lst=subject_lst,
                                         hdf5_path=model_params["hdf5_path"],
                                         target_suffix=target_suffix,
@@ -698,7 +698,7 @@ class HDF5Dataset:
             print("Missing contrasts = {}".format(self.cst_matrix.size - self.cst_matrix.sum()))
 
 
-def HDF5_to_Bids(hdf5_path, subjects, path_dir):
+def HDF5ToBIDS(hdf5_path, subjects, path_dir):
     """Convert HDF5 file to BIDS dataset.
 
     Args:

--- a/testing/unit_tests/test_HeMIS.py
+++ b/testing/unit_tests/test_HeMIS.py
@@ -209,7 +209,7 @@ def test_HeMIS(p=0.0001):
 
 def test_hdf5_bids():
     os.makedirs("test_adap_bids")
-    imed_adaptative.HDF5_to_Bids('testing_data/mytestfile.hdf5', ['sub-unf01'], "test_adap_bids")
+    imed_adaptative.HDF5ToBIDS('testing_data/mytestfile.hdf5', ['sub-unf01'], "test_adap_bids")
     assert os.path.isdir("test_adap_bids/sub-unf01/anat")
     assert os.path.isdir("test_adap_bids/derivatives/labels/sub-unf01/anat")
     # once done we can delete the file

--- a/testing/unit_tests/test_HeMIS.py
+++ b/testing/unit_tests/test_HeMIS.py
@@ -61,7 +61,7 @@ def test_HeMIS(p=0.0001):
             "missing_probability_growth": 0.9,
             "contrasts": ["T1w", "T2w"],
             "ram": False,
-            "hdf5_path": 'testing_data/mytestfile.hdf5',
+            "path_hdf5": 'testing_data/mytestfile.hdf5',
             "csv_path": 'testing_data/hdf5.csv',
             "target_lst": ["T2w"],
             "roi_lst": ["T2w"]

--- a/testing/unit_tests/test_adaptative.py
+++ b/testing/unit_tests/test_adaptative.py
@@ -1,5 +1,5 @@
 import os
-
+import h5py
 import torch
 from torch.utils.data import DataLoader
 
@@ -38,17 +38,17 @@ def test_hdf5():
 
     roi_params = {"suffix": "_seg-manual", "slice_filter_roi": None}
 
-    hdf5_file = imed_adaptative.Bids_to_hdf5(PATH_BIDS,
-                                             subject_lst=train_lst,
-                                             hdf5_name='testing_data/mytestfile.hdf5',
-                                             target_suffix=["_lesion-manual"],
-                                             roi_params=roi_params,
-                                             contrast_lst=['T1w', 'T2w', 'T2star'],
-                                             metadata_choice="contrast",
-                                             transform=transform_lst,
-                                             contrast_balance={},
-                                             slice_axis=2,
-                                             slice_filter_fn=imed_loader_utils.SliceFilter(filter_empty_input=True,
+    bids_to_hdf5 = imed_adaptative.Bids_to_hdf5(PATH_BIDS,
+                                                subject_lst=train_lst,
+                                                hdf5_path='testing_data/mytestfile.hdf5',
+                                                target_suffix=["_lesion-manual"],
+                                                roi_params=roi_params,
+                                                contrast_lst=['T1w', 'T2w', 'T2star'],
+                                                metadata_choice="contrast",
+                                                transform=transform_lst,
+                                                contrast_balance={},
+                                                slice_axis=2,
+                                                slice_filter_fn=imed_loader_utils.SliceFilter(filter_empty_input=True,
                                                                                     filter_empty_mask=True))
 
     # Checking architecture
@@ -60,90 +60,91 @@ def test_hdf5():
             print("    %s: %s" % (key, val))
 
     print('\n[INFO]: HDF5 architecture:')
-    hdf5_file.hdf5_file.visititems(print_attrs)
-    print('\n[INFO]: HDF5 file successfully generated.')
-    print('[INFO]: Generating dataframe ...\n')
+    with h5py.File(bids_to_hdf5.hdf5_path, "a") as hdf5_file:
+        hdf5_file.visititems(print_attrs)
+        print('\n[INFO]: HDF5 file successfully generated.')
+        print('[INFO]: Generating dataframe ...\n')
 
-    df = imed_adaptative.Dataframe(hdf5=hdf5_file.hdf5_file,
-                                   contrasts=['T1w', 'T2w', 'T2star'],
-                                   path='testing_data/hdf5.csv',
-                                   target_suffix=['T1w', 'T2w', 'T2star'],
-                                   roi_suffix=['T1w', 'T2w', 'T2star'],
-                                   dim=2,
-                                   filter_slices=True)
+        df = imed_adaptative.Dataframe(hdf5_file=hdf5_file,
+                                       contrasts=['T1w', 'T2w', 'T2star'],
+                                       path='testing_data/hdf5.csv',
+                                       target_suffix=['T1w', 'T2w', 'T2star'],
+                                       roi_suffix=['T1w', 'T2w', 'T2star'],
+                                       dim=2,
+                                       filter_slices=True)
 
-    print(df.df)
+        print(df.df)
 
-    print('\n[INFO]: Dataframe successfully generated. ')
-    print('[INFO]: Creating dataset ...\n')
+        print('\n[INFO]: Dataframe successfully generated. ')
+        print('[INFO]: Creating dataset ...\n')
 
-    model_params = {
-            "name": "HeMISUnet",
-            "dropout_rate": 0.3,
-            "bn_momentum": 0.9,
-            "depth": 2,
-            "in_channel": 1,
-            "out_channel": 1,
-            "missing_probability": 0.00001,
-            "missing_probability_growth": 0.9,
-            "contrasts": ["T1w", "T2w"],
-            "ram": False,
-            "hdf5_path": 'testing_data/mytestfile.hdf5',
-            "csv_path": 'testing_data/hdf5.csv',
-            "target_lst": ["T2w"],
-            "roi_lst": ["T2w"]
+        model_params = {
+                "name": "HeMISUnet",
+                "dropout_rate": 0.3,
+                "bn_momentum": 0.9,
+                "depth": 2,
+                "in_channel": 1,
+                "out_channel": 1,
+                "missing_probability": 0.00001,
+                "missing_probability_growth": 0.9,
+                "contrasts": ["T1w", "T2w"],
+                "ram": False,
+                "hdf5_path": 'testing_data/mytestfile.hdf5',
+                "csv_path": 'testing_data/hdf5.csv',
+                "target_lst": ["T2w"],
+                "roi_lst": ["T2w"]
+            }
+        contrast_params = {
+            "contrast_lst": ['T1w', 'T2w', 'T2star'],
+            "balance": {}
         }
-    contrast_params = {
-        "contrast_lst": ['T1w', 'T2w', 'T2star'],
-        "balance": {}
-    }
 
-    dataset = imed_adaptative.HDF5Dataset(root_dir=PATH_BIDS,
-                                          subject_lst=train_lst,
-                                          target_suffix="_lesion-manual",
-                                          slice_axis=2,
-                                          model_params=model_params,
-                                          contrast_params=contrast_params,
-                                          transform=transform_lst,
-                                          metadata_choice=False,
-                                          dim=2,
-                                          slice_filter_fn=imed_loader_utils.SliceFilter(filter_empty_input=True,
-                                                                                 filter_empty_mask=True),
-                                          roi_params=roi_params)
+        dataset = imed_adaptative.HDF5Dataset(root_dir=PATH_BIDS,
+                                              subject_lst=train_lst,
+                                              target_suffix="_lesion-manual",
+                                              slice_axis=2,
+                                              model_params=model_params,
+                                              contrast_params=contrast_params,
+                                              transform=transform_lst,
+                                              metadata_choice=False,
+                                              dim=2,
+                                              slice_filter_fn=imed_loader_utils.SliceFilter(filter_empty_input=True,
+                                                                                     filter_empty_mask=True),
+                                              roi_params=roi_params)
 
-    dataset.load_into_ram(['T1w', 'T2w', 'T2star'])
-    print("Dataset RAM status:")
-    print(dataset.status)
-    print("In memory Dataframe:")
-    print(dataset.dataframe)
-    print('\n[INFO]: Test passed successfully. ')
+        dataset.load_into_ram(['T1w', 'T2w', 'T2star'])
+        print("Dataset RAM status:")
+        print(dataset.status)
+        print("In memory Dataframe:")
+        print(dataset.dataframe)
+        print('\n[INFO]: Test passed successfully. ')
 
-    print("\n[INFO]: Starting loader test ...")
+        print("\n[INFO]: Starting loader test ...")
 
-    device = torch.device("cuda:" + str(GPU_NUMBER) if torch.cuda.is_available() else "cpu")
-    cuda_available = torch.cuda.is_available()
-    if cuda_available:
-        torch.cuda.set_device(device)
-        print("Using GPU number {}".format(device))
-
-    train_loader = DataLoader(dataset, batch_size=BATCH_SIZE,
-                              shuffle=False, pin_memory=True,
-                              collate_fn=imed_loader_utils.imed_collate,
-                              num_workers=1)
-
-    for i, batch in enumerate(train_loader):
-        input_samples, gt_samples = batch["input"], batch["gt"]
-        print("len input = {}".format(len(input_samples)))
-        print("Batch = {}, {}".format(input_samples[0].shape, gt_samples[0].shape))
-
+        device = torch.device("cuda:" + str(GPU_NUMBER) if torch.cuda.is_available() else "cpu")
+        cuda_available = torch.cuda.is_available()
         if cuda_available:
-            var_input = imed_utils.cuda(input_samples)
-            var_gt = imed_utils.cuda(gt_samples, non_blocking=True)
-        else:
-            var_input = input_samples
-            var_gt = gt_samples
+            torch.cuda.set_device(device)
+            print("Using GPU number {}".format(device))
 
-        break
-    os.remove('testing_data/mytestfile.hdf5')
-    print("Congrats your dataloader works! You can go Home now and get a beer.")
-    return 0
+        train_loader = DataLoader(dataset, batch_size=BATCH_SIZE,
+                                  shuffle=False, pin_memory=True,
+                                  collate_fn=imed_loader_utils.imed_collate,
+                                  num_workers=1)
+
+        for i, batch in enumerate(train_loader):
+            input_samples, gt_samples = batch["input"], batch["gt"]
+            print("len input = {}".format(len(input_samples)))
+            print("Batch = {}, {}".format(input_samples[0].shape, gt_samples[0].shape))
+
+            if cuda_available:
+                var_input = imed_utils.cuda(input_samples)
+                var_gt = imed_utils.cuda(gt_samples, non_blocking=True)
+            else:
+                var_input = input_samples
+                var_gt = gt_samples
+
+            break
+        os.remove('testing_data/mytestfile.hdf5')
+        print("Congrats your dataloader works! You can go Home now and get a beer.")
+        return 0

--- a/testing/unit_tests/test_adaptative.py
+++ b/testing/unit_tests/test_adaptative.py
@@ -40,7 +40,7 @@ def test_hdf5():
 
     bids_to_hdf5 = imed_adaptative.BIDStoHDF5(PATH_BIDS,
                                                 subject_lst=train_lst,
-                                                hdf5_path='testing_data/mytestfile.hdf5',
+                                                path_hdf5='testing_data/mytestfile.hdf5',
                                                 target_suffix=["_lesion-manual"],
                                                 roi_params=roi_params,
                                                 contrast_lst=['T1w', 'T2w', 'T2star'],
@@ -60,7 +60,7 @@ def test_hdf5():
             print("    %s: %s" % (key, val))
 
     print('\n[INFO]: HDF5 architecture:')
-    with h5py.File(bids_to_hdf5.hdf5_path, "a") as hdf5_file:
+    with h5py.File(bids_to_hdf5.path_hdf5, "a") as hdf5_file:
         hdf5_file.visititems(print_attrs)
         print('\n[INFO]: HDF5 file successfully generated.')
         print('[INFO]: Generating dataframe ...\n')
@@ -89,7 +89,7 @@ def test_hdf5():
                 "missing_probability_growth": 0.9,
                 "contrasts": ["T1w", "T2w"],
                 "ram": False,
-                "hdf5_path": 'testing_data/mytestfile.hdf5',
+                "path_hdf5": 'testing_data/mytestfile.hdf5',
                 "csv_path": 'testing_data/hdf5.csv',
                 "target_lst": ["T2w"],
                 "roi_lst": ["T2w"]

--- a/testing/unit_tests/test_adaptative.py
+++ b/testing/unit_tests/test_adaptative.py
@@ -38,7 +38,7 @@ def test_hdf5():
 
     roi_params = {"suffix": "_seg-manual", "slice_filter_roi": None}
 
-    bids_to_hdf5 = imed_adaptative.Bids_to_hdf5(PATH_BIDS,
+    bids_to_hdf5 = imed_adaptative.BIDStoHDF5(PATH_BIDS,
                                                 subject_lst=train_lst,
                                                 hdf5_path='testing_data/mytestfile.hdf5',
                                                 target_suffix=["_lesion-manual"],


### PR DESCRIPTION
## Description

In the file `loader/adaptative.py`, several of the classes/functions read or write to `*.hdf5` files. According to the documentation (https://docs.h5py.org/en/stable/high/file.html):

> HDF5 files work generally like standard Python file objects. They support standard modes like r/w/a, and should be closed
> when they are no longer in use.

Throughout the `adaptative.py` file, `*.hdf5` files are opened in read or write mode, but none of the files are being closed. This is leading to errors in this pull request, which adds files for testing: https://github.com/ivadomed/ivadomed/pull/580. Leaving files open can lead to issues, such as not being able to open a file because it hasn't been closed properly.

## This Pull Request Achieves...

1. In this pull request, I have fixed the `*.hdf5*` read/write issue by using:

```
with h5py.File(hdf5_file_name, "w") as f:
    # do something here
```

2. I renamed `Bids_to_hdf5` -> `BIDSToHDF5` and `HDF5_to_Bids` -> `HDF5ToBIDS` to be `PEP8` compliant (PascalCase)


## Linked issues
Resolves: https://github.com/ivadomed/ivadomed/issues/590
