### PR TITLE
Remove PyTorch requirement in documentation

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -11,7 +11,7 @@ users have the possibility to install and use ``ivadomed`` via
 Python
 ------
 
-``ivadomed`` requires Python >= 3.6 and <3.9  as well as PyTorch == 1.5.0. We recommend
+``ivadomed`` requires Python >= 3.6 and <3.9. We recommend
 working under a virtual environment, which could be set as follows:
 
 ::
@@ -19,11 +19,11 @@ working under a virtual environment, which could be set as follows:
     virtualenv venv-ivadomed
     source venv-ivadomed/bin/activate
 
-.. warning:: 
+.. warning::
    If the default Python version installed in your system does not fit the version requirements, you might need to specify a version of Python associated with your virtual environment:
-   
+
    ::
-   
+
      virtualenv venv-ivadomed --python=python3.6
 
 


### PR DESCRIPTION
## Description
As mentioned in the linked issue, the installation page currently says that the user needs to have `PyTorch == 1.5.0`. However, this requirement is not necessary for the user to install, as it is included in `requirements.txt` and is installed with the `ivadomed` package. This pull request removes that line in the documentation.

## Linked issues
Resolves https://github.com/ivadomed/ivadomed/issues/655
