### PR TITLE
Add pre-commit hooks to limit file size to 500KB 

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -27,17 +27,11 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
           restore-keys: |
             ${{ runner.os }}-pip-
-      - name: Install ivadomed
+      - name: Install dependencies
         if: steps.cache-pip-dependencies.cache-hit != 'true'
         run: |
-          pip install ".[docs, dev]"
+          pip install '-e .'
       - name: Run pre-commit large file check
         run: pre-commit run --all-files check-added-large-files
-      - name: Run pre-commit Python syntax check
-        run: pre-commit run --all-files check-ast
-      - name: Run pre-commit merge conflict string check
-        run: pre-commit run --all-files check-merge-conflict
-      - name: Run pre-commit JSON check
-        run: pre-commit run --all-files check-json
       - name: Run pre-commit YAML check # for GitHub Actions configs
         run: pre-commit run --all-files check-yaml

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         if: steps.cache-pip-dependencies.cache-hit != 'true'
         run: |
-          pip install '-e .' && pre-commit install
+          'pip install -e . && pre-commit install'
       - name: Run pre-commit large file check
         run: pre-commit run --all-files check-added-large-files
       - name: Run pre-commit YAML check # for GitHub Actions configs

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         if: steps.cache-pip-dependencies.cache-hit != 'true'
         run: |
-          pip install '-e .'
+          pip install '-e .' && pre-commit install
       - name: Run pre-commit large file check
         run: pre-commit run --all-files check-added-large-files
       - name: Run pre-commit YAML check # for GitHub Actions configs

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,43 @@
+name: Pre-commit check hooks
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  pre-commit-checks:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.6'
+      - name: Cache pip dependencies
+        id: cache-pip-dependencies
+        uses: actions/cache@v2
+        with:
+          # Ubuntu-specific, see
+          # https://github.com/actions/cache/blob/main/examples.md#python---pip
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install ivadomed
+        if: steps.cache-pip-dependencies.cache-hit != 'true'
+        run: |
+          pip install ".[docs, dev]"
+      - name: Run pre-commit large file check
+        run: pre-commit run --all-files check-added-large-files
+      - name: Run pre-commit Python syntax check
+        run: pre-commit run --all-files check-ast
+      - name: Run pre-commit merge conflict string check
+        run: pre-commit run --all-files check-merge-conflict
+      - name: Run pre-commit JSON check
+        run: pre-commit run --all-files check-json
+      - name: Run pre-commit YAML check # for GitHub Actions configs
+        run: pre-commit run --all-files check-yaml

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -28,9 +28,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
       - name: Install dependencies
-        if: steps.cache-pip-dependencies.cache-hit != 'true'
         run: |
-          'pip install -e . && pre-commit install'
+              python -m pip install --upgrade pip
+              if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+              pip install -e .
+              pre-commit install
       - name: Run pre-commit large file check
         run: pre-commit run --all-files check-added-large-files
       - name: Run pre-commit YAML check # for GitHub Actions configs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: check-json
+    -   id: check-merge-conflict
+    -   id: check-ast #check if files are valid python
+    -   id: check-added-large-files
+        args: [--maxkb=500]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,5 @@ repos:
     rev: v2.3.0
     hooks:
     -   id: check-yaml
-    -   id: check-json
-    -   id: check-merge-conflict
-    -   id: check-ast #check if files are valid python
     -   id: check-added-large-files
         args: [--maxkb=500]

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -50,3 +50,15 @@ on Github. Installation procedure is the following:
     git clone https://github.com/neuropoly/ivadomed.git
     cd ivadomed
     pip install -e .
+
+
+Install pre-commit hooks for development
+----------------------------------------
+
+We use ``pre-commit`` to enforce a limit on file size.
+After you've installed ``ivadomed``, install the hooks:
+
+::
+
+    pre-commit install
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ tqdm>=4.30
 pytest-ordering
 sphinx-jsonschema
 pytest-console-scripts
+pre-commit==2.10.1

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
             'sphinx<2',
             'sphinx-rtd-theme<0.5',
         ],
+        'dev': ["pre-commit>=2.10.0"]
     },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
## Description
Local commit hooks have been added using `pre-commit` to prevent files > 500KB from being committed. Pre-commit hooks are also utilized via Github actions. These changes are similar to what was implemented [here](https://github.com/shimming-toolbox/shimming-toolbox/pull/215)

## Linked issues
#583 
