### PR TITLE
Add explanation for Windows incompatibility in installation docs

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,6 +1,16 @@
 Installation
 ============
 
+Supported OS:
+-------------
+
+Currently, we only support ``MacOS`` and ``Linux`` operating systems. You can try installing
+on ``Windows``, but we cannot guarantee success. We would like to add support for ``Windows``
+in the future though.
+
+Python
+------
+
 ``ivadomed`` requires Python >= 3.6 and <3.9  as well as PyTorch == 1.5.0. We recommend
 working under a virtual environment, which could be set as follows:
 
@@ -31,4 +41,3 @@ on Github. Installation procedure is the following:
     git clone https://github.com/neuropoly/ivadomed.git
     cd ivadomed
     pip install -e .
-


### PR DESCRIPTION
## Description
Mention operating system compatibility in docs. As mentioned in this review: https://github.com/openjournals/joss-reviews/issues/2868#issuecomment-752687437, there are difficulties in installing on `Windows` machines. To address this, I have added a few lines in the installation docs to state that we don't currently support `Windows`, but would like to in the future.

## Linked issues
Related to: https://github.com/ivadomed/ivadomed/issues/604
