### PR TITLE
Fix pandas typecast issue in test_split_dataset.py

### DIFF
--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -39,7 +39,8 @@ def split_dataset(df, center_test_lst, split_method, random_seed, train_frac=0.8
 
     Args:
         df (pd.DataFrame): Dataframe containing "participants.tsv" file information.
-        center_test_lst (list): list of centers to include in the testing set.
+        center_test_lst (list): list of centers to include in the testing set. Must be
+            float.
         split_method (str): Between 'per_center' or 'per_person'. If 'per_center' the separation fraction are
             applied to centers, if 'per_person' they are applied to the subject list.
         random_seed (int): Random seed to ensure reproducible splits.

--- a/testing/unit_tests/test_split_dataset.py
+++ b/testing/unit_tests/test_split_dataset.py
@@ -17,7 +17,7 @@ N_CENTERS = 5
 @pytest.mark.parametrize('split_params', [{
         "fname_split": None,
         "random_seed": 6,
-        "center_test": ['0'],
+        "center_test": [0],
         "method": "per_center",
         "train_fraction": 0.6,
         "test_fraction": 0.2
@@ -44,7 +44,7 @@ def load_dataset(split_params):
 @pytest.mark.parametrize('split_params', [{
         "fname_split": None,
         "random_seed": 6,
-        "center_test": ['0'],
+        "center_test": [0],
         "method": "per_center",
         "train_fraction": 0.6,
         "test_fraction": 0.2
@@ -149,7 +149,7 @@ def test_per_patient_balance(split_params):
 @pytest.mark.parametrize('split_params', [{
         "fname_split": None,
         "random_seed": 6,
-        "center_test": ['0'],
+        "center_test": [0],
         "balance": "disability",
         "method": "per_center",
         "train_fraction": 0.4,


### PR DESCRIPTION
## Description
It looks like for the `pandas` versions used in Python 3.7 and 3.8, there is a typecasting issue which is affecting the `test_split_dataset.py`. This is why the unit tests are currently failing. During this test, a file called `bids/participants.tsv` is created, with a list of subjects and institution IDs. These are read in as `float64`, but the test is querying based on `str`, in the form of the parameter `center_test`. In Python 3.6 it seems `pandas` was able to convert these values properly, but the newer versions of `pandas` doesn't do the conversion. This has been causing `test_per_center_balance` and `test_per_center_testcenter_0` to fail.

In particular, it is this line, in `ivadomed/loader/utils.py` that is causing the issue:

```
X_test = df[df['institution_id'].isin(center_test_lst)]['participant_id'].tolist()
X_remain = df[~df['institution_id'].isin(center_test_lst)]['participant_id'].tolist()
```

## Linked issues

This should fix this issue: https://github.com/ivadomed/ivadomed/issues/599