### PR TITLE
Add new keys config manager

### DIFF
--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -344,7 +344,6 @@ def get_path_output(args, context):
             logger.error("Have not specified a path-output argument via CLI nor config file.")
 
 
-
 def get_path_data(args, context):
     if args.path_data:
         return args.path_data


### PR DESCRIPTION
In PR #652, two keys in the configuration file were changed. These changes are not retrocompatible with old configuration files. The new keys were added to the configuration manager to ensure retrocompatiblity.
