### PR TITLE
Fix missing dilate-gt.png

### DIFF
--- a/ivadomed/transforms.py
+++ b/ivadomed/transforms.py
@@ -496,8 +496,8 @@ class ROICrop(Crop):
 class DilateGT(ImedTransform):
     """Randomly dilate a ground-truth tensor.
 
-    .. image:: ../../images/dilate-gt.png
-        :width: 600px
+    .. image:: https://raw.githubusercontent.com/ivadomed/doc-figures/main/technical_features/dilate-gt.png
+        :width: 500px
         :align: center
 
     Args:


### PR DESCRIPTION
## Description
In the `transforms.py` file, the docstring for `DilateGT` has an image embedded:

```
class DilateGT(ImedTransform):
    """Randomly dilate a ground-truth tensor.
    .. image:: ../../images/dilate-gt.png
        :width: 600px
        :align: center
```

but this image does not exist in the `images` folder. This pull request points it to the correct file:
https://raw.githubusercontent.com/ivadomed/doc-figures/main/technical_features/dilate-gt.png
