### PR TITLE
Multiclass ignored during inference if n_input and n_output are different

### DIFF
--- a/ivadomed/inference.py
+++ b/ivadomed/inference.py
@@ -277,7 +277,7 @@ def segment_volume(folder_model, fname_images, gpu_id=0, options=None):
             else:
                 # undo transformations
                 preds_i_undo, metadata_idx = undo_transforms(preds[i_slice],
-                                                             batch["input_metadata"][i_slice],
+                                                             batch["gt_metadata"][i_slice],
                                                              data_type='gt')
 
                 # Add new segmented slice to preds_list


### PR DESCRIPTION
In `inference.py`: only n_input classes are saved. This is a problem if n_input < n_output: eg input=dwi, output=gm, wm --> only gm segmented.
This mini-mini PR fixes this bug.

Note: the behavior is however correct in `testing.py`, which is a relief, see [here](https://github.com/ivadomed/ivadomed/blob/master/ivadomed/testing.py#L184).