### PR TITLE
Specify Python version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'Intended Audience :: Developers',
         'Programming Language :: Python :: 3',
     ],
+    python_requires='>=3.6, <3.9',
     packages=find_packages(exclude=['docs', 'tests']),
     include_package_data=True,
     install_requires=requirements,


### PR DESCRIPTION
## Description

The purpose is to add the `python_requires` argument to `setup.py`, to ensure the correct version of `Python` is available. 

As mentioned here: https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires:

> **Note**: Support for this feature is relatively recent. Your project’s source distributions and wheels (see Packaging your project) must be built using at least version 24.2.0 of `setuptools` in order for the `python_requires` argument to be recognized and the appropriate metadata generated.
In addition, only versions 9.0.0 and higher of pip recognize the python_requires metadata. Users with earlier versions of pip will be able to download & install projects on any Python version regardless of the projects’ python_requires values.

## Resolves
https://github.com/openjournals/joss-reviews/issues/2868#issuecomment-752687437
