### PR TITLE
Bug in Coveralls release 3.0.0

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -39,14 +39,14 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
-      env: 
+      env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_FLAG_NAME: ${{ matrix.test-name }}
         COVERALLS_PARALLEL: true
       run: |
          ivadomed_download_data -d data_testing -o testing_data
          pytest --cov=./ --cov-report term-missing
-         coveralls
+         coveralls --service=github
 
   coveralls:
     needs: test


### PR DESCRIPTION
## Description

In the latest release of the Python `coveralls` package (https://github.com/coveralls-clients/coveralls-python/releases, 3.0.0, released 2020-01-11), there is a bug: https://github.com/coveralls-clients/coveralls-python/issues/251. This is causing our tests to fail. I'm not sure if/when they will fix the bug, but there is a reported workaround, which is changing:

```
run: |
  coveralls
```
to
```
run: |
  coveralls --service=github
```
in our `run_tests.yml` file.

