### PR TITLE
Add metavar to parser

### DIFF
--- a/ivadomed/scripts/automate_training.py
+++ b/ivadomed/scripts/automate_training.py
@@ -24,7 +24,7 @@ import torch.multiprocessing as mp
 
 from ivadomed import main as ivado
 from ivadomed import config_manager as imed_config_manager
-from ivadomed.utils import init_ivadomed
+from ivadomed.utils import init_ivadomed, Metavar
 from ivadomed.loader import utils as imed_loader_utils
 from ivadomed.scripts.compare_models import compute_statistics
 
@@ -34,11 +34,15 @@ logging.basicConfig(filename=LOG_FILENAME, level=logging.DEBUG)
 
 def get_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--config", required=True, help="Base config file path.")
-    parser.add_argument("-p", "--params", required=True, help="JSON file where hyperparameters to experiment are "
-                                                              "listed.")
+    parser.add_argument("-c", "--config", required=True, help="Base config file path.",
+                        metavar=Metavar.file)
+    parser.add_argument("-p", "--params", required=True,
+                        help="""JSON file where hyperparameters to experiment are
+                                listed.""",
+                        metavar=Metavar.file)
     parser.add_argument("-n", "--n-iterations", dest="n_iterations", default=1,
-                        type=int, help="Number of times to run each config.")
+                        type=int, help="Number of times to run each config.",
+                        metavar=Metavar.int)
     parser.add_argument("--all-combin", dest='all_combin', action='store_true',
                         help="To run all combinations of config"),
     parser.add_argument("-m", "--multi-params", dest="multi_params", action='store_true',
@@ -50,9 +54,11 @@ def get_parser():
     parser.add_argument("-l", "--all-logs", dest="all_logs", action='store_true',
                         help="Keep all log directories for each iteration.")
     parser.add_argument('-t', '--thr-increment', dest="thr_increment", required=False, type=float,
-                        help="A threshold analysis is performed at the end of the training using the trained model and "
-                             "the validation sub-dataset to find the optimal binarization threshold. The specified "
-                             "value indicates the increment between 0 and 1 used during the analysis (e.g. 0.1).")
+                        help="""A threshold analysis is performed at the end of the training using
+                                the trained model and the validation sub-dataset to find the optimal
+                                binarization threshold. The specified value indicates the increment
+                                between 0 and 1 used during the analysis (e.g. 0.1).""",
+                        metavar=Metavar.float)
 
     return parser
 

--- a/ivadomed/scripts/compare_models.py
+++ b/ivadomed/scripts/compare_models.py
@@ -14,7 +14,7 @@ import argparse
 import numpy as np
 import pandas as pd
 
-from ivadomed.utils import init_ivadomed
+from ivadomed.utils import init_ivadomed, Metavar
 
 from scipy.stats import ttest_ind_from_stats
 
@@ -22,13 +22,17 @@ from scipy.stats import ttest_ind_from_stats
 def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("-df", "--dataframe", required=True,
-                        help="Path to saved dataframe (csv file).")
+                        help="Path to saved dataframe (csv file).",
+                        metavar=Metavar.file)
     parser.add_argument("-n", "--n-iterations", required=True, dest="n_iterations",
-                        type=int, help="Number of times each config was run .")
+                        type=int, help="Number of times each config was run .",
+                        metavar=Metavar.int)
     parser.add_argument("--run_test", dest='run_test', action='store_true',
-                        help="Evaluate the trained model on the testing sub-set instead of validation.")
+                        help="""Evaluate the trained model on the testing sub-set instead of
+                                validation.""")
     parser.add_argument("-o", "--output", dest='out', default="comparison_models.csv",
-                        help="if defined will represents the output csv file.")
+                        help="if defined will represents the output csv file.",
+                        metavar=Metavar.file)
     return parser
 
 

--- a/ivadomed/scripts/convert_to_onnx.py
+++ b/ivadomed/scripts/convert_to_onnx.py
@@ -7,7 +7,7 @@ from ivadomed.utils import init_ivadomed, Metavar, save_onnx_model
 def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("-m", "--model", dest="model", required=True, type=str,
-                        help="Path to .pt model.", metavar=Metavar.str)
+                        help="Path to .pt model.", metavar=Metavar.file)
     parser.add_argument("-d", "--dimension", dest="dimension", required=True,
                         type=int, help="Input dimension (2 for 2D inputs, 3 for 3D inputs).",
                         metavar=Metavar.int)
@@ -15,7 +15,7 @@ def get_parser():
                         help="Number of input channels of the model.",
                         metavar=Metavar.int)
     parser.add_argument("-g", "--gpu", dest="gpu", default=0, type=str,
-                        help="GPU number if available.", metavar=Metavar.str)
+                        help="GPU number if available.", metavar=Metavar.int)
     return parser
 
 

--- a/ivadomed/scripts/convert_to_onnx.py
+++ b/ivadomed/scripts/convert_to_onnx.py
@@ -1,7 +1,7 @@
 import argparse
 import torch
 
-from ivadomed.utils import init_ivadomed, Metavar
+from ivadomed.utils import init_ivadomed, Metavar, save_onnx_model
 
 
 def get_parser():
@@ -42,7 +42,7 @@ def convert_pytorch_to_onnx(model, dimension, n_channels, gpu=0):
     model_net = torch.load(model, map_location=device)
     dummy_input = torch.randn(1, n_channels, 96, 96, device=device) if dimension == 2 \
                   else torch.randn(1, n_channels, 96, 96, 96, device=device)
-    imed_utils.save_onnx_model(model_net, dummy_input, model.replace("pt", "onnx"))
+    save_onnx_model(model_net, dummy_input, model.replace("pt", "onnx"))
 
 
 def main():

--- a/ivadomed/scripts/convert_to_onnx.py
+++ b/ivadomed/scripts/convert_to_onnx.py
@@ -1,17 +1,21 @@
 import argparse
 import torch
 
-from ivadomed import utils as imed_utils
+from ivadomed.utils import init_ivadomed, Metavar
 
 
 def get_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-m", "--model", dest="model", required=True, type=str, help="Path to .pt model.")
+    parser.add_argument("-m", "--model", dest="model", required=True, type=str,
+                        help="Path to .pt model.", metavar=Metavar.str)
     parser.add_argument("-d", "--dimension", dest="dimension", required=True,
-                        type=int, help="Input dimension (2 for 2D inputs, 3 for 3D inputs).")
+                        type=int, help="Input dimension (2 for 2D inputs, 3 for 3D inputs).",
+                        metavar=Metavar.int)
     parser.add_argument("-n", "--n_channels", dest="n_channels", default=1, type=int,
-                        help="Number of input channels of the model.")
-    parser.add_argument("-g", "--gpu", dest="gpu", default=0, type=str, help="GPU number if available.")
+                        help="Number of input channels of the model.",
+                        metavar=Metavar.int)
+    parser.add_argument("-g", "--gpu", dest="gpu", default=0, type=str,
+                        help="GPU number if available.", metavar=Metavar.str)
     return parser
 
 
@@ -42,7 +46,7 @@ def convert_pytorch_to_onnx(model, dimension, n_channels, gpu=0):
 
 
 def main():
-    imed_utils.init_ivadomed()
+    init_ivadomed()
 
     parser = get_parser()
     args = parser.parse_args()

--- a/ivadomed/scripts/download_data.py
+++ b/ivadomed/scripts/download_data.py
@@ -13,7 +13,7 @@ import sys
 import argparse
 import textwrap
 
-from ivadomed.utils import init_ivadomed
+from ivadomed.utils import init_ivadomed, Metavar
 
 
 DICT_URL = {
@@ -47,11 +47,11 @@ def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("-d", required=True,
                         choices=(sorted(DICT_URL)),
-                        help="Data to download")
-    parser.add_argument("-k", "--keep", required=False, default=False,
+                        help="Data to download", metavar=Metavar.str)
+    parser.add_argument("-k", "--keep", action="store_true",
                         help="Keep existing data in destination directory")
     parser.add_argument("-o", "--output", required=False,
-                        help="Output Folder.")
+                        help="Output Folder.", metavar=Metavar.file)
     return parser
 
 
@@ -278,7 +278,7 @@ def main(args=None):
         dest_folder = arguments.output
 
     url = DICT_URL[data_name]["url"]
-    install_data(url, dest_folder, keep=arguments.keep)
+    install_data(url, dest_folder, keep=bool(arguments.keep))
     return 0
 
 

--- a/ivadomed/scripts/extract_small_dataset.py
+++ b/ivadomed/scripts/extract_small_dataset.py
@@ -6,25 +6,30 @@ import argparse
 import numpy as np
 import pandas as pd
 
-from ivadomed.utils import init_ivadomed
+from ivadomed.utils import init_ivadomed, Metavar
 
 EXCLUDED_SUBJECT = ["sub-mniPilot1"]
+
 
 def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("-i", "--input", required=True,
-                        help="Input BIDS folder.")
+                        help="Input BIDS folder.", metavar=Metavar.file)
     parser.add_argument("-n", "--number", required=False, default=1,
-                        help="Number of subjects.")
+                        help="Number of subjects.", metavar=Metavar.int)
     parser.add_argument("-c", "--contrasts", required=False,
-                        help="Contrast list.")
+                        help="Contrast list.", metavar=Metavar.list)
     parser.add_argument("-o", "--output", required=True,
-                        help="Output BIDS Folder.")
+                        help="Output BIDS Folder.", metavar=Metavar.file)
     parser.add_argument("-s", "--seed", required=False, default=-1,
-                        help="Set np.random.RandomState to ensure reproducibility: the same subjects will be selected "
-                             "if the script is run several times on the same dataset. Set to -1 (default) otherwise.")
-    parser.add_argument("-d", "--derivatives", required=False, default=1,
-                        help="1: Include derivatives/labels content. 0: Do not include derivatives/labels content.")
+                        help="""Set np.random.RandomState to ensure reproducibility: the same
+                                subjects will be selected if the script is run several times on the
+                                same dataset. Set to -1 (default) otherwise.""",
+                        metavar=Metavar.int)
+    parser.add_argument("-d", "--exclude-derivatives",
+                        action="store_true",
+                        dest="exclude_derivatives",
+                        help="""If true, do not include derivatives/labels content.""")
     return parser
 
 
@@ -43,7 +48,8 @@ def remove_some_contrasts(folder, subject_list, good_contrast_list):
         os.remove(ff)
 
 
-def extract_small_dataset(input, output, n=10, contrast_list=None, include_derivatives=True, seed=-1):
+def extract_small_dataset(input, output, n=10, contrast_list=None, include_derivatives=True,
+                          seed=-1):
     """Extract small BIDS dataset from a larger BIDS dataset.
 
     Example::
@@ -138,7 +144,7 @@ def main():
     args = parser.parse_args()
     # Run script
     extract_small_dataset(args.input, args.output, int(args.number), args.contrasts.split(","),
-                          bool(int(args.derivatives)), int(args.seed))
+                          not bool(args.exclude_derivatives), int(args.seed))
 
 
 if __name__ == '__main__':

--- a/ivadomed/scripts/extract_small_dataset.py
+++ b/ivadomed/scripts/extract_small_dataset.py
@@ -25,10 +25,12 @@ def get_parser():
                                 subjects will be selected if the script is run several times on the
                                 same dataset. Set to -1 (default) otherwise.""",
                         metavar=imed_utils.Metavar.int)
-    parser.add_argument("-d", "--include-derivatives",
-                        action="store_true",
-                        dest="include_derivatives",
-                        help="""If true, include derivatives/labels content.""")
+    parser.add_argument("-d", "--derivatives",
+                        dest="derivatives",
+                        default=1,
+                        help="""If true, include derivatives/labels content.
+                                1 = true, 0 = false""",
+                        metavar=imed_utils.Metavar.int)
     return parser
 
 
@@ -150,7 +152,7 @@ def main(args=None):
         contrast_list = None
 
     extract_small_dataset(args.input, args.output, int(args.number), contrast_list,
-                          bool(args.include_derivatives), int(args.seed))
+                          bool(int(args.derivatives)), int(args.seed))
 
 
 if __name__ == '__main__':

--- a/ivadomed/scripts/extract_small_dataset.py
+++ b/ivadomed/scripts/extract_small_dataset.py
@@ -25,10 +25,10 @@ def get_parser():
                                 subjects will be selected if the script is run several times on the
                                 same dataset. Set to -1 (default) otherwise.""",
                         metavar=imed_utils.Metavar.int)
-    parser.add_argument("-d", "--exclude-derivatives",
+    parser.add_argument("-d", "--include-derivatives",
                         action="store_true",
-                        dest="exclude_derivatives",
-                        help="""If true, do not include derivatives/labels content.""")
+                        dest="include_derivatives",
+                        help="""If true, include derivatives/labels content.""")
     return parser
 
 
@@ -150,7 +150,7 @@ def main(args=None):
         contrast_list = None
 
     extract_small_dataset(args.input, args.output, int(args.number), contrast_list,
-                          not bool(args.exclude_derivatives), int(args.seed))
+                          bool(args.include_derivatives), int(args.seed))
 
 
 if __name__ == '__main__':

--- a/ivadomed/scripts/prepare_dataset_vertebral_labeling.py
+++ b/ivadomed/scripts/prepare_dataset_vertebral_labeling.py
@@ -1,5 +1,5 @@
 import argparse
-import ivadomed.utils as imed_utils
+from ivadomed.utils import init_ivadomed, Metavar
 import ivadomed.preprocessing as imed_preprocessing
 import nibabel as nib
 import numpy as np
@@ -50,7 +50,7 @@ def extract_mid_slice_and_convert_coordinates_to_heatmaps(path, suffix, aim=-1):
     Example::
 
         ivadomed_prepare_dataset_vertebral_labeling -p path/to/bids -s _T2w -a 0
-    
+
     Args:
         path (string): path to BIDS dataset form which images will be generated. Flag: ``--path``, ``-p``
         suffix (string): suffix of image that will be processed (e.g., T2w). Flag: ``--suffix``, ``-s``
@@ -94,17 +94,21 @@ def extract_mid_slice_and_convert_coordinates_to_heatmaps(path, suffix, aim=-1):
 def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--path", dest="path", required=True, type=str,
-                        help="Path to bids folder")
-    parser.add_argument("-s", "--suffix", dest="suffix", required=True,
-                        type=str, help="Suffix of the input file as in sub-xxxSUFFIX.nii.gz (E.g., _T2w)")
+                        help="Path to bids folder",
+                        metavar=Metavar.file)
+    parser.add_argument("-s", "--suffix", dest="suffix", required=True, type=str,
+                        help="""Suffix of the input file as in
+                                sub-xxxSUFFIX.nii.gz (E.g., _T2w)""",
+                        metavar=Metavar.str)
     parser.add_argument("-a", "--aim", dest="aim", default=-1, type=int,
-                        help="-1 or positive int. If set to any positive int,"
-                             " only label with this value will be taken into account ")
+                        help="""-1 or positive int. If set to any positive int,
+                                only label with this value will be taken into account""",
+                        metavar=Metavar.int)
     return parser
 
 
 def main():
-    imed_utils.init_ivadomed()
+    init_ivadomed()
 
     parser = get_parser()
     args = parser.parse_args()
@@ -114,5 +118,6 @@ def main():
     # Run Script
     extract_mid_slice_and_convert_coordinates_to_heatmaps(bids_path, suffix, aim)
 
-if __name__=='__main__':
+
+if __name__ == '__main__':
     main()

--- a/ivadomed/scripts/training_curve.py
+++ b/ivadomed/scripts/training_curve.py
@@ -22,15 +22,15 @@ def get_parser():
                                 path_log_dir1,path_logdir2.""",
                         metavar=Metavar.str)
     parser.add_argument("--multiple", required=False, dest="multiple", action='store_true',
-                        help="Multiple log directories are considered: all available folders with -i as "
-                             "prefix. The plot represents the mean value (hard line) surrounded by the standard "
-                             "deviation envelope.")
+                        help="""Multiple log directories are considered: all available folders
+                                with -i as prefix. The plot represents the mean value (hard line)
+                                surrounded by the standard deviation envelope.""")
     parser.add_argument("-y", "--ylim_loss", required=False, type=str,
                         help="""Indicates the limits on the y-axis for the loss plots, otherwise
                                 these limits are automatically defined. Please separate the lower
                                 and the upper limit by a comma, eg -1,0. Note: for the validation
                                 metrics: the y-limits are always 0.0 and 1.0.""",
-                        metavar=Metavar.str)
+                        metavar=Metavar.float)
     parser.add_argument("-o", "--output", required=True, type=str,
                         help="Output folder.", metavar=Metavar.file)
     return parser

--- a/ivadomed/scripts/training_curve.py
+++ b/ivadomed/scripts/training_curve.py
@@ -9,26 +9,30 @@ import matplotlib.pyplot as plt
 from textwrap import wrap
 from tensorboard.backend.event_processing.event_accumulator import EventAccumulator
 
-from ivadomed.utils import init_ivadomed
+from ivadomed.utils import init_ivadomed, Metavar
 
 
 def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("-i", "--input", required=True, type=str,
-                        help="Input log directory. If using --multiple, this parameter indicates the suffix path of all"
-                             " log directories of interest. To compare trainings or set of trainings (using "
-                             "``--multiple``) with subplots, please list the paths by separating them with commas, eg "
-                             "path_log_dir1,path_logdir2.")
+                        help="""Input log directory. If using --multiple, this parameter indicates
+                                the suffix path of all log directories of interest. To compare
+                                trainings or set of trainings (using ``--multiple``) with subplots,
+                                please list the paths by separating them with commas, eg
+                                path_log_dir1,path_logdir2.""",
+                        metavar=Metavar.str)
     parser.add_argument("--multiple", required=False, dest="multiple", action='store_true',
                         help="Multiple log directories are considered: all available folders with -i as "
                              "prefix. The plot represents the mean value (hard line) surrounded by the standard "
                              "deviation envelope.")
     parser.add_argument("-y", "--ylim_loss", required=False, type=str,
-                        help="Indicates the limits on the y-axis for the loss plots, otherwise these limits are "
-                             "automatically defined. Please separate the lower and the upper limit by a comma, eg -1,0."
-                             "Note: for the validation metrics: the y-limits are always 0.0 and 1.0.")
+                        help="""Indicates the limits on the y-axis for the loss plots, otherwise
+                                these limits are automatically defined. Please separate the lower
+                                and the upper limit by a comma, eg -1,0. Note: for the validation
+                                metrics: the y-limits are always 0.0 and 1.0.""",
+                        metavar=Metavar.str)
     parser.add_argument("-o", "--output", required=True, type=str,
-                        help="Output folder.")
+                        help="Output folder.", metavar=Metavar.file)
     return parser
 
 

--- a/ivadomed/scripts/visualize_transforms.py
+++ b/ivadomed/scripts/visualize_transforms.py
@@ -5,7 +5,6 @@ import argparse
 import nibabel as nib
 import numpy as np
 import random
-import json
 
 from ivadomed import config_manager as imed_config_manager
 from ivadomed.loader import utils as imed_loader_utils
@@ -17,14 +16,18 @@ from ivadomed import maths as imed_maths
 def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("-i", "--input", required=True,
-                        help="Input image filename.")
+                        help="Input image filename.",
+                        metavar=imed_utils.Metavar.file)
     parser.add_argument("-c", "--config", required=True,
-                        help="Config filename.")
+                        help="Config filename.",
+                        metavar=imed_utils.Metavar.file)
     parser.add_argument("-n", "--number", required=False, default=1,
-                        help="Number of random slices to visualize.")
+                        help="Number of random slices to visualize.",
+                        metavar=imed_utils.Metavar.int)
     parser.add_argument("-o", "--output", required=False, default="./",
-                        help="Output folder.")
-    parser.add_argument("-r", "--roi", required=False,
+                        help="Output folder.",
+                        metavar=imed_utils.Metavar.file)
+    parser.add_argument("-r", "--roi", required=False, metavar=imed_utils.Metavar.file,
                         help="ROI filename. Only required if ROICrop is part of the transformations.")
     return parser
 

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -1,12 +1,10 @@
 import logging
 import os
 import subprocess
-import joblib
-
 import matplotlib
 import matplotlib.pyplot as plt
 import torch
-import torch.nn as nn
+from enum import Enum
 
 AXIS_DCT = {'sagittal': 0, 'coronal': 1, 'axial': 2}
 
@@ -14,6 +12,20 @@ AXIS_DCT = {'sagittal': 0, 'coronal': 1, 'axial': 2}
 CLASSIFIER_LIST = ['resnet18', 'densenet121']
 
 logger = logging.getLogger(__name__)
+
+
+class Metavar(Enum):
+    """This class is used to display intuitive input types via the metavar field of argparse."""
+
+    file = "<file>"
+    str = "<str>"
+    folder = "<folder>"
+    int = "<int>"
+    list = "<list>"
+    float = "<float>"
+
+    def __str__(self):
+        return self.value
 
 
 def get_task(model_name):

--- a/testing/functional_tests/test_extract_small_dataset.py
+++ b/testing/functional_tests/test_extract_small_dataset.py
@@ -12,8 +12,7 @@ def setup_function():
 def test_extract_small_dataset_default_n():
     __output_dir__ = os.path.join(__tmp_dir__, 'output_extract_small_dataset')
     extract_small_dataset.main(args=['--input', __data_testing_dir__,
-                                     '--output', __output_dir__,
-                                     '-d'])
+                                     '--output', __output_dir__])
     assert os.path.exists(__output_dir__)
     output_dir_list = os.listdir(__output_dir__)
     assert 'derivatives' in output_dir_list
@@ -28,8 +27,7 @@ def test_extract_small_dataset_n_2():
     __output_dir__ = os.path.join(__tmp_dir__, 'output_extract_small_dataset_2')
     extract_small_dataset.main(args=['--input', __data_testing_dir__,
                                      '--output', __output_dir__,
-                                     '-n', '2',
-                                     '-d'])
+                                     '-n', '2'])
     assert os.path.exists(__output_dir__)
     output_dir_list = os.listdir(__output_dir__)
     assert 'derivatives' in output_dir_list
@@ -46,7 +44,8 @@ def test_extract_small_dataset_n_2():
 def test_extract_small_dataset_no_derivatives():
     __output_dir__ = os.path.join(__tmp_dir__, 'output_extract_small_dataset_3')
     extract_small_dataset.main(args=['--input', __data_testing_dir__,
-                                     '--output', __output_dir__])
+                                     '--output', __output_dir__,
+                                     '-d', '0'])
     assert os.path.exists(__output_dir__)
     output_dir_list = os.listdir(__output_dir__)
     assert 'derivatives' not in output_dir_list
@@ -61,8 +60,7 @@ def test_extract_small_dataset_contrast_list():
     __output_dir__ = os.path.join(__tmp_dir__, 'output_extract_small_dataset_4')
     extract_small_dataset.main(args=['--input', __data_testing_dir__,
                                      '--output', __output_dir__,
-                                     '-c', 'T1w, T2w',
-                                     '-d'])
+                                     '-c', 'T1w, T2w'])
     assert os.path.exists(__output_dir__)
     output_dir_list = os.listdir(__output_dir__)
     assert 'derivatives' in output_dir_list

--- a/testing/functional_tests/test_extract_small_dataset.py
+++ b/testing/functional_tests/test_extract_small_dataset.py
@@ -12,7 +12,8 @@ def setup_function():
 def test_extract_small_dataset_default_n():
     __output_dir__ = os.path.join(__tmp_dir__, 'output_extract_small_dataset')
     extract_small_dataset.main(args=['--input', __data_testing_dir__,
-                                     '--output', __output_dir__])
+                                     '--output', __output_dir__,
+                                     '-d'])
     assert os.path.exists(__output_dir__)
     output_dir_list = os.listdir(__output_dir__)
     assert 'derivatives' in output_dir_list
@@ -27,7 +28,8 @@ def test_extract_small_dataset_n_2():
     __output_dir__ = os.path.join(__tmp_dir__, 'output_extract_small_dataset_2')
     extract_small_dataset.main(args=['--input', __data_testing_dir__,
                                      '--output', __output_dir__,
-                                     '-n', '2'])
+                                     '-n', '2',
+                                     '-d'])
     assert os.path.exists(__output_dir__)
     output_dir_list = os.listdir(__output_dir__)
     assert 'derivatives' in output_dir_list
@@ -44,8 +46,7 @@ def test_extract_small_dataset_n_2():
 def test_extract_small_dataset_no_derivatives():
     __output_dir__ = os.path.join(__tmp_dir__, 'output_extract_small_dataset_3')
     extract_small_dataset.main(args=['--input', __data_testing_dir__,
-                                     '--output', __output_dir__,
-                                     '-d', '0'])
+                                     '--output', __output_dir__])
     assert os.path.exists(__output_dir__)
     output_dir_list = os.listdir(__output_dir__)
     assert 'derivatives' not in output_dir_list
@@ -60,7 +61,8 @@ def test_extract_small_dataset_contrast_list():
     __output_dir__ = os.path.join(__tmp_dir__, 'output_extract_small_dataset_4')
     extract_small_dataset.main(args=['--input', __data_testing_dir__,
                                      '--output', __output_dir__,
-                                     '-c', 'T1w, T2w'])
+                                     '-c', 'T1w, T2w',
+                                     '-d'])
     assert os.path.exists(__output_dir__)
     output_dir_list = os.listdir(__output_dir__)
     assert 'derivatives' in output_dir_list


### PR DESCRIPTION
## Description
This pull request adds a class called `Metavar` to `ivadomed.utils`. This class defines different input types for command line arguments. All of the command line tools have been updated to implement this class. The purpose is to give users a better idea of what the input type should be.

For example, in `ivadomed_automate_training`:
```
usage: ivadomed_automate_training [-h] -c <file> -p <file> [-n <int>] [--all-combin] [-m] [--run-test]
                                  [--fixed-split] [-l] [-t <float>]

optional arguments:
  -h, --help            show this help message and exit
  -c <file>, --config <file>
                        Base config file path.
  -p <file>, --params <file>
                        JSON file where hyperparameters to experiment are listed.
  -n <int>, --n-iterations <int>
                        Number of times to run each config.
  --all-combin          To run all combinations of config
  -m, --multi-params    To change multiple parameters at once.
  --run-test            Evaluate the trained model on the testing sub-set.
  --fixed-split         Keep a constant dataset split for all configs and iterations
  -l, --all-logs        Keep all log directories for each iteration.
  -t <float>, --thr-increment <float>
                        A threshold analysis is performed at the end of the training using the trained model
                        and the validation sub-dataset to find the optimal binarization threshold. The
                        specified value indicates the increment between 0 and 1 used during the analysis (e.g.
                        0.1).
```



## Linked issues
https://github.com/ivadomed/ivadomed/issues/627
