### PR TITLE
Indicate folder created after running ivadomed_download_data

### DIFF
--- a/ivadomed/scripts/download_data.py
+++ b/ivadomed/scripts/download_data.py
@@ -246,6 +246,7 @@ def install_data(url, dest_folder, keep=False):
             shutil.copy(srcpath, dstpath)
 
     logger.info("Removing temporary folders...")
+    logger.info("Folder Created: {}".format(dest_folder))
     shutil.rmtree(os.path.dirname(tmp_file))
     shutil.rmtree(extraction_folder)
 


### PR DESCRIPTION
## Description
When running ivadomed_download_data command, it should now log a message containing the destination folder path.

## Linked issues
Fixes #608