### PR TITLE
Standardize the gpu ID argument

### DIFF
--- a/docs/source/configuration_file.rst
+++ b/docs/source/configuration_file.rst
@@ -29,10 +29,10 @@ sub-datasets, ``"test"``: evaluate a trained model on a testing sub-dataset, ``"
 segment a entire dataset using a trained model.
 
 
-gpu
-^^^
+gpu_ids
+^^^^^^^
 
-Integer. ID of the GPU to use.
+``List`` ``Integer``. List of IDs of one or more GPUs to use.
 
 log\_directory
 ^^^^^^^^^^^^^^
@@ -152,9 +152,9 @@ below.
 -  ``filter_absent_class``: Bool. Discard slices where all voxel
    labels are zero for one or more classes (this is most relevant for
    multi-class models that need GT for all classes at train time).
--  ``filter_classification``: Bool. Discard slices where all images fail 
+-  ``filter_classification``: Bool. Discard slices where all images fail
    a custom classifier filter. If used, ``classifier_path`` must also be
-   specified, pointing to a saved PyTorch classifier. 
+   specified, pointing to a saved PyTorch classifier.
 
 roi
 ^^^

--- a/docs/source/configuration_file.rst
+++ b/docs/source/configuration_file.rst
@@ -32,7 +32,10 @@ segment a entire dataset using a trained model.
 gpu_ids
 ^^^^^^^
 
-``List`` ``Integer``. List of IDs of one or more GPUs to use.
+``list`` ``integer``: List of IDs of one or more GPUs to use.
+
+.. note::
+    Currently only ``ivadomed_automate_training`` supports the use of more than one GPU.
 
 log\_directory
 ^^^^^^^^^^^^^^

--- a/ivadomed/config/config.json
+++ b/ivadomed/config/config.json
@@ -1,6 +1,6 @@
 {
     "command": "train",
-    "gpu": 0,
+    "gpu_ids": [0],
     "log_directory": "spineGeneric",
     "model_name": "my_model",
     "debugging": false,

--- a/ivadomed/config/config_classification.json
+++ b/ivadomed/config/config_classification.json
@@ -1,6 +1,6 @@
 {
     "command": "train",
-    "gpu": 6,
+    "gpu_ids": [6],
     "log_directory": "classification_lesion_ax",
     "model_name": "label_lesion_t2_t2star",
     "debugging": false,

--- a/ivadomed/config/config_default.json
+++ b/ivadomed/config/config_default.json
@@ -1,6 +1,6 @@
 {
     "command": "train",
-    "gpu": 0,
+    "gpu_ids": [0],
     "log_directory": "log_directory",
     "model_name": "my_model",
     "debugging": false,

--- a/ivadomed/config/config_new_loader.json
+++ b/ivadomed/config/config_new_loader.json
@@ -1,6 +1,6 @@
 {
     "command": "train",
-    "gpu": 0,
+    "gpu_ids": [0],
     "log_directory": "log_directory/new_loader",
     "model_name": "model_name",
     "debugging": true,

--- a/ivadomed/config/config_sctTesting.json
+++ b/ivadomed/config/config_sctTesting.json
@@ -1,6 +1,6 @@
 {
     "command": "train",
-    "gpu": 6,
+    "gpu_ids": [6],
     "log_directory": "sct_testing_lesion_ax",
     "model_name": "seg_lesion_t2_t2star",
     "debugging": false,

--- a/ivadomed/config/config_small.json
+++ b/ivadomed/config/config_small.json
@@ -1,6 +1,6 @@
 {
     "command": "test",
-    "gpu": 2,
+    "gpu_ids": [2],
     "log_directory": "spineGeneric_small",
     "model_name": "seg_sc_t2star",
     "debugging": false,

--- a/ivadomed/config/config_spineGeHemis.json
+++ b/ivadomed/config/config_spineGeHemis.json
@@ -1,6 +1,6 @@
 {
     "command": "train",
-    "gpu": 0,
+    "gpu_ids": [0],
     "log_directory": "HeMIS",
     "model_name": "seg_tumor_t2_t1",
     "debugging": false,

--- a/ivadomed/config/config_tumorSeg.json
+++ b/ivadomed/config/config_tumorSeg.json
@@ -1,6 +1,6 @@
 {
     "command": "train",
-    "gpu": 0,
+    "gpu_ids": [0],
     "log_directory": "tumor_segmentation",
     "model_name": "seg_tumor_t2",
     "debugging": true,

--- a/ivadomed/config/config_vertebral_labeling.json
+++ b/ivadomed/config/config_vertebral_labeling.json
@@ -1,6 +1,6 @@
 {
     "command": "train",
-    "gpu": 7,
+    "gpu_ids": [7],
     "log_directory": "labeling_t2test",
     "model_name": "find_disc_t1",
     "debugging": true,

--- a/ivadomed/inference.py
+++ b/ivadomed/inference.py
@@ -95,7 +95,7 @@ def pred_to_nib(data_lst, z_lst, fname_ref, fname_out, slice_axis, debug=False, 
     return nib_pred
 
 
-def segment_volume(folder_model, fname_images, gpu_number=0, options=None):
+def segment_volume(folder_model, fname_images, gpu_id=0, options=None):
     """Segment an image.
     Segment an image (`fname_image`) using a pre-trained model (`folder_model`). If provided, a region of interest
     (`fname_roi`) is used to crop the image prior to segment it.
@@ -106,7 +106,7 @@ def segment_volume(folder_model, fname_images, gpu_number=0, options=None):
             see https://github.com/neuropoly/ivadomed/wiki/configuration-file
         fname_images (list): list of image filenames (e.g. .nii.gz) to segment. Multichannel models require multiple
             images to segment, e.i., len(fname_images) > 1.
-        gpu_number (int): Number representing gpu number if available.
+        gpu_id (int): Number representing gpu number if available.
         options (dict): Contains postprocessing steps and prior filename (fname_prior) which is an image filename
             (e.g., .nii.gz) containing processing information (e.i., spinal cord segmentation, spinal location or MS
             lesion classification)
@@ -119,7 +119,7 @@ def segment_volume(folder_model, fname_images, gpu_number=0, options=None):
     """
     # Define device
     cuda_available = torch.cuda.is_available()
-    device = torch.device("cpu") if not cuda_available else torch.device("cuda:" + str(gpu_number))
+    device = torch.device("cpu") if not cuda_available else torch.device("cuda:" + str(gpu_id))
 
     # Check if model folder exists and get filenames
     fname_model, fname_model_metadata = imed_models.get_model_filenames(folder_model)
@@ -302,7 +302,7 @@ def segment_volume(folder_model, fname_images, gpu_number=0, options=None):
 
 def split_classes(nib_prediction):
     """Split a 4D nibabel multi-class segmentation file in multiple 3D nibabel binary segmentation files.
-    
+
     Args:
         nib_prediction (nibabelObject): 4D nibabel object.
     Returns:

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -372,7 +372,7 @@ def run_command(context, n_gif=0, thr_increment=None, resume_training=False):
                 options = {'metadata': metadata}
             pred_list, target_list = imed_inference.segment_volume(path_model,
                                                                    fname_images=fname_img,
-                                                                   gpu_number=context['gpu'][0],
+                                                                   gpu_id=context['gpu'][0],
                                                                    options=options)
             pred_path = os.path.join(context['log_directory'], "pred_masks")
             if not os.path.exists(pred_path):

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -105,7 +105,7 @@ def run_command(context, n_gif=0, thr_increment=None, resume_training=False):
     create_dataset_and_ivadomed_version_log(context)
 
     # Define device
-    cuda_available, device = imed_utils.define_device(context['gpu'][0])
+    cuda_available, device = imed_utils.define_device(context['gpu_ids'][0])
 
     # Get subject lists. "segment" command uses all participants of BIDS path, hence no need to split
     if command != "segment":
@@ -167,7 +167,7 @@ def run_command(context, n_gif=0, thr_increment=None, resume_training=False):
     # Update loader params
     if 'object_detection_params' in context:
         object_detection_params = context['object_detection_params']
-        object_detection_params.update({"gpu": context['gpu'][0],
+        object_detection_params.update({"gpu_ids": context['gpu_ids'][0],
                                         "log_directory": context['log_directory']})
         loader_params.update({"object_detection_params": object_detection_params})
 
@@ -372,7 +372,7 @@ def run_command(context, n_gif=0, thr_increment=None, resume_training=False):
                 options = {'metadata': metadata}
             pred_list, target_list = imed_inference.segment_volume(path_model,
                                                                    fname_images=fname_img,
-                                                                   gpu_id=context['gpu'][0],
+                                                                   gpu_id=context['gpu_ids'][0],
                                                                    options=options)
             pred_path = os.path.join(context['log_directory'], "pred_masks")
             if not os.path.exists(pred_path):

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -105,7 +105,7 @@ def run_command(context, n_gif=0, thr_increment=None, resume_training=False):
     create_dataset_and_ivadomed_version_log(context)
 
     # Define device
-    cuda_available, device = imed_utils.define_device(context['gpu'])
+    cuda_available, device = imed_utils.define_device(context['gpu'][0])
 
     # Get subject lists. "segment" command uses all participants of BIDS path, hence no need to split
     if command != "segment":
@@ -167,7 +167,7 @@ def run_command(context, n_gif=0, thr_increment=None, resume_training=False):
     # Update loader params
     if 'object_detection_params' in context:
         object_detection_params = context['object_detection_params']
-        object_detection_params.update({"gpu": context['gpu'],
+        object_detection_params.update({"gpu": context['gpu'][0],
                                         "log_directory": context['log_directory']})
         loader_params.update({"object_detection_params": object_detection_params})
 
@@ -372,7 +372,7 @@ def run_command(context, n_gif=0, thr_increment=None, resume_training=False):
                 options = {'metadata': metadata}
             pred_list, target_list = imed_inference.segment_volume(path_model,
                                                                    fname_images=fname_img,
-                                                                   gpu_number=context['gpu'],
+                                                                   gpu_number=context['gpu'][0],
                                                                    options=options)
             pred_path = os.path.join(context['log_directory'], "pred_masks")
             if not os.path.exists(pred_path):

--- a/ivadomed/object_detection/utils.py
+++ b/ivadomed/object_detection/utils.py
@@ -86,7 +86,7 @@ def resize_to_multiple(shape, multiple, length):
     return new_dim
 
 
-def generate_bounding_box_file(subject_list, model_path, log_dir, gpu_number=0, slice_axis=0, contrast_lst=None,
+def generate_bounding_box_file(subject_list, model_path, log_dir, gpu_id=0, slice_axis=0, contrast_lst=None,
                                keep_largest_only=True, safety_factor=None):
     """Creates json file containing the bounding box dimension for each images. The file has the following format:
     {"path/to/img.nii.gz": [[x1_min, x1_max, y1_min, y1_max, z1_min, z1_max],
@@ -97,7 +97,7 @@ def generate_bounding_box_file(subject_list, model_path, log_dir, gpu_number=0, 
         subject_list (list): List of all subjects in the BIDS directory.
         model_path (string): Path to object detection model.
         log_dir (string): Log directory.
-        gpu_number (int): If available, GPU number.
+        gpu_id (int): If available, GPU number.
         slice_axis (int): Slice axis (0: sagittal, 1: coronal, 2: axial).
         contrast_lst (list): Contrasts.
         keep_largest_only (bool): Boolean representing if only the largest object of the prediction is kept.
@@ -113,7 +113,7 @@ def generate_bounding_box_file(subject_list, model_path, log_dir, gpu_number=0, 
     for subject in subject_list:
         if subject.record["modality"] in contrast_lst:
             subject_path = str(subject.record["absolute_path"])
-            object_mask, _ = imed_inference.segment_volume(model_path, [subject_path], gpu_number=gpu_number)
+            object_mask, _ = imed_inference.segment_volume(model_path, [subject_path], gpu_id=gpu_id)
             object_mask = object_mask[0]
             if keep_largest_only:
                 object_mask = imed_postpro.keep_largest_object(object_mask)

--- a/ivadomed/scripts/automate_training.py
+++ b/ivadomed/scripts/automate_training.py
@@ -73,7 +73,7 @@ def train_worker(config, thr_incr):
     ID = int(current.name[-1]) - 1
 
     # Use GPU i from the array specified in the config file
-    config["gpu_ids"] = config["gpu_ids"][ID]
+    config["gpu_ids"] = [config["gpu_ids"][ID]]
 
     # Call ivado cmd_train
     try:
@@ -102,7 +102,7 @@ def test_worker(config):
     ID = int(current.name[-1]) - 1
 
     # Use GPU i from the array specified in the config file
-    config["gpu_ids"] = config["gpu_ids"][ID]
+    config["gpu_ids"] = [config["gpu_ids"][ID]]
 
     try:
         # Save best test score
@@ -290,6 +290,8 @@ def automate_training(config, param, fixed_split, all_combin, n_iterations=1, ru
     ctx = mp.get_context("spawn")
 
     # Run all configs on a separate process, with a maximum of n_gpus  processes at a given time
+    print(initial_config['gpu_ids'])
+
     pool = ctx.Pool(processes=len(initial_config["gpu_ids"]))
     results_df = pd.DataFrame()
     eval_df = pd.DataFrame()

--- a/ivadomed/scripts/automate_training.py
+++ b/ivadomed/scripts/automate_training.py
@@ -83,7 +83,7 @@ def train_worker(config, thr_incr):
 
     except Exception:
         logging.exception('Got exception on main handler')
-        print("Unexpected error:", sys.exc_info()[0])
+        logging.info("Unexpected error:", sys.exc_info()[0])
         raise
 
     # Save config file in log directory
@@ -111,7 +111,7 @@ def test_worker(config):
 
     except Exception:
         logging.exception('Got exception on main handler')
-        print("Unexpected error:", sys.exc_info()[0])
+        logging.info("Unexpected error:", sys.exc_info()[0])
         raise
 
     return config["log_directory"], test_dice, df_results
@@ -290,93 +290,88 @@ def automate_training(config, param, fixed_split, all_combin, n_iterations=1, ru
     ctx = mp.get_context("spawn")
 
     # Run all configs on a separate process, with a maximum of n_gpus  processes at a given time
-    print(initial_config['gpu_ids'])
+    logging.info(initial_config['gpu_ids'])
 
-    pool = ctx.Pool(processes=len(initial_config["gpu_ids"]))
     results_df = pd.DataFrame()
     eval_df = pd.DataFrame()
     all_mean = pd.DataFrame()
-    for i in range(n_iterations):
-        if not fixed_split:
-            # Set seed for iteration
-            seed = random.randint(1, 10001)
-            for config in config_list:
-                config["split_dataset"]["random_seed"] = seed
-                if all_logs:
-                    if i:
-                        config["log_directory"] = config["log_directory"].replace("_n=" + str(i - 1).zfill(2),
-                                                                                  "_n=" + str(i).zfill(2))
-                    else:
-                        config["log_directory"] += "_n=" + str(i).zfill(2)
-        try:
-            validation_scores = pool.map(partial(train_worker, thr_incr=thr_increment), config_list)
-        except Exception:
-            pool.close()
-            raise Exception('Training failed')
-        val_df = pd.DataFrame(validation_scores, columns=[
-            'log_directory', 'best_training_dice', 'best_training_loss', 'best_validation_dice',
-            'best_validation_loss'])
 
-        if run_test:
-            new_config_list = []
-            for config in config_list:
-                # Delete path_pred
-                path_pred = os.path.join(config['log_directory'], 'pred_masks')
-                if os.path.isdir(path_pred) and n_iterations > 1:
-                    try:
-                        shutil.rmtree(path_pred)
-                    except OSError as e:
-                        print("Error: %s - %s." % (e.filename, e.strerror))
+    with ctx.Pool(processes=len(initial_config["gpu_ids"])) as pool:
+        for i in range(n_iterations):
+            if not fixed_split:
+                # Set seed for iteration
+                seed = random.randint(1, 10001)
+                for config in config_list:
+                    config["split_dataset"]["random_seed"] = seed
+                    if all_logs:
+                        if i:
+                            config["log_directory"] = config["log_directory"].replace("_n=" + str(i - 1).zfill(2),
+                                                                                      "_n=" + str(i).zfill(2))
+                        else:
+                            config["log_directory"] += "_n=" + str(i).zfill(2)
 
-                # Take the config file within the log_directory because binarize_prediction may have been updated
-                json_path = os.path.join(config['log_directory'], 'config_file.json')
-                new_config = imed_config_manager.ConfigurationManager(json_path).get_config()
-                new_config["gpu_ids"] = config["gpu_ids"]
-                new_config_list.append(new_config)
+                validation_scores = pool.map(partial(train_worker, thr_incr=thr_increment), config_list)
 
-            try:
+            val_df = pd.DataFrame(validation_scores, columns=[
+                'log_directory', 'best_training_dice', 'best_training_loss', 'best_validation_dice',
+                'best_validation_loss'])
+
+            if run_test:
+                new_config_list = []
+                for config in config_list:
+                    # Delete path_pred
+                    path_pred = os.path.join(config['log_directory'], 'pred_masks')
+                    if os.path.isdir(path_pred) and n_iterations > 1:
+                        try:
+                            shutil.rmtree(path_pred)
+                        except OSError as e:
+                            logging.info("Error: %s - %s." % (e.filename, e.strerror))
+
+                    # Take the config file within the log_directory because binarize_prediction may have been updated
+                    json_path = os.path.join(config['log_directory'], 'config_file.json')
+                    new_config = imed_config_manager.ConfigurationManager(json_path).get_config()
+                    new_config["gpu_ids"] = config["gpu_ids"]
+                    new_config_list.append(new_config)
+
                 test_results = pool.map(test_worker, new_config_list)
-            except Exception:
-                pool.close()
-                raise Exception("Testing failed")
 
-            df_lst = []
-            # Merge all eval df together to have a single excel file
-            for j, result in enumerate(test_results):
-                df = result[-1]
+                df_lst = []
+                # Merge all eval df together to have a single excel file
+                for j, result in enumerate(test_results):
+                    df = result[-1]
 
-                if i == 0:
-                    all_mean = df.mean(axis=0)
-                    std_metrics = df.std(axis=0)
-                    metrics = pd.concat([all_mean, std_metrics], sort=False, axis=1)
-                else:
-                    all_mean = pd.concat([all_mean, df.mean(axis=0)], sort=False, axis=1)
-                    mean_metrics = all_mean.mean(axis=1)
-                    std_metrics = all_mean.std(axis=1)
-                    metrics = pd.concat([mean_metrics, std_metrics], sort=False, axis=1)
+                    if i == 0:
+                        all_mean = df.mean(axis=0)
+                        std_metrics = df.std(axis=0)
+                        metrics = pd.concat([all_mean, std_metrics], sort=False, axis=1)
+                    else:
+                        all_mean = pd.concat([all_mean, df.mean(axis=0)], sort=False, axis=1)
+                        mean_metrics = all_mean.mean(axis=1)
+                        std_metrics = all_mean.std(axis=1)
+                        metrics = pd.concat([mean_metrics, std_metrics], sort=False, axis=1)
 
-                metrics.rename({0: "mean"}, axis=1, inplace=True)
-                metrics.rename({1: "std"}, axis=1, inplace=True)
-                id = result[0].split("_n=")[0]
-                cols = metrics.columns.values
-                for idx, col in enumerate(cols):
-                    metrics.rename({col: col + "_" + id}, axis=1, inplace=True)
-                df_lst.append(metrics)
-                test_results[j] = result[:2]
+                    metrics.rename({0: "mean"}, axis=1, inplace=True)
+                    metrics.rename({1: "std"}, axis=1, inplace=True)
+                    id = result[0].split("_n=")[0]
+                    cols = metrics.columns.values
+                    for idx, col in enumerate(cols):
+                        metrics.rename({col: col + "_" + id}, axis=1, inplace=True)
+                    df_lst.append(metrics)
+                    test_results[j] = result[:2]
 
-            # Init or add eval results to dataframe
-            eval_df = pd.concat(df_lst, sort=False, axis=1)
+                # Init or add eval results to dataframe
+                eval_df = pd.concat(df_lst, sort=False, axis=1)
 
-            test_df = pd.DataFrame(test_results, columns=['log_directory', 'test_dice'])
-            combined_df = val_df.set_index('log_directory').join(test_df.set_index('log_directory'))
-            combined_df = combined_df.reset_index()
+                test_df = pd.DataFrame(test_results, columns=['log_directory', 'test_dice'])
+                combined_df = val_df.set_index('log_directory').join(test_df.set_index('log_directory'))
+                combined_df = combined_df.reset_index()
 
-        else:
-            combined_df = val_df
+            else:
+                combined_df = val_df
 
-        results_df = pd.concat([results_df, combined_df])
-        results_df.to_csv(os.path.join(output_dir, "temporary_results.csv"))
-        eval_df.to_csv(os.path.join(output_dir, "average_eval.csv"))
+            results_df = pd.concat([results_df, combined_df])
+            results_df.to_csv(os.path.join(output_dir, "temporary_results.csv"))
+            eval_df.to_csv(os.path.join(output_dir, "average_eval.csv"))
 
     # Merge config and results in a df
     config_df = pd.DataFrame.from_dict(config_list)
@@ -390,8 +385,8 @@ def automate_training(config, param, fixed_split, all_combin, n_iterations=1, ru
 
     results_df.to_csv(os.path.join(output_dir, "detailed_results.csv"))
 
-    print("Detailed results")
-    print(results_df)
+    logging.info("Detailed results")
+    logging.info(results_df)
 
     # Compute avg, std, p-values
     if n_iterations > 1:

--- a/ivadomed/scripts/automate_training.py
+++ b/ivadomed/scripts/automate_training.py
@@ -63,7 +63,7 @@ def train_worker(config, thr_incr):
     ID = int(current.name[-1]) - 1
 
     # Use GPU i from the array specified in the config file
-    config["gpu"] = config["gpu"][ID]
+    config["gpu_ids"] = config["gpu_ids"][ID]
 
     # Call ivado cmd_train
     try:
@@ -91,7 +91,7 @@ def test_worker(config):
     ID = int(current.name[-1]) - 1
 
     # Use GPU i from the array specified in the config file
-    config["gpu"] = config["gpu"][ID]
+    config["gpu_ids"] = config["gpu_ids"][ID]
 
     try:
         # Save best test score
@@ -265,7 +265,7 @@ def automate_training(config, param, fixed_split, all_combin, n_iterations=1, ru
     mp.set_start_method('spawn')
 
     # Run all configs on a separate process, with a maximum of n_gpus  processes at a given time
-    pool = mp.Pool(processes=len(initial_config["gpu"]))
+    pool = mp.Pool(processes=len(initial_config["gpu_ids"]))
 
     results_df = pd.DataFrame()
     eval_df = pd.DataFrame()
@@ -301,7 +301,7 @@ def automate_training(config, param, fixed_split, all_combin, n_iterations=1, ru
                 # Take the config file within the log_directory because binarize_prediction may have been updated
                 json_path = os.path.join(config['log_directory'], 'config_file.json')
                 new_config = imed_config_manager.ConfigurationManager(json_path).get_config()
-                new_config["gpu"] = config["gpu"]
+                new_config["gpu_ids"] = config["gpu_ids"]
                 new_config_list.append(new_config)
 
             test_results = pool.map(test_worker, new_config_list)

--- a/ivadomed/scripts/convert_to_onnx.py
+++ b/ivadomed/scripts/convert_to_onnx.py
@@ -11,7 +11,8 @@ def get_parser():
                         type=int, help="Input dimension (2 for 2D inputs, 3 for 3D inputs).")
     parser.add_argument("-n", "--n_channels", dest="n_channels", default=1, type=int,
                         help="Number of input channels of the model.")
-    parser.add_argument("-g", "--gpu", dest="gpu", default=0, type=str, help="GPU number if available.")
+    parser.add_argument("-g", "--gpu", dest="gpu", default=[0], type=list,
+                        help="GPU ID to use, if available.")
     return parser
 
 
@@ -48,7 +49,8 @@ def main():
     args = parser.parse_args()
     fname_model = args.model
     dimension = int(args.dimension)
-    gpu = str(args.gpu)
+    gpu = list(args.gpu)
+    gpu = str(gpu[0])
     n_channels = args.n_channels
     # Run Script
     convert_pytorch_to_onnx(fname_model, dimension, n_channels, gpu)

--- a/ivadomed/scripts/convert_to_onnx.py
+++ b/ivadomed/scripts/convert_to_onnx.py
@@ -11,12 +11,12 @@ def get_parser():
                         type=int, help="Input dimension (2 for 2D inputs, 3 for 3D inputs).")
     parser.add_argument("-n", "--n_channels", dest="n_channels", default=1, type=int,
                         help="Number of input channels of the model.")
-    parser.add_argument("-g", "--gpu", dest="gpu", default=0, type=str,
+    parser.add_argument("-g", "--gpu_id", dest="gpu_id", default=0, type=str,
                         help="GPU ID to use, if available.")
     return parser
 
 
-def convert_pytorch_to_onnx(model, dimension, n_channels, gpu=0):
+def convert_pytorch_to_onnx(model, dimension, n_channels, gpu_id=0):
     """Convert PyTorch model to ONNX.
 
     The integration of Deep Learning models into the clinical routine requires cpu optimized models. To export the
@@ -29,10 +29,10 @@ def convert_pytorch_to_onnx(model, dimension, n_channels, gpu=0):
     Args:
         model (string): Model filename. Flag: ``--model``, ``-m``.
         dimension (int): Indicates whether the model is 2D or 3D. Choice between 2 or 3. Flag: ``--dimension``, ``-d``
-        gpu (string): GPU ID, if available. Flag: ``--gpu``, ``-g``
+        gpu_id (string): GPU ID, if available. Flag: ``--gpu_id``, ``-g``
     """
     if torch.cuda.is_available():
-        device = "cuda:" + str(gpu)
+        device = "cuda:" + str(gpu_id)
     else:
         device = "cpu"
 
@@ -49,10 +49,10 @@ def main():
     args = parser.parse_args()
     fname_model = args.model
     dimension = int(args.dimension)
-    gpu = str(args.gpu)
+    gpu_id = str(args.gpu_id)
     n_channels = args.n_channels
     # Run Script
-    convert_pytorch_to_onnx(fname_model, dimension, n_channels, gpu)
+    convert_pytorch_to_onnx(fname_model, dimension, n_channels, gpu_id)
 
 
 if __name__ == '__main__':

--- a/ivadomed/scripts/convert_to_onnx.py
+++ b/ivadomed/scripts/convert_to_onnx.py
@@ -11,7 +11,7 @@ def get_parser():
                         type=int, help="Input dimension (2 for 2D inputs, 3 for 3D inputs).")
     parser.add_argument("-n", "--n_channels", dest="n_channels", default=1, type=int,
                         help="Number of input channels of the model.")
-    parser.add_argument("-g", "--gpu", dest="gpu", default=[0], type=list,
+    parser.add_argument("-g", "--gpu", dest="gpu", default=0, type=str,
                         help="GPU ID to use, if available.")
     return parser
 
@@ -49,8 +49,7 @@ def main():
     args = parser.parse_args()
     fname_model = args.model
     dimension = int(args.dimension)
-    gpu = list(args.gpu)
-    gpu = str(gpu[0])
+    gpu = str(args.gpu)
     n_channels = args.n_channels
     # Run Script
     convert_pytorch_to_onnx(fname_model, dimension, n_channels, gpu)

--- a/ivadomed/scripts/download_data.py
+++ b/ivadomed/scripts/download_data.py
@@ -39,7 +39,7 @@ DICT_URL = {
         "url": ["https://github.com/ivadomed/model_find_disc_t2/archive/r20200928.zip"],
         "description": "Intervertebral disc detection model trained on T2-weighted images."},
     "data_functional_testing": {
-        "url": ["https://github.com/ivadomed/data_functional_testing/archive/r20210112.zip"],
+        "url": ["https://github.com/ivadomed/data_functional_testing/archive/r20210119.zip"],
         "description": "Data used for functional testing in Ivadomed."
     }
 

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -90,9 +90,9 @@ def define_device(gpu_id):
         print("Working on {}.".format(device))
     if cuda_available:
         # Set the GPU
-        gpu_number = int(gpu_id)
-        torch.cuda.set_device(gpu_number)
-        print("Using GPU number {}".format(gpu_number))
+        gpu_id = int(gpu_id)
+        torch.cuda.set_device(gpu_id)
+        print(f"Using GPU ID {gpu_id}")
     return cuda_available, device
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,3 @@ torch==1.5.0
 torchvision==0.6.0
 tqdm>=4.30
 pytest-ordering
-pytest-console-scripts

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ torch==1.5.0
 torchvision==0.6.0
 tqdm>=4.30
 pytest-ordering
+pytest-console-scripts

--- a/testing/functional_tests/test_automate_training.py
+++ b/testing/functional_tests/test_automate_training.py
@@ -1,7 +1,7 @@
 import logging
 import os
+import pytest
 from functional_tests.t_utils import remove_tmp_dir, __tmp_dir__, create_tmp_dir, __data_testing_dir__
-from ivadomed.scripts import automate_training
 logger = logging.getLogger(__name__)
 
 
@@ -9,32 +9,38 @@ def setup_function():
     create_tmp_dir()
 
 
-def test_automate_training():
+@pytest.mark.script_launch_mode('subprocess')
+def test_automate_training(script_runner):
     config_file = os.path.join(__data_testing_dir__, 'automate_training_config.json')
     param_file = os.path.join(__data_testing_dir__,
                               'automate_training_hyperparameter_opt.json')
     __output_dir__ = os.path.join(__tmp_dir__, 'results')
-    automate_training.main(args=[
-        '--config', f'{config_file}',
-        '--params', f'{param_file}',
-        '--output_dir', f'{__output_dir__}'
-    ])
+
+    ret = script_runner.run('ivadomed_automate_training', '--config', f'{config_file}',
+                            '--params', f'{param_file}',
+                            '--output_dir', f'{__output_dir__}')
+    print(f"{ret.stdout}")
+    print(f"{ret.stderr}")
+    assert ret.success
     assert os.path.exists(os.path.join(__output_dir__, 'detailed_results.csv'))
     assert os.path.exists(os.path.join(__output_dir__, 'temporary_results.csv'))
     assert os.path.exists(os.path.join(__output_dir__, 'average_eval.csv'))
 
 
-def test_automate_training_run_test():
+@pytest.mark.script_launch_mode('subprocess')
+def test_automate_training_run_test(script_runner):
     config_file = os.path.join(__data_testing_dir__, 'automate_training_config.json')
     param_file = os.path.join(__data_testing_dir__,
                               'automate_training_hyperparameter_opt.json')
     __output_dir__ = os.path.join(__tmp_dir__, 'results')
-    automate_training.main(args=[
-        '--config', f'{config_file}',
-        '--params', f'{param_file}',
-        '--output_dir', f'{__output_dir__}',
-        '--run-test'
-    ])
+
+    ret = script_runner.run('ivadomed_automate_training', '--config', f'{config_file}',
+                            '--params', f'{param_file}',
+                            '--output_dir', f'{__output_dir__}',
+                            '--run-test')
+    print(f"{ret.stdout}")
+    print(f"{ret.stderr}")
+    assert ret.success
     assert os.path.exists(os.path.join(__output_dir__, 'detailed_results.csv'))
     assert os.path.exists(os.path.join(__output_dir__, 'temporary_results.csv'))
     assert os.path.exists(os.path.join(__output_dir__, 'average_eval.csv'))

--- a/testing/functional_tests/test_automate_training.py
+++ b/testing/functional_tests/test_automate_training.py
@@ -1,7 +1,7 @@
 import logging
 import os
-import pytest
 from functional_tests.t_utils import remove_tmp_dir, __tmp_dir__, create_tmp_dir, __data_testing_dir__
+from ivadomed.scripts import automate_training
 logger = logging.getLogger(__name__)
 
 
@@ -9,38 +9,16 @@ def setup_function():
     create_tmp_dir()
 
 
-@pytest.mark.script_launch_mode('subprocess')
-def test_automate_training(script_runner):
+def test_automate_training():
     config_file = os.path.join(__data_testing_dir__, 'automate_training_config.json')
     param_file = os.path.join(__data_testing_dir__,
                               'automate_training_hyperparameter_opt.json')
     __output_dir__ = os.path.join(__tmp_dir__, 'results')
-
-    ret = script_runner.run('ivadomed_automate_training', '--config', f'{config_file}',
-                            '--params', f'{param_file}',
-                            '--output_dir', f'{__output_dir__}')
-    print(f"{ret.stdout}")
-    print(f"{ret.stderr}")
-    assert ret.success
-    assert os.path.exists(os.path.join(__output_dir__, 'detailed_results.csv'))
-    assert os.path.exists(os.path.join(__output_dir__, 'temporary_results.csv'))
-    assert os.path.exists(os.path.join(__output_dir__, 'average_eval.csv'))
-
-
-@pytest.mark.script_launch_mode('subprocess')
-def test_automate_training_run_test(script_runner):
-    config_file = os.path.join(__data_testing_dir__, 'automate_training_config.json')
-    param_file = os.path.join(__data_testing_dir__,
-                              'automate_training_hyperparameter_opt.json')
-    __output_dir__ = os.path.join(__tmp_dir__, 'results')
-
-    ret = script_runner.run('ivadomed_automate_training', '--config', f'{config_file}',
-                            '--params', f'{param_file}',
-                            '--output_dir', f'{__output_dir__}',
-                            '--run-test')
-    print(f"{ret.stdout}")
-    print(f"{ret.stderr}")
-    assert ret.success
+    automate_training.main(args=[
+        '--config', f'{config_file}',
+        '--params', f'{param_file}',
+        '--output_dir', f'{__output_dir__}'
+    ])
     assert os.path.exists(os.path.join(__output_dir__, 'detailed_results.csv'))
     assert os.path.exists(os.path.join(__output_dir__, 'temporary_results.csv'))
     assert os.path.exists(os.path.join(__output_dir__, 'average_eval.csv'))

--- a/testing/functional_tests/test_automate_training.py
+++ b/testing/functional_tests/test_automate_training.py
@@ -24,5 +24,21 @@ def test_automate_training():
     assert os.path.exists(os.path.join(__output_dir__, 'average_eval.csv'))
 
 
+def test_automate_training_run_test():
+    config_file = os.path.join(__data_testing_dir__, 'automate_training_config.json')
+    param_file = os.path.join(__data_testing_dir__,
+                              'automate_training_hyperparameter_opt.json')
+    __output_dir__ = os.path.join(__tmp_dir__, 'results')
+    automate_training.main(args=[
+        '--config', f'{config_file}',
+        '--params', f'{param_file}',
+        '--output_dir', f'{__output_dir__}',
+        '--run-test'
+    ])
+    assert os.path.exists(os.path.join(__output_dir__, 'detailed_results.csv'))
+    assert os.path.exists(os.path.join(__output_dir__, 'temporary_results.csv'))
+    assert os.path.exists(os.path.join(__output_dir__, 'average_eval.csv'))
+
+
 def teardown_function():
     remove_tmp_dir()

--- a/testing/unit_tests/test_HeMIS.py
+++ b/testing/unit_tests/test_HeMIS.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 cudnn.benchmark = True
 
-GPU_NUMBER = 0
+GPU_ID = 0
 BATCH_SIZE = 4
 DROPOUT = 0.4
 BN = 0.1
@@ -115,8 +115,8 @@ def test_HeMIS(p=0.0001):
     cuda_available = torch.cuda.is_available()
 
     if cuda_available:
-        torch.cuda.set_device(GPU_NUMBER)
-        print("Using GPU number {}".format(GPU_NUMBER))
+        torch.cuda.set_device(GPU_ID)
+        print("Using GPU ID {}".format(GPU_ID))
         model.cuda()
 
     # Initialing Optimizer and scheduler

--- a/testing/unit_tests/test_adaptative.py
+++ b/testing/unit_tests/test_adaptative.py
@@ -10,7 +10,7 @@ import logging
 from t_utils import remove_tmp_dir, create_tmp_dir, __data_testing_dir__
 logger = logging.getLogger(__name__)
 
-GPU_NUMBER = 0
+GPU_ID = 0
 BATCH_SIZE = 4
 DROPOUT = 0.4
 DEPTH = 3
@@ -129,11 +129,11 @@ def test_hdf5():
 
         print("\n[INFO]: Starting loader test ...")
 
-        device = torch.device("cuda:" + str(GPU_NUMBER) if torch.cuda.is_available() else "cpu")
+        device = torch.device("cuda:" + str(GPU_ID) if torch.cuda.is_available() else "cpu")
         cuda_available = torch.cuda.is_available()
         if cuda_available:
             torch.cuda.set_device(device)
-            print("Using GPU number {}".format(device))
+            print("Using GPU ID {}".format(device))
 
         train_loader = DataLoader(dataset, batch_size=BATCH_SIZE,
                                   shuffle=False, pin_memory=True,

--- a/testing/unit_tests/test_inference.py
+++ b/testing/unit_tests/test_inference.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 cudnn.benchmark = True
 
-GPU_NUMBER = 0
+GPU_ID = 0
 BATCH_SIZE = 8
 DROPOUT = 0.4
 BN = 0.1
@@ -52,7 +52,7 @@ def setup_function():
         "n_it": 0
     }}])
 def test_inference(transforms_dict, test_lst, target_lst, roi_params, testing_params):
-    cuda_available, device = imed_utils.define_device(GPU_NUMBER)
+    cuda_available, device = imed_utils.define_device(GPU_ID)
 
     model_params = {"name": "Unet", "is_2d": True}
     loader_params = {

--- a/testing/unit_tests/test_orientation.py
+++ b/testing/unit_tests/test_orientation.py
@@ -11,7 +11,7 @@ from t_utils import remove_tmp_dir, create_tmp_dir,  __data_testing_dir__
 
 logger = logging.getLogger(__name__)
 
-GPU_NUMBER = 0
+GPU_ID = 0
 
 
 def setup_function():
@@ -19,11 +19,11 @@ def setup_function():
 
 
 def test_image_orientation():
-    device = torch.device("cuda:" + str(GPU_NUMBER) if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:" + str(GPU_ID) if torch.cuda.is_available() else "cpu")
     cuda_available = torch.cuda.is_available()
     if cuda_available:
         torch.cuda.set_device(device)
-        print("Using GPU number {}".format(device))
+        print("Using GPU ID {}".format(device))
 
     train_lst = ['sub-unf01']
 

--- a/testing/unit_tests/test_sampler.py
+++ b/testing/unit_tests/test_sampler.py
@@ -8,7 +8,7 @@ from t_utils import remove_tmp_dir, create_tmp_dir,  __data_testing_dir__
 
 
 cudnn.benchmark = True
-GPU_NUMBER = 0
+GPU_ID = 0
 BATCH_SIZE = 1
 
 
@@ -49,7 +49,7 @@ def _cmpt_label(ds_loader):
 @pytest.mark.parametrize('target_lst', [["_lesion-manual"]])
 @pytest.mark.parametrize('roi_params', [{"suffix": "_seg-manual", "slice_filter_roi": 10}])
 def test_sampler(transforms_dict, train_lst, target_lst, roi_params):
-    cuda_available, device = imed_utils.define_device(GPU_NUMBER)
+    cuda_available, device = imed_utils.define_device(GPU_ID)
 
     loader_params = {
         "transforms_params": transforms_dict,

--- a/testing/unit_tests/test_slice_filter.py
+++ b/testing/unit_tests/test_slice_filter.py
@@ -9,7 +9,7 @@ from t_utils import remove_tmp_dir, create_tmp_dir,  __data_testing_dir__
 
 cudnn.benchmark = True
 
-GPU_NUMBER = 0
+GPU_ID = 0
 BATCH_SIZE = 1
 
 
@@ -49,7 +49,7 @@ def test_slice_filter(transforms_dict, train_lst, target_lst, roi_params, slice_
     if "ROICrop" in transforms_dict and roi_params["suffix"] is None:
         return
 
-    cuda_available, device = imed_utils.define_device(GPU_NUMBER)
+    cuda_available, device = imed_utils.define_device(GPU_ID)
 
     loader_params = {
         "transforms_params": transforms_dict,

--- a/testing/unit_tests/test_training_time.py
+++ b/testing/unit_tests/test_training_time.py
@@ -14,7 +14,7 @@ from t_utils import remove_tmp_dir, create_tmp_dir,  __data_testing_dir__
 
 cudnn.benchmark = True
 
-GPU_NUMBER = 0
+GPU_ID = 0
 BATCH_SIZE = 8
 N_EPOCHS = 2
 INIT_LR = 0.01
@@ -89,7 +89,7 @@ def setup_function():
     }
 ])
 def test_unet_time(train_lst, target_lst, config):
-    cuda_available, device = imed_utils.define_device(GPU_NUMBER)
+    cuda_available, device = imed_utils.define_device(GPU_ID)
 
     loader_params = {
         "data_list": train_lst,


### PR DESCRIPTION
## Description
In our config files, generally there is a GPU argument which specifies the device ID to use:
```
"gpu": 0
```

However, in the config file for `automate_training`, the GPU argument is a list:

```
"gpu": [0,1,2]
```

For consistency, I think it makes sense to change the config files to all use the list method, as this will encompass both cases.

This pull request does the following:

1. Refactor terms such as `gpu_number` and `gpu` to either `gpu_id` or `gpu_ids`. 
  `gpu_id` (int): the GPU ID for one device
  `gpu_ids` (list)(int): a list of GPU IDs
2. Refactor config files and the `ivadomed.main`, which accepts config files as an argument, to use a list of GPU ids.

## Linked issues
https://github.com/ivadomed/ivadomed/issues/589
