### PR TITLE
New loader: Refactor BidsDataset classes

### DIFF
--- a/dev/df_new_loader.py
+++ b/dev/df_new_loader.py
@@ -11,10 +11,33 @@
 
 
 # IMPORTS
+import json
 import os
+import argparse
+import copy
+import joblib
+import torch.backends.cudnn as cudnn
+import nibabel as nib
+import sys
+import platform
+import multiprocessing
 import pandas as pd
+
+from bids_neuropoly import bids
+from ivadomed.utils import logger
+from ivadomed import evaluation as imed_evaluation
 from ivadomed import config_manager as imed_config_manager
-from ivadomed.loader import utils as imed_loader_utils
+from ivadomed import testing as imed_testing
+from ivadomed import training as imed_training
+from ivadomed import transforms as imed_transforms
+from ivadomed import utils as imed_utils
+from ivadomed import metrics as imed_metrics
+from ivadomed import inference as imed_inference
+# Here imed_loader refers temporarily to the loader_new.py, to fix when integrating in pipeline
+from ivadomed.loader import utils as imed_loader_utils, loader_new as imed_loader, film as imed_film
+
+
+### STEP 1 - CREATE BidsDataframe object
 
 # GET LOADER PARAMETERS FROM IVADOMED CONFIG FILE
 # The loader parameters have 2 new fields: "bids_config" and "extensions".
@@ -46,14 +69,15 @@ bids_df = imed_loader_utils.BidsDataframe(loader_params, derivatives, path_outpu
 df = bids_df.df
 
 # DROP "path" AND "parent_path" COLUMNS AND SORT BY FILENAME FOR TESTING PURPOSES WITH data-testing
-df = df.drop(columns=['path', 'parent_path'])
-df = df.sort_values(by=['filename']).reset_index(drop=True)
+#df = df.drop(columns=['path', 'parent_path'])
+#df = df.sort_values(by=['filename']).reset_index(drop=True)
 
 # SAVE DATAFRAME TO CSV FILE FOR data-testing
-path_csv = "test_df_new_loader.csv"
-df.to_csv(path_csv, index=False)
-print(df)
+#path_csv = "test_df_new_loader.csv"
+#df.to_csv(path_csv, index=False)
+#print(df)
 
+### STEP 2 - SPLIT DATASET
 
 # SPLIT TRAIN/VALID/TEST (with "new" functions)
 train_lst, valid_lst, test_lst = imed_loader_utils.get_subdatasets_subjects_list_new(context["split_dataset"],
@@ -61,6 +85,105 @@ train_lst, valid_lst, test_lst = imed_loader_utils.get_subdatasets_subjects_list
                                                                                      path_output,
                                                                                      context["loader_parameters"]
                                                                                      ['subject_selection'])
-print("Train:", train_lst)
-print("Valid:", valid_lst)
-print("Test:", test_lst)
+#print("Train:", train_lst)
+#print("Valid:", valid_lst)
+#print("Test:", test_lst)
+
+### STEP 3 - LOAD DATASET (DERIVED FROM MAIN)
+
+# List of not-default available models i.e. different from Unet
+MODEL_LIST = ['Modified3DUNet', 'HeMISUnet', 'FiLMedUnet', 'resnet18', 'densenet121', 'Countception']
+
+command = copy.deepcopy(context["command"])
+path_output = copy.deepcopy(context["path_output"])
+if not os.path.isdir(path_output):
+    print('Creating output path: {}'.format(path_output))
+    os.makedirs(path_output)
+else:
+    print('Output path already exists: {}'.format(path_output))
+
+cuda_available, device = imed_utils.define_device(context['gpu_ids'][0])
+
+# Loader params
+loader_params = copy.deepcopy(context["loader_parameters"])
+if command == "train":
+    loader_params["contrast_params"]["contrast_lst"] = loader_params["contrast_params"]["training_validation"]
+else:
+    loader_params["contrast_params"]["contrast_lst"] = loader_params["contrast_params"]["testing"]
+if "FiLMedUnet" in context and context["FiLMedUnet"]["applied"]:
+    loader_params.update({"metadata_type": context["FiLMedUnet"]["metadata"]})
+# Load metadata necessary to balance the loader
+if context['training_parameters']['balance_samples']['applied'] and \
+        context['training_parameters']['balance_samples']['type'] != 'gt':
+    loader_params.update({"metadata_type": context['training_parameters']['balance_samples']['type']})
+# Get transforms for each subdataset
+transform_train_params, transform_valid_params, transform_test_params = \
+    imed_transforms.get_subdatasets_transforms(context["transformation"])
+# MODEL PARAMETERS
+model_params = copy.deepcopy(context["default_model"])
+model_params["folder_name"] = copy.deepcopy(context["model_name"])
+model_context_list = [model_name for model_name in MODEL_LIST
+                      if model_name in context and context[model_name]["applied"]]
+if len(model_context_list) == 1:
+    model_params["name"] = model_context_list[0]
+    model_params.update(context[model_context_list[0]])
+elif 'Modified3DUNet' in model_context_list and 'FiLMedUnet' in model_context_list and len(model_context_list) == 2:
+    model_params["name"] = 'Modified3DUNet'
+    for i in range(len(model_context_list)):
+        model_params.update(context[model_context_list[i]])
+elif len(model_context_list) > 1:
+    print('ERROR: Several models are selected in the configuration file: {}.'
+          'Please select only one (i.e. only one where: "applied": true).'.format(model_context_list))
+    exit()
+model_params['is_2d'] = False if "Modified3DUNet" in model_params['name'] else model_params['is_2d']
+# Get in_channel from contrast_lst
+if loader_params["multichannel"]:
+    model_params["in_channel"] = len(loader_params["contrast_params"]["contrast_lst"])
+else:
+    model_params["in_channel"] = 1
+# Get out_channel from target_suffix
+model_params["out_channel"] = len(loader_params["target_suffix"])
+# If multi-class output, then add background class
+if model_params["out_channel"] > 1:
+    model_params.update({"out_channel": model_params["out_channel"] + 1})
+# Display for spec' check
+imed_utils.display_selected_model_spec(params=model_params)
+# Update loader params
+if 'object_detection_params' in context:
+    object_detection_params = context['object_detection_params']
+    object_detection_params.update({"gpu_ids": context['gpu_ids'][0],
+                                    "path_output": context['path_output']})
+    loader_params.update({"object_detection_params": object_detection_params})
+loader_params.update({"model_params": model_params})
+# TESTING PARAMS
+# Aleatoric uncertainty
+if context['uncertainty']['aleatoric'] and context['uncertainty']['n_it'] > 0:
+    transformation_dict = transform_train_params
+else:
+    transformation_dict = transform_test_params
+undo_transforms = imed_transforms.UndoCompose(imed_transforms.Compose(transformation_dict, requires_undo=True))
+testing_params = copy.deepcopy(context["training_parameters"])
+testing_params.update({'uncertainty': context["uncertainty"]})
+testing_params.update({'target_suffix': loader_params["target_suffix"], 'undo_transforms': undo_transforms,
+                       'slice_axis': loader_params['slice_axis']})
+if command == "train":
+    imed_utils.display_selected_transfoms(transform_train_params, dataset_type=["training"])
+    imed_utils.display_selected_transfoms(transform_valid_params, dataset_type=["validation"])
+elif command == "test":
+    imed_utils.display_selected_transfoms(transformation_dict, dataset_type=["testing"])
+# Check if multiple raters
+if any([isinstance(class_suffix, list) for class_suffix in loader_params["target_suffix"]]):
+    print(
+        "\nAnnotations from multiple raters will be used during model training, one annotation from one rater "
+        "randomly selected at each iteration.\n")
+    if command != "train":
+        print(
+            "\nERROR: Please provide only one annotation per class in 'target_suffix' when not training a model.\n")
+        exit()
+if command == 'train':
+    # LOAD DATASET
+    # Get Validation dataset
+    ds_valid = imed_loader.load_dataset(bids_df, **{**loader_params,
+                                           **{'data_list': valid_lst, 'transforms_params': transform_valid_params,
+                                              'dataset_type': 'validation'}}, device=device,
+                                        cuda_available=cuda_available)

--- a/ivadomed/config/config_new_loader.json
+++ b/ivadomed/config/config_new_loader.json
@@ -11,14 +11,14 @@
     "loader_parameters": {
         "path_data": ["data_example_spinegeneric"],
         "bids_config": "ivadomed/config/config_bids.json",
-        "target_suffix": ["_seg-manual", "_seg-axon-manual"],
-        "extensions": [".nii.gz", ".png"],
+        "target_suffix": ["_seg-manual"],
+        "extensions": [".nii.gz"],
         "roi_params": {
             "suffix": null,
             "slice_filter_roi": null
         },
         "contrast_params": {
-            "training_validation": ["T1w", "T2w", "SEM"],
+            "training_validation": ["T1w", "T2w"],
             "testing": [],
             "balance": {}
         },
@@ -32,9 +32,9 @@
     },
     "split_dataset": {
         "fname_split": null,
-        "random_seed": 500,
+        "random_seed": 6,
         "split_method" : "participant_id",
-        "data_testing": {"data_type": "institution_id", "data_value":["oxfordFmrib"]},
+        "data_testing": {"data_type": null, "data_value":[]},
         "balance": null,
         "train_fraction": 0.6,
         "test_fraction": 0.2

--- a/ivadomed/loader/adaptative_new.py
+++ b/ivadomed/loader/adaptative_new.py
@@ -1,0 +1,775 @@
+import copy
+import os
+from os import path
+
+import h5py
+import nibabel as nib
+import numpy as np
+import pandas as pd
+from bids_neuropoly import bids
+from tqdm import tqdm
+
+from ivadomed import transforms as imed_transforms
+from ivadomed.loader import utils as imed_loader_utils, loader as imed_loader, film as imed_film
+from ivadomed.object_detection import utils as imed_obj_detect
+from ivadomed import utils as imed_utils
+
+
+class Dataframe:
+    """
+    This class aims to create a dataset using an HDF5 file, which can be used by an adapative loader
+    to perform curriculum learning, Active Learning or any other strategy that needs to load samples
+    in a specific way.
+    It works on RAM or on the fly and can be saved for later.
+
+    Args:
+        hdf5_file (hdf5): hdf5 file containing dataset information
+        contrasts (list of str): List of the contrasts of interest.
+        path (str): Dataframe path.
+        target_suffix (list of str): List of suffix of targetted structures.
+        roi_suffix (str): List of suffix of ROI masks.
+        filter_slices (SliceFilter): Object that filters slices according to their content.
+        dim (int): Choice 2 or 3, for 2D or 3D data respectively.
+
+    Attributes:
+        dim (int): Choice 2 or 3, for 2D or 3D data respectively.
+        contrasts (list of str): List of the contrasts of interest.
+        filter_slices (SliceFilter): Object that filters slices according to their content.
+        df (pd.Dataframe): Dataframe containing dataset information
+    """
+
+    def __init__(self, hdf5_file, contrasts, path, target_suffix=None, roi_suffix=None,
+                 filter_slices=False, dim=2):
+        # Number of dimension
+        self.dim = dim
+        # List of all contrasts
+        self.contrasts = copy.deepcopy(contrasts)
+
+        if target_suffix:
+            for gt in target_suffix:
+                self.contrasts.append('gt/' + gt)
+        else:
+            self.contrasts.append('gt')
+
+        if roi_suffix:
+            for roi in roi_suffix:
+                self.contrasts.append('roi/' + roi)
+        else:
+            self.contrasts.append('ROI')
+
+        self.df = None
+        self.filter = filter_slices
+
+        # Data frame
+        if os.path.exists(path):
+            self.load_dataframe(path)
+        else:
+            self.create_df(hdf5_file)
+
+    def shuffle(self):
+        """Shuffle the whole data frame."""
+        self.df = self.df.sample(frac=1)
+
+    def load_dataframe(self, path):
+        """Load the dataframe from a csv file.
+
+        Args:
+            path (str): Path to hdf5 file.
+        """
+        try:
+            self.df = pd.read_csv(path)
+            print("Dataframe has been correctly loaded from {}.".format(path))
+        except FileNotFoundError:
+            print("No csv file found")
+
+    def save(self, path):
+        """Save the dataframe into a csv file.
+
+        Args:
+            path (str): Path to hdf5 file.
+        """
+        try:
+            self.df.to_csv(path, index=False)
+            print("Dataframe has been saved at {}.".format(path))
+        except FileNotFoundError:
+            print("Wrong path.")
+
+    def create_df(self, hdf5_file):
+        """Generate the Data frame using the hdf5 file.
+
+        Args:
+            hdf5_file (hdf5): File containing dataset information
+        """
+        # Template of a line
+        empty_line = {col: 'None' for col in self.contrasts}
+        empty_line['Slices'] = 'None'
+
+        # Initialize the data frame
+        col_names = [col for col in empty_line.keys()]
+        col_names.append('Subjects')
+        df = pd.DataFrame(columns=col_names)
+        print(hdf5_file.attrs['patients_id'])
+        # Filling the data frame
+        for subject in hdf5_file.attrs['patients_id']:
+            # Getting the Group the corresponding patient
+            grp = hdf5_file[subject]
+            line = copy.deepcopy(empty_line)
+            line['Subjects'] = subject
+
+            # inputs
+            assert 'inputs' in grp.keys()
+            inputs = grp['inputs']
+            for c in inputs.attrs['contrast']:
+                if c in col_names:
+                    line[c] = '{}/inputs/{}'.format(subject, c)
+                else:
+                    continue
+            # GT
+            assert 'gt' in grp.keys()
+            inputs = grp['gt']
+            for c in inputs.attrs['contrast']:
+                key = 'gt/' + c
+                for col in col_names:
+                    if key in col:
+                        line[col] = '{}/gt/{}'.format(subject, c)
+                    else:
+                        continue
+            # ROI
+            assert 'roi' in grp.keys()
+            inputs = grp['roi']
+            for c in inputs.attrs['contrast']:
+                key = 'roi/' + c
+                for col in col_names:
+                    if key in col:
+                        line[col] = '{}/roi/{}'.format(subject, c)
+                    else:
+                        continue
+
+            # Adding slices & removing useless slices if loading in ram
+            line['Slices'] = np.array(grp.attrs['slices'])
+
+            # If the number of dimension is 2, we separate the slices
+            if self.dim == 2:
+                if self.filter:
+                    for n in line['Slices']:
+                        line_slice = copy.deepcopy(line)
+                        line_slice['Slices'] = n
+                        df = df.append(line_slice, ignore_index=True)
+
+            else:
+                df = df.append(line, ignore_index=True)
+
+        self.df = df
+
+    def clean(self, contrasts):
+        """Aims to remove lines where one of the contrasts in not available.
+
+        Agrs:
+            contrasts (list of str): List of contrasts.
+        """
+        # Replacing 'None' values by np.nan
+        self.df[contrasts] = self.df[contrasts].replace(to_replace='None', value=np.nan)
+        # Dropping np.nan
+        self.df = self.df.dropna()
+
+
+class BIDStoHDF5:
+    """Converts a BIDS dataset to a HDF5 file.
+
+    Args:
+        path_data (list) or (str): Path(s) to BIDS datasets
+        subject_lst (list): Subject names list.
+        target_suffix (list): List of suffixes for target masks.
+        roi_params (dict): Dictionary containing parameters related to ROI image processing.
+        contrast_lst (list): List of the contrasts.
+        path_hdf5 (str): Path and name of the hdf5 file.
+        contrast_balance (dict): Dictionary controlling image contrasts balance.
+        slice_axis (int): Indicates the axis used to extract slices: "axial": 2, "sagittal": 0, "coronal": 1.
+        metadata_choice (str): Choice between "mri_params", "contrasts", None or False, related to FiLM.
+        slice_filter_fn (SliceFilter): Class that filters slices according to their content.
+        transform (Compose): Transformations.
+        object_detection_params (dict): Object detection parameters.
+
+    Attributes:
+        bids_ds (BIDS): BIDS dataset.
+        dt (dtype): hdf5 special dtype.
+        path_hdf5 (str): path to hdf5 file containing dataset information.
+        filename_pairs (list): A list of tuples in the format (input filename list containing all modalities,ground \
+            truth filename, ROI filename, metadata).
+        metadata (dict): Dictionary containing metadata of input and gt.
+        prepro_transforms (Compose): Transforms to be applied before training.
+        transform (Compose): Transforms to be applied during training.
+        has_bounding_box (bool): True if all metadata contains bounding box coordinates, else False.
+        slice_axis (int): Indicates the axis used to extract slices: "axial": 2, "sagittal": 0, "coronal": 1.
+        slice_filter_fn (SliceFilter): Object that filters slices according to their content.
+    """
+
+    def __init__(self, path_data, subject_lst, target_suffix, contrast_lst, path_hdf5, contrast_balance=None,
+                 slice_axis=2, metadata_choice=False, slice_filter_fn=None, roi_params=None, transform=None,
+                 object_detection_params=None, soft_gt=False):
+        print("Starting conversion")
+
+        # Getting all patients id
+        self.bids_ds = []
+        path_data = imed_utils.format_path_data(path_data)
+        for bids_folder in path_data:
+            self.bids_ds.append(bids.BIDS(bids_folder))
+        # Append subjects from all BIDSdatasets into a list
+        bids_subjects = [s for s in self.bids_ds[0].get_subjects() if s.record["subject_id"] in subject_lst]
+        for i_bids_folder in range(1, len(path_data)):
+            bids_subjects += [s for s in self.bids_ds[i_bids_folder].get_subjects() if
+                              s.record["subject_id"] in subject_lst]
+
+        self.soft_gt = soft_gt
+        self.dt = h5py.special_dtype(vlen=str)
+        # opening an hdf5 file with write access and writing metadata
+        # self.hdf5_file = h5py.File(hdf5_name, "w")
+        self.path_hdf5 = path_hdf5
+        list_patients = []
+
+        self.filename_pairs = []
+
+        if metadata_choice == 'mri_params':
+            self.metadata = {"FlipAngle": [], "RepetitionTime": [],
+                             "EchoTime": [], "Manufacturer": []}
+
+        self.prepro_transforms, self.transform = transform
+        # Create a list with the filenames for all contrasts and subjects
+        subjects_tot = []
+        for subject in bids_subjects:
+            subjects_tot.append(str(subject.record["absolute_path"]))
+
+        # Create a dictionary with the number of subjects for each contrast of contrast_balance
+        tot = {contrast: len([s for s in bids_subjects if s.record["modality"] == contrast])
+               for contrast in contrast_balance.keys()}
+
+        # Create a counter that helps to balance the contrasts
+        c = {contrast: 0 for contrast in contrast_balance.keys()}
+
+        # Append get_subjects()
+        get_subjects_all = self.bids_ds[0].get_subjects()
+        for i_bids_folder in range(1, len(self.bids_ds)):
+            get_subjects_all.extend(self.bids_ds[i_bids_folder].get_subjects())
+
+        self.has_bounding_box = True
+        bounding_box_dict = imed_obj_detect.load_bounding_boxes(object_detection_params,
+                                                                get_subjects_all,
+                                                                slice_axis,
+                                                                contrast_lst)
+
+        for subject in tqdm(bids_subjects, desc="Loading dataset"):
+
+            if subject.record["modality"] in contrast_lst:
+
+                # Training & Validation: do not consider the contrasts over the threshold contained in contrast_balance
+                if subject.record["modality"] in contrast_balance.keys():
+                    c[subject.record["modality"]] = c[subject.record["modality"]] + 1
+                    if c[subject.record["modality"]] / tot[subject.record["modality"]] \
+                            > contrast_balance[subject.record["modality"]]:
+                        continue
+
+                if not subject.has_derivative("labels"):
+                    print("Subject without derivative, skipping.")
+                    continue
+                derivatives = subject.get_derivatives("labels")
+
+                target_filename, roi_filename = [None] * len(target_suffix), None
+
+                for deriv in derivatives:
+                    for idx, suffix in enumerate(target_suffix):
+                        if deriv.endswith(subject.record["modality"] + suffix + ".nii.gz"):
+                            target_filename[idx] = deriv
+
+                    if not (roi_params["suffix"] is None) and \
+                            deriv.endswith(subject.record["modality"] + roi_params["suffix"] + ".nii.gz"):
+                        roi_filename = [deriv]
+
+                if (not any(target_filename)) or (not (roi_params["suffix"] is None) and (roi_filename is None)):
+                    continue
+
+                if not subject.has_metadata():
+                    print("Subject without metadata.")
+                    metadata = {}
+                else:
+                    metadata = subject.metadata()
+                    # add contrast to metadata
+                metadata['contrast'] = subject.record["modality"]
+
+                if metadata_choice == 'mri_params':
+                    if not all([imed_film.check_isMRIparam(m, metadata) for m in self.metadata.keys()]):
+                        continue
+
+                if len(bounding_box_dict):
+                    # Take only one bounding box for cropping
+                    metadata['bounding_box'] = bounding_box_dict[str(subject.record["absolute_path"])][0]
+
+                self.filename_pairs.append((subject.record["subject_id"], [subject.record.absolute_path],
+                                            target_filename, roi_filename, [metadata]))
+
+                list_patients.append(subject.record["subject_id"])
+
+        self.slice_axis = slice_axis
+        self.slice_filter_fn = slice_filter_fn
+
+        # Update HDF5 metadata
+        with h5py.File(self.path_hdf5, "w") as hdf5_file:
+            hdf5_file.attrs.create('patients_id', list(set(list_patients)), dtype=self.dt)
+            hdf5_file.attrs['slice_axis'] = slice_axis
+
+            hdf5_file.attrs['slice_filter_fn'] = [('filter_empty_input', True), ('filter_empty_mask', False)]
+            hdf5_file.attrs['metadata_choice'] = metadata_choice
+
+        # Save images into HDF5 file
+        self._load_filenames()
+        print("Files loaded.")
+
+    def _load_filenames(self):
+        """Load preprocessed pair data (input and gt) in handler."""
+        with h5py.File(self.path_hdf5, "a") as hdf5_file:
+            for subject_id, input_filename, gt_filename, roi_filename, metadata in self.filename_pairs:
+                # Creating/ getting the subject group
+                if str(subject_id) in hdf5_file.keys():
+                    grp = hdf5_file[str(subject_id)]
+                else:
+                    grp = hdf5_file.create_group(str(subject_id))
+
+                roi_pair = imed_loader.SegmentationPair(input_filename, roi_filename, metadata=metadata,
+                                                        slice_axis=self.slice_axis, cache=False, soft_gt=self.soft_gt)
+
+                seg_pair = imed_loader.SegmentationPair(input_filename, gt_filename, metadata=metadata,
+                                                        slice_axis=self.slice_axis, cache=False, soft_gt=self.soft_gt)
+                print("gt filename", gt_filename)
+                input_data_shape, _ = seg_pair.get_pair_shapes()
+
+                useful_slices = []
+                input_volumes = []
+                gt_volume = []
+                roi_volume = []
+
+                for idx_pair_slice in range(input_data_shape[-1]):
+
+                    slice_seg_pair = seg_pair.get_pair_slice(idx_pair_slice)
+
+                    self.has_bounding_box = imed_obj_detect.verify_metadata(slice_seg_pair, self.has_bounding_box)
+                    if self.has_bounding_box:
+                        imed_obj_detect.adjust_transforms(self.prepro_transforms, slice_seg_pair)
+
+                    # keeping idx of slices with gt
+                    if self.slice_filter_fn:
+                        filter_fn_ret_seg = self.slice_filter_fn(slice_seg_pair)
+                    if self.slice_filter_fn and filter_fn_ret_seg:
+                        useful_slices.append(idx_pair_slice)
+
+                    roi_pair_slice = roi_pair.get_pair_slice(idx_pair_slice)
+                    slice_seg_pair, roi_pair_slice = imed_transforms.apply_preprocessing_transforms(self.prepro_transforms,
+                                                                                                    slice_seg_pair,
+                                                                                                    roi_pair_slice)
+
+                    input_volumes.append(slice_seg_pair["input"][0])
+
+                    # Handle unlabeled data
+                    if not len(slice_seg_pair["gt"]):
+                        gt_volume = []
+                    else:
+                        gt_volume.append((slice_seg_pair["gt"][0] * 255).astype(np.uint8) / 255.)
+
+                    # Handle data with no ROI provided
+                    if not len(roi_pair_slice["gt"]):
+                        roi_volume = []
+                    else:
+                        roi_volume.append((roi_pair_slice["gt"][0] * 255).astype(np.uint8) / 255.)
+
+                # Getting metadata using the one from the last slice
+                input_metadata = slice_seg_pair['input_metadata'][0]
+                gt_metadata = slice_seg_pair['gt_metadata'][0]
+                roi_metadata = roi_pair_slice['input_metadata'][0]
+
+                if grp.attrs.__contains__('slices'):
+                    grp.attrs['slices'] = list(set(np.concatenate((grp.attrs['slices'], useful_slices))))
+                else:
+                    grp.attrs['slices'] = useful_slices
+
+                # Creating datasets and metadata
+                contrast = input_metadata['contrast']
+                # Inputs
+                print(len(input_volumes))
+                print("grp= ", str(subject_id))
+                key = "inputs/{}".format(contrast)
+                print("key = ", key)
+                if len(input_volumes) < 1:
+                    print("list empty")
+                    continue
+                grp.create_dataset(key, data=input_volumes)
+                # Sub-group metadata
+                if grp['inputs'].attrs.__contains__('contrast'):
+                    attr = grp['inputs'].attrs['contrast']
+                    new_attr = [c for c in attr]
+                    new_attr.append(contrast)
+                    grp['inputs'].attrs.create('contrast', new_attr, dtype=self.dt)
+
+                else:
+                    grp['inputs'].attrs.create('contrast', [contrast], dtype=self.dt)
+
+                # dataset metadata
+                grp[key].attrs['input_filenames'] = input_metadata['input_filenames']
+                grp[key].attrs['data_type'] = input_metadata['data_type']
+
+                if "zooms" in input_metadata.keys():
+                    grp[key].attrs["zooms"] = input_metadata['zooms']
+                if "data_shape" in input_metadata.keys():
+                    grp[key].attrs["data_shape"] = input_metadata['data_shape']
+                if "bounding_box" in input_metadata.keys():
+                    grp[key].attrs["bounding_box"] = input_metadata['bounding_box']
+
+                # GT
+                key = "gt/{}".format(contrast)
+                grp.create_dataset(key, data=gt_volume)
+                # Sub-group metadata
+                if grp['gt'].attrs.__contains__('contrast'):
+                    attr = grp['gt'].attrs['contrast']
+                    new_attr = [c for c in attr]
+                    new_attr.append(contrast)
+                    grp['gt'].attrs.create('contrast', new_attr, dtype=self.dt)
+
+                else:
+                    grp['gt'].attrs.create('contrast', [contrast], dtype=self.dt)
+
+                # dataset metadata
+                grp[key].attrs['gt_filenames'] = input_metadata['gt_filenames']
+                grp[key].attrs['data_type'] = gt_metadata['data_type']
+
+                if "zooms" in gt_metadata.keys():
+                    grp[key].attrs["zooms"] = gt_metadata['zooms']
+                if "data_shape" in gt_metadata.keys():
+                    grp[key].attrs["data_shape"] = gt_metadata['data_shape']
+                if gt_metadata['bounding_box'] is not None:
+                    grp[key].attrs["bounding_box"] = gt_metadata['bounding_box']
+
+                # ROI
+                key = "roi/{}".format(contrast)
+                grp.create_dataset(key, data=roi_volume)
+                # Sub-group metadata
+                if grp['roi'].attrs.__contains__('contrast'):
+                    attr = grp['roi'].attrs['contrast']
+                    new_attr = [c for c in attr]
+                    new_attr.append(contrast)
+                    grp['roi'].attrs.create('contrast', new_attr, dtype=self.dt)
+
+                else:
+                    grp['roi'].attrs.create('contrast', [contrast], dtype=self.dt)
+
+                # dataset metadata
+                grp[key].attrs['roi_filename'] = roi_metadata['gt_filenames']
+                grp[key].attrs['data_type'] = roi_metadata['data_type']
+
+                if "zooms" in roi_metadata.keys():
+                    grp[key].attrs["zooms"] = roi_metadata['zooms']
+                if "data_shape" in roi_metadata.keys():
+                    grp[key].attrs["data_shape"] = roi_metadata['data_shape']
+
+                # Adding contrast to group metadata
+                if grp.attrs.__contains__('contrast'):
+                    attr = grp.attrs['contrast']
+                    new_attr = [c for c in attr]
+                    new_attr.append(contrast)
+                    grp.attrs.create('contrast', new_attr, dtype=self.dt)
+
+                else:
+                    grp.attrs.create('contrast', [contrast], dtype=self.dt)
+
+
+class HDF5Dataset:
+    """HDF5 dataset object.
+
+    Args:
+        path_data (list) or (str): Path(s) to BIDS datasets
+        subject_lst (list of str): List of subjects.
+        model_params (dict): Dictionary containing model parameters.
+        target_suffix (list of str): List of suffixes of the target structures.
+        contrast_params (dict): Dictionary containing contrast parameters.
+        slice_axis (int): Indicates the axis used to extract slices: "axial": 2, "sagittal": 0, "coronal": 1.
+        transform (Compose): Transformations.
+        metadata_choice (str): Choice between "mri_params", "contrasts", None or False, related to FiLM.
+        dim (int): Choice 2 or 3, for 2D or 3D data respectively.
+        complet (bool): If True removes lines where contrasts is not available.
+        slice_filter_fn (SliceFilter): Object that filters slices according to their content.
+        roi_params (dict): Dictionary containing parameters related to ROI image processing.
+        object_detection_params (dict): Object detection parameters.
+
+    Attributes:
+        cst_lst (list): Contrast list.
+        gt_lst (list): Contrast label used for ground truth.
+        roi_lst (list): Contrast label used for ROI cropping.
+        dim (int): Choice 2 or 3, for 2D or 3D data respectively.
+        filter_slices (SliceFilter): Object that filters slices according to their content.
+        prepro_transforms (Compose): Transforms to be applied before training.
+        transform (Compose): Transforms to be applied during training.
+        df_object (pd.Dataframe): Dataframe containing dataset information.
+
+    """
+
+    def __init__(self, path_data, subject_lst, model_params, target_suffix, contrast_params,
+                 slice_axis=2, transform=None, metadata_choice=False, dim=2, complet=True,
+                 slice_filter_fn=None, roi_params=None, object_detection_params=None, soft_gt=False):
+        self.cst_lst = copy.deepcopy(contrast_params["contrast_lst"])
+        self.gt_lst = copy.deepcopy(model_params["target_lst"] if "target_lst" in model_params else None)
+        self.roi_lst = copy.deepcopy(model_params["roi_lst"] if "roi_lst" in model_params else None)
+        self.dim = dim
+        self.roi_params = roi_params if roi_params is not None else {"suffix": None, "slice_filter_roi": None}
+        self.filter_slices = slice_filter_fn
+        self.prepro_transforms, self.transform = transform
+
+        metadata_choice = False if metadata_choice is None else metadata_choice
+        # Getting HDS5 dataset file
+        if not os.path.exists(model_params["path_hdf5"]):
+            print("Computing hdf5 file of the data")
+            bids_to_hdf5 = BIDStoHDF5(path_data=path_data,
+                                      subject_lst=subject_lst,
+                                      path_hdf5=model_params["path_hdf5"],
+                                      target_suffix=target_suffix,
+                                      roi_params=self.roi_params,
+                                      contrast_lst=self.cst_lst,
+                                      metadata_choice=metadata_choice,
+                                      contrast_balance=contrast_params["balance"],
+                                      slice_axis=slice_axis,
+                                      slice_filter_fn=slice_filter_fn,
+                                      transform=transform,
+                                      object_detection_params=object_detection_params,
+                                      soft_gt=soft_gt)
+
+            self.path_hdf5 = bids_to_hdf5.path_hdf5
+        else:
+            self.path_hdf5 = model_params["path_hdf5"]
+
+        # Loading dataframe object
+        with h5py.File(self.path_hdf5, "r") as hdf5_file:
+            self.df_object = Dataframe(hdf5_file, self.cst_lst, model_params["csv_path"],
+                                       target_suffix=self.gt_lst, roi_suffix=self.roi_lst,
+                                       dim=self.dim, filter_slices=slice_filter_fn)
+            if complet:
+                self.df_object.clean(self.cst_lst)
+            print("after cleaning")
+            print(self.df_object.df.head())
+
+            self.initial_dataframe = self.df_object.df
+
+            self.dataframe = copy.deepcopy(self.df_object.df)
+
+            self.cst_matrix = np.ones([len(self.dataframe), len(self.cst_lst)], dtype=int)
+
+            # RAM status
+            self.status = {ct: False for ct in self.df_object.contrasts}
+
+            ram = model_params["ram"] if "ram" in model_params else True
+            if ram:
+                self.load_into_ram(self.cst_lst)
+
+    def load_into_ram(self, contrast_lst=None):
+        """Aims to load into RAM the contrasts from the list.
+
+        Args:
+            contrast_lst (list of str): List of contrasts of interest.
+        """
+        keys = self.status.keys()
+        with h5py.File(self.path_hdf5, "r") as hdf5_file:
+            for ct in contrast_lst:
+                if ct not in keys:
+                    print("Key error: status has no key {}".format(ct))
+                    continue
+                if self.status[ct]:
+                    print("Contrast {} already in RAM".format(ct))
+                else:
+                    print("Loading contrast {} in RAM...".format(ct), end='')
+                    for sub in self.dataframe.index:
+                        if self.filter_slices:
+                            slices = self.dataframe.at[sub, 'Slices']
+                            self.dataframe.at[sub, ct] = hdf5_file[self.dataframe.at[sub, ct]][np.array(slices)]
+                    print("Done.")
+                self.status[ct] = True
+
+    def set_transform(self, transform):
+        """Set the transforms."""
+        self.transform = transform
+
+    def __len__(self):
+        """Get the dataset size, ie he number of subvolumes."""
+        return len(self.dataframe)
+
+    def __getitem__(self, index):
+        """Get samples.
+
+        Warning: For now, this method only supports one gt / roi.
+
+        Args:
+            index (int): Sample index.
+
+        Returns:
+            dict: Dictionary containing image and label tensors as well as metadata.
+        """
+        line = self.dataframe.iloc[index]
+        # For HeMIS strategy. Otherwise the values of the matrix dont change anything.
+        missing_modalities = self.cst_matrix[index]
+
+        input_metadata = []
+        input_tensors = []
+
+        # Inputs
+        with h5py.File(self.path_hdf5, "r") as f:
+            for i, ct in enumerate(self.cst_lst):
+                if self.status[ct]:
+                    input_tensor = line[ct] * missing_modalities[i]
+                else:
+                    input_tensor = f[line[ct]][line['Slices']] * missing_modalities[i]
+
+                input_tensors.append(input_tensor)
+                # input Metadata
+                metadata = imed_loader_utils.SampleMetadata({key: value for key, value in f['{}/inputs/{}'
+                                                            .format(line['Subjects'], ct)].attrs.items()})
+                metadata['slice_index'] = line["Slices"]
+                metadata['missing_mod'] = missing_modalities
+                metadata['crop_params'] = {}
+                input_metadata.append(metadata)
+
+            # GT
+            gt_img = []
+            gt_metadata = []
+            for idx, gt in enumerate(self.gt_lst):
+                if self.status['gt/' + gt]:
+                    gt_data = line['gt/' + gt]
+                else:
+                    gt_data = f[line['gt/' + gt]][line['Slices']]
+
+                gt_data = gt_data.astype(np.uint8)
+                gt_img.append(gt_data)
+                gt_metadata.append(imed_loader_utils.SampleMetadata({key: value for key, value in
+                                                                     f[line['gt/' + gt]].attrs.items()}))
+                gt_metadata[idx]['crop_params'] = {}
+
+            # ROI
+            roi_img = []
+            roi_metadata = []
+            if self.roi_lst:
+                if self.status['roi/' + self.roi_lst[0]]:
+                    roi_data = line['roi/' + self.roi_lst[0]]
+                else:
+                    roi_data = f[line['roi/' + self.roi_lst[0]]][line['Slices']]
+
+                roi_data = roi_data.astype(np.uint8)
+                roi_img.append(roi_data)
+
+                roi_metadata.append(imed_loader_utils.SampleMetadata({key: value for key, value in
+                                                                      f[
+                                                                          line['roi/' + self.roi_lst[0]]].attrs.items()}))
+                roi_metadata[0]['crop_params'] = {}
+
+            # Run transforms on ROI
+            # ROI goes first because params of ROICrop are needed for the followings
+            stack_roi, metadata_roi = self.transform(sample=roi_img,
+                                                     metadata=roi_metadata,
+                                                     data_type="roi")
+            # Update metadata_input with metadata_roi
+            metadata_input = imed_loader_utils.update_metadata(metadata_roi, input_metadata)
+
+            # Run transforms on images
+            stack_input, metadata_input = self.transform(sample=input_tensors,
+                                                         metadata=metadata_input,
+                                                         data_type="im")
+            # Update metadata_input with metadata_roi
+            metadata_gt = imed_loader_utils.update_metadata(metadata_input, gt_metadata)
+
+            # Run transforms on images
+            stack_gt, metadata_gt = self.transform(sample=gt_img,
+                                                   metadata=metadata_gt,
+                                                   data_type="gt")
+            data_dict = {
+                'input': stack_input,
+                'gt': stack_gt,
+                'roi': stack_roi,
+                'input_metadata': metadata_input,
+                'gt_metadata': metadata_gt,
+                'roi_metadata': metadata_roi
+            }
+
+            return data_dict
+
+    def update(self, strategy="Missing", p=0.0001):
+        """Update the Dataframe itself.
+
+        Args:
+            p (float): Float between 0 and 1, probability of the contrast to be missing.
+            strategy (str): Update the dataframe using the corresponding strategy. For now the only the strategy
+                implemented is the one used by HeMIS (i.e. by removing contrasts with a certain probability.) Other
+                strategies that could be implemented are Active Learning, Curriculum Learning, ...
+        """
+        if strategy == 'Missing':
+            print("Probalility of missing contrast = {}".format(p))
+            for idx in range(len(self.dataframe)):
+                missing_mod = np.random.choice(2, len(self.cst_lst), p=[p, 1 - p])
+                # if all contrasts are removed from a subject randomly choose 1
+                if not np.any(missing_mod):
+                    missing_mod = np.zeros((len(self.cst_lst)))
+                    missing_mod[np.random.randint(2, size=1)] = 1
+                self.cst_matrix[idx, ] = missing_mod
+
+            print("Missing contrasts = {}".format(self.cst_matrix.size - self.cst_matrix.sum()))
+
+
+def HDF5ToBIDS(path_hdf5, subjects, path_dir):
+    """Convert HDF5 file to BIDS dataset.
+
+    Args:
+        path_hdf5 (str): Path to the HDF5 file.
+        subjects (list): List of subject names.
+        path_dir (str): Output folder path, already existing.
+    """
+    # Open FDH5 file
+    with h5py.File(path_hdf5, "r") as hdf5_file:
+        # check the dir exists:
+        if not path.exists(path_dir):
+            raise FileNotFoundError("Directory {} doesn't exist. Stopping process.".format(path_dir))
+
+        # loop over all subjects
+        for sub in subjects:
+            path_sub = path_dir + '/' + sub + '/anat/'
+            path_label = path_dir + '/derivatives/labels/' + sub + '/anat/'
+
+            if not path.exists(path_sub):
+                os.makedirs(path_sub)
+
+            if not path.exists(path_label):
+                os.makedirs(path_label)
+
+            # Get Subject Group
+            try:
+                grp = hdf5_file[sub]
+            except Exception:
+                continue
+            # inputs
+            cts = grp['inputs'].attrs['contrast']
+
+            # Relation between voxel and world coordinates is not available
+            for ct in cts:
+                input_data = np.array(grp['inputs/{}'.format(ct)])
+                nib_image = nib.Nifti1Image(input_data, np.eye(4))
+                filename = os.path.join(path_sub, sub + "_" + ct + ".nii.gz")
+                nib.save(nib_image, filename)
+
+            # GT
+            cts = grp['gt'].attrs['contrast']
+
+            for ct in cts:
+                for filename in grp['gt/{}'.format(ct)].attrs['gt_filenames']:
+                    gt_data = grp['gt/{}'.format(ct)]
+                    nib_image = nib.Nifti1Image(gt_data, np.eye(4))
+                    filename = os.path.join(path_label, filename.split("/")[-1])
+                    nib.save(nib_image, filename)
+
+            cts = grp['roi'].attrs['contrast']
+
+            for ct in cts:
+                roi_data = grp['roi/{}'.format(ct)]
+                if np.any(roi_data.shape):
+                    nib_image = nib.Nifti1Image(roi_data, np.eye(4))
+                    filename = os.path.join(path_label,
+                                            grp['roi/{}'.format(ct)].attrs['roi_filename'][0].split("/")[-1])
+                    nib.save(nib_image, filename)

--- a/ivadomed/loader/adaptative_new.py
+++ b/ivadomed/loader/adaptative_new.py
@@ -177,6 +177,7 @@ class BIDStoHDF5:
     """Converts a BIDS dataset to a HDF5 file.
 
     Args:
+        bids_df (BidsDataframe): Object containing dataframe with all BIDS image files and their metadata.
         path_data (list) or (str): Path(s) to BIDS datasets
         subject_lst (list): Subject names list.
         target_suffix (list): List of suffixes for target masks.
@@ -204,7 +205,7 @@ class BIDStoHDF5:
         slice_filter_fn (SliceFilter): Object that filters slices according to their content.
     """
 
-    def __init__(self, path_data, subject_lst, target_suffix, contrast_lst, path_hdf5, contrast_balance=None,
+    def __init__(self, bids_df, path_data, subject_lst, target_suffix, contrast_lst, path_hdf5, contrast_balance=None,
                  slice_axis=2, metadata_choice=False, slice_filter_fn=None, roi_params=None, transform=None,
                  object_detection_params=None, soft_gt=False):
         print("Starting conversion")
@@ -482,6 +483,7 @@ class HDF5Dataset:
     """HDF5 dataset object.
 
     Args:
+        bids_df (BidsDataframe): Object containing dataframe with all BIDS image files and their metadata.
         path_data (list) or (str): Path(s) to BIDS datasets
         subject_lst (list of str): List of subjects.
         model_params (dict): Dictionary containing model parameters.
@@ -508,7 +510,7 @@ class HDF5Dataset:
 
     """
 
-    def __init__(self, path_data, subject_lst, model_params, target_suffix, contrast_params,
+    def __init__(self, bids_df, path_data, subject_lst, model_params, target_suffix, contrast_params,
                  slice_axis=2, transform=None, metadata_choice=False, dim=2, complet=True,
                  slice_filter_fn=None, roi_params=None, object_detection_params=None, soft_gt=False):
         self.cst_lst = copy.deepcopy(contrast_params["contrast_lst"])
@@ -523,7 +525,8 @@ class HDF5Dataset:
         # Getting HDS5 dataset file
         if not os.path.exists(model_params["path_hdf5"]):
             print("Computing hdf5 file of the data")
-            bids_to_hdf5 = BIDStoHDF5(path_data=path_data,
+            bids_to_hdf5 = BIDStoHDF5(bids_df=bids_df,
+                                      path_data=path_data,
                                       subject_lst=subject_lst,
                                       path_hdf5=model_params["path_hdf5"],
                                       target_suffix=target_suffix,

--- a/ivadomed/loader/adaptative_new.py
+++ b/ivadomed/loader/adaptative_new.py
@@ -217,6 +217,10 @@ class BIDStoHDF5:
         # Sort subject_lst and create a sub-dataframe from bids_df containing only subjects from subject_lst
         subject_lst = sorted(subject_lst)
         df_subjects = bids_df.df[bids_df.df['filename'].isin(subject_lst)]
+        # Backward compatibility for subject_lst containing participant_ids instead of filenames
+        if df_subjects.empty:
+            df_subjects = bids_df.df[bids_df.df['participant_id'].isin(subject_lst)]
+            subject_lst = sorted(df_subjects['filename'].to_list())
 
         self.soft_gt = soft_gt
         self.dt = h5py.special_dtype(vlen=str)

--- a/ivadomed/loader/adaptative_new.py
+++ b/ivadomed/loader/adaptative_new.py
@@ -214,7 +214,8 @@ class BIDStoHDF5:
 
         path_data = imed_utils.format_path_data(path_data)
 
-        # Create a sub-dataframe from bids_df containing only subjects from subject_lst
+        # Sort subject_lst and create a sub-dataframe from bids_df containing only subjects from subject_lst
+        subject_lst = sorted(subject_lst)
         df_subjects = bids_df.df[bids_df.df['filename'].isin(subject_lst)]
 
         self.soft_gt = soft_gt

--- a/ivadomed/loader/loader_new.py
+++ b/ivadomed/loader/loader_new.py
@@ -1,0 +1,929 @@
+import copy
+import random
+import nibabel as nib
+import numpy as np
+import torch
+import pandas as pd
+import os
+from bids_neuropoly import bids
+from torch.utils.data import Dataset
+from tqdm import tqdm
+
+from ivadomed import postprocessing as imed_postpro
+from ivadomed import transforms as imed_transforms
+from ivadomed import utils as imed_utils
+from ivadomed.loader import utils as imed_loader_utils, adaptative as imed_adaptative, film as imed_film
+from ivadomed.object_detection import utils as imed_obj_detect
+
+
+def load_dataset(data_list, path_data, transforms_params, model_params, target_suffix, roi_params,
+                 contrast_params, slice_filter_params, slice_axis, multichannel,
+                 dataset_type="training", requires_undo=False, metadata_type=None,
+                 object_detection_params=None, soft_gt=False, device=None,
+                 cuda_available=None, **kwargs):
+    """Get loader appropriate loader according to model type. Available loaders are Bids3DDataset for 3D data,
+    BidsDataset for 2D data and HDF5Dataset for HeMIS.
+
+    Args:
+        data_list (list): Subject names list.
+        path_data (list) or (str): Path to the BIDS dataset(s).
+        transforms_params (dict): Dictionary containing transformations for "training", "validation", "testing" (keys),
+            eg output of imed_transforms.get_subdatasets_transforms.
+        model_params (dict): Dictionary containing model parameters.
+        target_suffix (list of str): List of suffixes for target masks.
+        roi_params (dict): Contains ROI related parameters.
+        contrast_params (dict): Contains image contrasts related parameters.
+        slice_filter_params (dict): Contains slice_filter parameters, see :doc:`configuration_file` for more details.
+        slice_axis (string): Choice between "axial", "sagittal", "coronal" ; controls the axis used to extract the 2D
+            data.
+        multichannel (bool): If True, the input contrasts are combined as input channels for the model. Otherwise, each
+            contrast is processed individually (ie different sample / tensor).
+        metadata_type (str): Choice between None, "mri_params", "contrasts".
+        dataset_type (str): Choice between "training", "validation" or "testing".
+        requires_undo (bool): If True, the transformations without undo_transform will be discarded.
+        object_detection_params (dict): Object dection parameters.
+        soft_gt (bool): If True, ground truths are not binarized before being fed to the network. Otherwise, ground
+        truths are thresholded (0.5) after the data augmentation operations.
+    Returns:
+        BidsDataset
+
+    Note: For more details on the parameters transform_params, target_suffix, roi_params, contrast_params,
+    slice_filter_params and object_detection_params see :doc:`configuration_file`.
+    """
+    # Compose transforms
+    tranform_lst, _ = imed_transforms.prepare_transforms(copy.deepcopy(transforms_params), requires_undo)
+
+    # If ROICrop is not part of the transforms, then enforce no slice filtering based on ROI data.
+    if 'ROICrop' not in transforms_params:
+        roi_params["slice_filter_roi"] = None
+
+    if model_params["name"] == "Modified3DUNet" or ('is_2d' in model_params and not model_params['is_2d']):
+        dataset = Bids3DDataset(path_data,
+                                subject_lst=data_list,
+                                target_suffix=target_suffix,
+                                roi_params=roi_params,
+                                contrast_params=contrast_params,
+                                metadata_choice=metadata_type,
+                                slice_axis=imed_utils.AXIS_DCT[slice_axis],
+                                transform=tranform_lst,
+                                multichannel=multichannel,
+                                model_params=model_params,
+                                object_detection_params=object_detection_params,
+                                soft_gt=soft_gt)
+
+    elif model_params["name"] == "HeMISUnet":
+        dataset = imed_adaptative.HDF5Dataset(path_data=path_data,
+                                              subject_lst=data_list,
+                                              model_params=model_params,
+                                              contrast_params=contrast_params,
+                                              target_suffix=target_suffix,
+                                              slice_axis=imed_utils.AXIS_DCT[slice_axis],
+                                              transform=tranform_lst,
+                                              metadata_choice=metadata_type,
+                                              slice_filter_fn=imed_loader_utils.SliceFilter(**slice_filter_params,
+                                                                                            device=device,
+                                                                                            cuda_available=cuda_available),
+                                              roi_params=roi_params,
+                                              object_detection_params=object_detection_params,
+                                              soft_gt=soft_gt)
+    else:
+        # Task selection
+        task = imed_utils.get_task(model_params["name"])
+
+        dataset = BidsDataset(path_data,
+                              subject_lst=data_list,
+                              target_suffix=target_suffix,
+                              roi_params=roi_params,
+                              contrast_params=contrast_params,
+                              metadata_choice=metadata_type,
+                              slice_axis=imed_utils.AXIS_DCT[slice_axis],
+                              transform=tranform_lst,
+                              multichannel=multichannel,
+                              slice_filter_fn=imed_loader_utils.SliceFilter(**slice_filter_params, device=device,
+                                                                            cuda_available=cuda_available),
+                              soft_gt=soft_gt,
+                              object_detection_params=object_detection_params,
+                              task=task)
+        dataset.load_filenames()
+
+    if model_params["name"] != "Modified3DUNet":
+        print("Loaded {} {} slices for the {} set.".format(len(dataset), slice_axis, dataset_type))
+    else:
+        print("Loaded {} volumes of size {} for the {} set.".format(len(dataset), slice_axis, dataset_type))
+
+    return dataset
+
+
+class SegmentationPair(object):
+    """This class is used to build segmentation datasets. It represents
+    a pair of of two data volumes (the input data and the ground truth data).
+
+    Args:
+        input_filenames (list of str): The input filename list (supported by nibabel). For single channel, the list will
+            contain 1 input filename.
+        gt_filenames (list of str): The ground-truth filenames list.
+        metadata (list): Metadata list with each item corresponding to an image (contrast) in input_filenames.
+            For single channel, the list will contain metadata related to one image.
+        cache (bool): If the data should be cached in memory or not.
+        slice_axis (int): Indicates the axis used to extract slices: "axial": 2, "sagittal": 0, "coronal": 1.
+        prepro_transforms (dict): Output of get_preprocessing_transforms.
+
+    Attributes:
+        input_filenames (list): List of input filenames.
+        gt_filenames (list): List of ground truth filenames.
+        metadata (dict): Dictionary containing metadata of input and gt.
+        cache (bool): If the data should be cached in memory or not.
+        slice_axis (int): Indicates the axis used to extract slices: "axial": 2, "sagittal": 0, "coronal": 1.
+        prepro_transforms (dict): Transforms to be applied before training.
+        input_handle (list): List of input nifty data.
+        gt_handle (list): List of gt nifty data.
+    """
+
+    def __init__(self, input_filenames, gt_filenames, metadata=None, slice_axis=2, cache=True, prepro_transforms=None,
+                 soft_gt=False):
+
+        self.input_filenames = input_filenames
+        self.gt_filenames = gt_filenames
+        self.metadata = metadata
+        self.cache = cache
+        self.slice_axis = slice_axis
+        self.soft_gt = soft_gt
+        self.prepro_transforms = prepro_transforms
+        # list of the images
+        self.input_handle = []
+
+        # loop over the filenames (list)
+        for input_file in self.input_filenames:
+            input_img = nib.load(input_file)
+            self.input_handle.append(input_img)
+            if len(input_img.shape) > 3:
+                raise RuntimeError("4-dimensional volumes not supported.")
+
+        # list of GT for multiclass segmentation
+        self.gt_handle = []
+
+        # Labeled data (ie not inference time)
+        if self.gt_filenames is not None:
+            if not isinstance(self.gt_filenames, list):
+                self.gt_filenames = [self.gt_filenames]
+            for gt in self.gt_filenames:
+                if gt is not None:
+                    if isinstance(gt, str):  # this tissue has annotation from only one rater
+                        self.gt_handle.append(nib.load(gt))
+                    else:  # this tissue has annotation from several raters
+                        self.gt_handle.append([nib.load(gt_rater) for gt_rater in gt])
+                else:
+                    self.gt_handle.append(None)
+
+        # Sanity check for dimensions, should be the same
+        input_shape, gt_shape = self.get_pair_shapes()
+
+        if self.gt_filenames is not None and self.gt_filenames[0] is not None:
+            if not np.allclose(input_shape, gt_shape):
+                raise RuntimeError('Input and ground truth with different dimensions.')
+
+        for idx, handle in enumerate(self.input_handle):
+            self.input_handle[idx] = nib.as_closest_canonical(handle)
+
+        # Labeled data (ie not inference time)
+        if self.gt_filenames is not None:
+            for idx, gt in enumerate(self.gt_handle):
+                if gt is not None:
+                    if not isinstance(gt, list):  # this tissue has annotation from only one rater
+                        self.gt_handle[idx] = nib.as_closest_canonical(gt)
+                    else:  # this tissue has annotation from several raters
+                        self.gt_handle[idx] = [nib.as_closest_canonical(gt_rater) for gt_rater in gt]
+
+        # If binary classification, then extract labels from GT mask
+
+        if self.metadata:
+            self.metadata = []
+            for data, input_filename in zip(metadata, input_filenames):
+                data["input_filenames"] = input_filename
+                data["gt_filenames"] = gt_filenames
+                self.metadata.append(data)
+
+    def get_pair_shapes(self):
+        """Return the tuple (input, ground truth) representing both the input and ground truth shapes."""
+        input_shape = []
+        for handle in self.input_handle:
+            shape = imed_loader_utils.orient_shapes_hwd(handle.header.get_data_shape(), self.slice_axis)
+            input_shape.append(tuple(shape))
+
+            if not len(set(input_shape)):
+                raise RuntimeError('Inputs have different dimensions.')
+
+        gt_shape = []
+
+        for gt in self.gt_handle:
+            if gt is not None:
+                if not isinstance(gt, list):  # this tissue has annotation from only one rater
+                    gt = [gt]
+                for gt_rater in gt:
+                    shape = imed_loader_utils.orient_shapes_hwd(gt_rater.header.get_data_shape(), self.slice_axis)
+                    gt_shape.append(tuple(shape))
+
+                if not len(set(gt_shape)):
+                    raise RuntimeError('Labels have different dimensions.')
+
+        return input_shape[0], gt_shape[0] if len(gt_shape) else None
+
+    def get_pair_data(self):
+        """Return the tuple (input, ground truth) with the data content in numpy array."""
+        cache_mode = 'fill' if self.cache else 'unchanged'
+
+        input_data = []
+        for handle in self.input_handle:
+            hwd_oriented = imed_loader_utils.orient_img_hwd(handle.get_fdata(cache_mode, dtype=np.float32),
+                                                            self.slice_axis)
+            input_data.append(hwd_oriented)
+
+        gt_data = []
+        # Handle unlabeled data
+        if self.gt_handle is None:
+            gt_data = None
+        for gt in self.gt_handle:
+            if gt is not None:
+                if not isinstance(gt, list):  # this tissue has annotation from only one rater
+                    hwd_oriented = imed_loader_utils.orient_img_hwd(gt.get_fdata(cache_mode, dtype=np.float32),
+                                                                    self.slice_axis)
+                    gt_data.append(hwd_oriented)
+                else:  # this tissue has annotation from several raters
+                    hwd_oriented_list = [
+                        imed_loader_utils.orient_img_hwd(gt_rater.get_fdata(cache_mode, dtype=np.float32),
+                                                         self.slice_axis) for gt_rater in gt]
+                    gt_data.append([hwd_oriented.astype(data_type) for hwd_oriented in hwd_oriented_list])
+            else:
+                gt_data.append(
+                    np.zeros(imed_loader_utils.orient_shapes_hwd(self.input_handle[0].shape, self.slice_axis),
+                             dtype=np.float32).astype(np.uint8))
+
+        return input_data, gt_data
+
+    def get_pair_metadata(self, slice_index=0, coord=None):
+        """Return dictionary containing input and gt metadata.
+
+        Args:
+            slice_index (int): Index of 2D slice if 2D model is used, else 0.
+            coord (tuple or list): Coordinates of subvolume in volume if 3D model is used, else None.
+
+        Returns:
+            dict: Input and gt metadata.
+        """
+        gt_meta_dict = []
+        for idx_class, gt in enumerate(self.gt_handle):
+            if gt is not None:
+                if not isinstance(gt, list):  # this tissue has annotation from only one rater
+                    gt_meta_dict.append(imed_loader_utils.SampleMetadata({
+                        "zooms": imed_loader_utils.orient_shapes_hwd(gt.header.get_zooms(), self.slice_axis),
+                        "data_shape": imed_loader_utils.orient_shapes_hwd(gt.header.get_data_shape(), self.slice_axis),
+                        "gt_filenames": self.metadata[0]["gt_filenames"],
+                        "bounding_box": self.metadata[0]["bounding_box"] if 'bounding_box' in self.metadata[
+                            0] else None,
+                        "data_type": 'gt',
+                        "crop_params": {}
+                    }))
+                else:
+                    gt_meta_dict.append([imed_loader_utils.SampleMetadata({
+                        "zooms": imed_loader_utils.orient_shapes_hwd(gt_rater.header.get_zooms(), self.slice_axis),
+                        "data_shape": imed_loader_utils.orient_shapes_hwd(gt_rater.header.get_data_shape(),
+                                                                          self.slice_axis),
+                        "gt_filenames": self.metadata[0]["gt_filenames"][idx_class][idx_rater],
+                        "bounding_box": self.metadata[0]["bounding_box"] if 'bounding_box' in self.metadata[
+                            0] else None,
+                        "data_type": 'gt',
+                        "crop_params": {}
+                    }) for idx_rater, gt_rater in enumerate(gt)])
+
+            else:
+                # Temporarily append null metadata to null gt
+                gt_meta_dict.append(None)
+
+        # Replace null metadata with metadata from other existing classes of the same subject
+        for idx, gt_metadata in enumerate(gt_meta_dict):
+            if gt_metadata is None:
+                gt_meta_dict[idx] = list(filter(None, gt_meta_dict))[0]
+
+        input_meta_dict = []
+        for handle in self.input_handle:
+            input_meta_dict.append(imed_loader_utils.SampleMetadata({
+                "zooms": imed_loader_utils.orient_shapes_hwd(handle.header.get_zooms(), self.slice_axis),
+                "data_shape": imed_loader_utils.orient_shapes_hwd(handle.header.get_data_shape(), self.slice_axis),
+                "data_type": 'im',
+                "crop_params": {}
+            }))
+
+        dreturn = {
+            "input_metadata": input_meta_dict,
+            "gt_metadata": gt_meta_dict,
+        }
+
+        for idx, metadata in enumerate(self.metadata):  # loop across channels
+            metadata["slice_index"] = slice_index
+            metadata["coord"] = coord
+            self.metadata[idx] = metadata
+            for metadata_key in metadata.keys():  # loop across input metadata
+                dreturn["input_metadata"][idx][metadata_key] = metadata[metadata_key]
+
+        return dreturn
+
+    def get_pair_slice(self, slice_index, gt_type="segmentation"):
+        """Return the specified slice from (input, ground truth).
+
+        Args:
+            slice_index (int): Slice number.
+            gt_type (str): Choice between segmentation or classification, returns mask (array) or label (int) resp.
+                for the ground truth.
+        """
+
+        metadata = self.get_pair_metadata(slice_index)
+        input_dataobj, gt_dataobj = self.get_pair_data()
+
+        if self.slice_axis not in [0, 1, 2]:
+            raise RuntimeError("Invalid axis, must be between 0 and 2.")
+
+        input_slices = []
+        # Loop over contrasts
+        for data_object in input_dataobj:
+            input_slices.append(np.asarray(data_object[..., slice_index],
+                                           dtype=np.float32))
+
+        # Handle the case for unlabeled data
+        if self.gt_handle is None:
+            gt_slices = None
+        else:
+            gt_slices = []
+            for gt_obj in gt_dataobj:
+                if gt_type == "segmentation":
+                    if not isinstance(gt_obj, list):  # annotation from only one rater
+                        gt_slices.append(np.asarray(gt_obj[..., slice_index],
+                                                    dtype=np.float32))
+                    else:  # annotations from several raters
+                        gt_slices.append([np.asarray(gt_obj_rater[..., slice_index],
+                                                     dtype=np.float32) for gt_obj_rater in gt_obj])
+                else:
+                    if not isinstance(gt_obj, list):  # annotation from only one rater
+                        gt_slices.append(np.asarray(int(np.any(gt_obj[..., slice_index]))))
+                    else:  # annotations from several raters
+                        gt_slices.append([np.asarray(int(np.any(gt_obj_rater[..., slice_index])))
+                                          for gt_obj_rater in gt_obj])
+        dreturn = {
+            "input": input_slices,
+            "gt": gt_slices,
+            "input_metadata": metadata["input_metadata"],
+            "gt_metadata": metadata["gt_metadata"],
+        }
+
+        return dreturn
+
+
+class MRI2DSegmentationDataset(Dataset):
+    """Generic class for 2D (slice-wise) segmentation dataset.
+
+    Args:
+        filename_pairs (list): a list of tuples in the format (input filename list containing all modalities,ground \
+            truth filename, ROI filename, metadata).
+        slice_axis (int): axis to make the slicing (default axial).
+        cache (bool): if the data should be cached in memory or not.
+        transform (torchvision.Compose): transformations to apply.
+        slice_filter_fn (dict): Slice filter parameters, see :doc:`configuration_file` for more details.
+        task (str): choice between segmentation or classification. If classification: GT is discrete values, \
+            If segmentation: GT is binary mask.
+        roi_params (dict): Dictionary containing parameters related to ROI image processing.
+        soft_gt (bool): If True, ground truths are not binarized before being fed to the network. Otherwise, ground
+        truths are thresholded (0.5) after the data augmentation operations.
+
+    Attributes:
+        indexes (list): List of indices corresponding to each slice or subvolume in the dataset.
+        filename_pairs (list): List of tuples in the format (input filename list containing all modalities,ground \
+            truth filename, ROI filename, metadata).
+        prepro_transforms (Compose): Transformations to apply before training.
+        transform (Compose): Transformations to apply during training.
+        cache (bool): Tf the data should be cached in memory or not.
+        slice_axis (int): Indicates the axis used to extract slices: "axial": 2, "sagittal": 0, "coronal": 1.
+        slice_filter_fn (dict): Slice filter parameters, see :doc:`configuration_file` for more details.
+        n_contrasts (int): Number of input contrasts.
+        has_bounding_box (bool): True if bounding box in all metadata, else False.
+        task (str): Choice between segmentation or classification. If classification: GT is discrete values, \
+            If segmentation: GT is binary mask.
+        soft_gt (bool): If True, ground truths are not binarized before being fed to the network. Otherwise, ground
+        truths are thresholded (0.5) after the data augmentation operations.
+        slice_filter_roi (bool): Indicates whether a slice filtering is done based on ROI data.
+        roi_thr (int): If the ROI mask contains less than this number of non-zero voxels, the slice will be discarded
+            from the dataset.
+
+    """
+
+    def __init__(self, filename_pairs, slice_axis=2, cache=True, transform=None, slice_filter_fn=None,
+                 task="segmentation", roi_params=None, soft_gt=False):
+        self.indexes = []
+        self.filename_pairs = filename_pairs
+        self.prepro_transforms, self.transform = transform
+        self.cache = cache
+        self.slice_axis = slice_axis
+        self.slice_filter_fn = slice_filter_fn
+        self.n_contrasts = len(self.filename_pairs[0][0])
+        if roi_params is None:
+            roi_params = {"suffix": None, "slice_filter_roi": None}
+        self.roi_thr = roi_params["slice_filter_roi"]
+        self.slice_filter_roi = roi_params["suffix"] is not None and isinstance(self.roi_thr, int)
+        self.soft_gt = soft_gt
+        self.has_bounding_box = True
+        self.task = task
+
+    def load_filenames(self):
+        """Load preprocessed pair data (input and gt) in handler."""
+        for input_filenames, gt_filenames, roi_filename, metadata in self.filename_pairs:
+            roi_pair = SegmentationPair(input_filenames, roi_filename, metadata=metadata, slice_axis=self.slice_axis,
+                                        cache=self.cache, prepro_transforms=self.prepro_transforms)
+
+            seg_pair = SegmentationPair(input_filenames, gt_filenames, metadata=metadata, slice_axis=self.slice_axis,
+                                        cache=self.cache, prepro_transforms=self.prepro_transforms,
+                                        soft_gt=self.soft_gt)
+
+            input_data_shape, _ = seg_pair.get_pair_shapes()
+
+            for idx_pair_slice in range(input_data_shape[-1]):
+                slice_seg_pair = seg_pair.get_pair_slice(idx_pair_slice, gt_type=self.task)
+                self.has_bounding_box = imed_obj_detect.verify_metadata(slice_seg_pair, self.has_bounding_box)
+                if self.has_bounding_box:
+                    self.prepro_transforms = imed_obj_detect.adjust_transforms(self.prepro_transforms, slice_seg_pair)
+
+                if self.slice_filter_fn and not self.slice_filter_fn(slice_seg_pair):
+                    continue
+
+                # Note: we force here gt_type=segmentation since ROI slice is needed to Crop the image
+                slice_roi_pair = roi_pair.get_pair_slice(idx_pair_slice, gt_type="segmentation")
+
+                if self.slice_filter_roi and imed_loader_utils.filter_roi(slice_roi_pair['gt'], self.roi_thr):
+                    continue
+
+                item = imed_transforms.apply_preprocessing_transforms(self.prepro_transforms,
+                                                                      slice_seg_pair,
+                                                                      slice_roi_pair)
+                self.indexes.append(item)
+
+    def set_transform(self, transform):
+        self.transform = transform
+
+    def __len__(self):
+        return len(self.indexes)
+
+    def __getitem__(self, index):
+        """Return the specific processed data corresponding to index (input, ground truth, roi and metadata).
+
+        Args:
+            index (int): Slice index.
+        """
+        seg_pair_slice, roi_pair_slice = self.indexes[index]
+
+        # In case multiple raters
+        if seg_pair_slice['gt'] is not None and isinstance(seg_pair_slice['gt'][0], list):
+            # Randomly pick a rater
+            idx_rater = random.randint(0, len(seg_pair_slice['gt'][0]) - 1)
+            # Use it as ground truth for this iteration
+            # Note: in case of multi-class: the same rater is used across classes
+            for idx_class in range(len(seg_pair_slice['gt'])):
+                seg_pair_slice['gt'][idx_class] = seg_pair_slice['gt'][idx_class][idx_rater]
+                seg_pair_slice['gt_metadata'][idx_class] = seg_pair_slice['gt_metadata'][idx_class][idx_rater]
+
+        # Clean transforms params from previous transforms
+        # i.e. remove params from previous iterations so that the coming transforms are different
+        metadata_input = imed_loader_utils.clean_metadata(seg_pair_slice['input_metadata'])
+        metadata_roi = imed_loader_utils.clean_metadata(roi_pair_slice['gt_metadata'])
+        metadata_gt = imed_loader_utils.clean_metadata(seg_pair_slice['gt_metadata'])
+
+        # Run transforms on ROI
+        # ROI goes first because params of ROICrop are needed for the followings
+        stack_roi, metadata_roi = self.transform(sample=roi_pair_slice["gt"],
+                                                 metadata=metadata_roi,
+                                                 data_type="roi")
+
+        # Update metadata_input with metadata_roi
+        metadata_input = imed_loader_utils.update_metadata(metadata_roi, metadata_input)
+
+        # Run transforms on images
+        stack_input, metadata_input = self.transform(sample=seg_pair_slice["input"],
+                                                     metadata=metadata_input,
+                                                     data_type="im")
+
+        # Update metadata_input with metadata_roi
+        metadata_gt = imed_loader_utils.update_metadata(metadata_input, metadata_gt)
+
+        if self.task == "segmentation":
+            # Run transforms on images
+            stack_gt, metadata_gt = self.transform(sample=seg_pair_slice["gt"],
+                                                   metadata=metadata_gt,
+                                                   data_type="gt")
+            # Make sure stack_gt is binarized
+            if stack_gt is not None and not self.soft_gt:
+                stack_gt = imed_postpro.threshold_predictions(stack_gt, thr=0.5).astype(np.uint8)
+
+        else:
+            # Force no transformation on labels for classification task
+            # stack_gt is a tensor of size 1x1, values: 0 or 1
+            # "expand(1)" is necessary to be compatible with segmentation convention: n_labelxhxwxd
+            stack_gt = torch.from_numpy(seg_pair_slice["gt"][0]).expand(1)
+
+        data_dict = {
+            'input': stack_input,
+            'gt': stack_gt,
+            'roi': stack_roi,
+            'input_metadata': metadata_input,
+            'gt_metadata': metadata_gt,
+            'roi_metadata': metadata_roi
+        }
+
+        return data_dict
+
+
+class MRI3DSubVolumeSegmentationDataset(Dataset):
+    """This is a class for 3D segmentation dataset. This class splits the initials volumes in several
+    subvolumes. Each subvolumes will be of the sizes of the length parameter.
+
+    This class also implement a stride parameter corresponding to the amount of voxels subvolumes are translated in
+    each dimension at every iteration.
+
+    Be careful, the input's dimensions should be compatible with the given
+    lengths and strides. This class doesn't handle missing dimensions.
+
+    Args:
+        filename_pairs (list): A list of tuples in the format (input filename, ground truth filename).
+        transform (Compose): Transformations to apply.
+        length (tuple): Size of each dimensions of the subvolumes, length equals 3.
+        stride (tuple): Size of the overlapping per subvolume and dimensions, length equals 3.
+        slice_axis (int): Indicates the axis used to extract slices: "axial": 2, "sagittal": 0, "coronal": 1.
+        soft_gt (bool): If True, ground truths are not binarized before being fed to the network. Otherwise, ground
+        truths are thresholded (0.5) after the data augmentation operations.
+    """
+
+    def __init__(self, filename_pairs, transform=None, length=(64, 64, 64), stride=(0, 0, 0), slice_axis=0,
+                 task="segmentation",
+                 soft_gt=False):
+        self.filename_pairs = filename_pairs
+        self.handlers = []
+        self.indexes = []
+        self.length = length
+        self.stride = stride
+        self.prepro_transforms, self.transform = transform
+        self.slice_axis = slice_axis
+        self.has_bounding_box = True
+        self.task = task
+        self.soft_gt = soft_gt
+
+        self._load_filenames()
+        self._prepare_indices()
+
+    def _load_filenames(self):
+        """Load preprocessed pair data (input and gt) in handler."""
+        for input_filename, gt_filename, roi_filename, metadata in self.filename_pairs:
+            segpair = SegmentationPair(input_filename, gt_filename, metadata=metadata, slice_axis=self.slice_axis,
+                                       soft_gt=self.soft_gt)
+            input_data, gt_data = segpair.get_pair_data()
+            metadata = segpair.get_pair_metadata()
+            seg_pair = {
+                'input': input_data,
+                'gt': gt_data,
+                'input_metadata': metadata['input_metadata'],
+                'gt_metadata': metadata['gt_metadata']
+            }
+
+            self.has_bounding_box = imed_obj_detect.verify_metadata(seg_pair, self.has_bounding_box)
+            if self.has_bounding_box:
+                self.prepro_transforms = imed_obj_detect.adjust_transforms(self.prepro_transforms, seg_pair,
+                                                                           length=self.length,
+                                                                           stride=self.stride)
+            seg_pair, roi_pair = imed_transforms.apply_preprocessing_transforms(self.prepro_transforms,
+                                                                                seg_pair=seg_pair)
+
+            for metadata in seg_pair['input_metadata']:
+                metadata['index_shape'] = seg_pair['input'][0].shape
+            self.handlers.append((seg_pair, roi_pair))
+
+    def _prepare_indices(self):
+        """Stores coordinates of subvolumes for training."""
+        for i in range(0, len(self.handlers)):
+            segpair, _ = self.handlers[i]
+            input_img = self.handlers[i][0]['input']
+            shape = input_img[0].shape
+
+            if ((shape[0] - self.length[0]) % self.stride[0]) != 0 or self.length[0] % 16 != 0 or shape[0] < \
+                    self.length[0] \
+                    or ((shape[1] - self.length[1]) % self.stride[1]) != 0 or self.length[1] % 16 != 0 or shape[1] < \
+                    self.length[1] \
+                    or ((shape[2] - self.length[2]) % self.stride[2]) != 0 or self.length[2] % 16 != 0 or shape[2] < \
+                    self.length[2]:
+                raise RuntimeError('Input shape of each dimension should be a \
+                                    multiple of length plus 2 * padding and a multiple of 16.')
+
+            for x in range(0, (shape[0] - self.length[0]) + 1, self.stride[0]):
+                for y in range(0, (shape[1] - self.length[1]) + 1, self.stride[1]):
+                    for z in range(0, (shape[2] - self.length[2]) + 1, self.stride[2]):
+                        self.indexes.append({
+                            'x_min': x,
+                            'x_max': x + self.length[0],
+                            'y_min': y,
+                            'y_max': y + self.length[1],
+                            'z_min': z,
+                            'z_max': z + self.length[2],
+                            'handler_index': i})
+
+    def __len__(self):
+        """Return the dataset size. The number of subvolumes."""
+        return len(self.indexes)
+
+    def __getitem__(self, index):
+        """Return the specific index pair subvolume (input, ground truth).
+
+        Args:
+            index (int): Subvolume index.
+        """
+        coord = self.indexes[index]
+        seg_pair, _ = self.handlers[coord['handler_index']]
+
+        # In case multiple raters
+        if seg_pair['gt'] is not None and isinstance(seg_pair['gt'][0], list):
+            # Randomly pick a rater
+            idx_rater = random.randint(0, len(seg_pair['gt'][0]) - 1)
+            # Use it as ground truth for this iteration
+            # Note: in case of multi-class: the same rater is used across classes
+            for idx_class in range(len(seg_pair['gt'])):
+                seg_pair['gt'][idx_class] = seg_pair['gt'][idx_class][idx_rater]
+                seg_pair['gt_metadata'][idx_class] = seg_pair['gt_metadata'][idx_class][idx_rater]
+
+        # Clean transforms params from previous transforms
+        # i.e. remove params from previous iterations so that the coming transforms are different
+        # Use copy to have different coordinates for reconstruction for a given handler
+        metadata_input = imed_loader_utils.clean_metadata(copy.deepcopy(seg_pair['input_metadata']))
+        metadata_gt = imed_loader_utils.clean_metadata(copy.deepcopy(seg_pair['gt_metadata']))
+
+        # Run transforms on images
+        stack_input, metadata_input = self.transform(sample=seg_pair['input'],
+                                                     metadata=metadata_input,
+                                                     data_type="im")
+        # Update metadata_gt with metadata_input
+        metadata_gt = imed_loader_utils.update_metadata(metadata_input, metadata_gt)
+
+        # Run transforms on images
+        stack_gt, metadata_gt = self.transform(sample=seg_pair['gt'],
+                                               metadata=metadata_gt,
+                                               data_type="gt")
+        # Make sure stack_gt is binarized
+        if stack_gt is not None and not self.soft_gt:
+            stack_gt = imed_postpro.threshold_predictions(stack_gt, thr=0.5).astype(np.uint8)
+
+        shape_x = coord["x_max"] - coord["x_min"]
+        shape_y = coord["y_max"] - coord["y_min"]
+        shape_z = coord["z_max"] - coord["z_min"]
+
+        # add coordinates to metadata to reconstruct volume
+        for metadata in metadata_input:
+            metadata['coord'] = [coord["x_min"], coord["x_max"], coord["y_min"], coord["y_max"], coord["z_min"],
+                                 coord["z_max"]]
+
+        subvolumes = {
+            'input': torch.zeros(stack_input.shape[0], shape_x, shape_y, shape_z),
+            'gt': torch.zeros(stack_gt.shape[0], shape_x, shape_y, shape_z) if stack_gt is not None else None,
+            'input_metadata': metadata_input,
+            'gt_metadata': metadata_gt
+        }
+
+        for _ in range(len(stack_input)):
+            subvolumes['input'] = stack_input[:,
+                                  coord['x_min']:coord['x_max'],
+                                  coord['y_min']:coord['y_max'],
+                                  coord['z_min']:coord['z_max']]
+
+        if stack_gt is not None:
+            for _ in range(len(stack_gt)):
+                subvolumes['gt'] = stack_gt[:,
+                                   coord['x_min']:coord['x_max'],
+                                   coord['y_min']:coord['y_max'],
+                                   coord['z_min']:coord['z_max']]
+
+        return subvolumes
+
+
+class Bids3DDataset(MRI3DSubVolumeSegmentationDataset):
+    """BIDS specific dataset loader for 3D dataset.
+
+    Args:
+        path_data (list) or (str): List of Paths to the BIDS datasets.
+        subject_lst (list): Subject names list.
+        target_suffix (list): List of suffixes for target masks.
+        model_params (dict): Dictionary containing model parameters.
+        contrast_params (dict): Contains image contrasts related parameters.
+        slice_axis (int): Indicates the axis used to extract slices: "axial": 2, "sagittal": 0, "coronal": 1.
+        cache (bool): If the data should be cached in memory or not.
+        transform (list): Transformation list (length 2) composed of preprocessing transforms (Compose) and transforms
+            to apply during training (Compose).
+        metadata_choice: Choice between "mri_params", "contrasts", None or False, related to FiLM.
+        roi_params (dict): Dictionary containing parameters related to ROI image processing.
+        multichannel (bool): If True, the input contrasts are combined as input channels for the model. Otherwise, each
+            contrast is processed individually (ie different sample / tensor).
+        object_detection_params (dict): Object dection parameters.
+    """
+
+    def __init__(self, path_data, subject_lst, target_suffix, model_params, contrast_params, slice_axis=2,
+                 cache=True, transform=None, metadata_choice=False, roi_params=None,
+                 multichannel=False, object_detection_params=None, task="segmentation", soft_gt=False):
+        dataset = BidsDataset(path_data=path_data,
+                              subject_lst=subject_lst,
+                              target_suffix=target_suffix,
+                              roi_params=roi_params,
+                              contrast_params=contrast_params,
+                              metadata_choice=metadata_choice,
+                              slice_axis=slice_axis,
+                              transform=transform,
+                              multichannel=multichannel,
+                              object_detection_params=object_detection_params)
+
+        super().__init__(dataset.filename_pairs, length=model_params["length_3D"], stride=model_params["stride_3D"],
+                         transform=transform, slice_axis=slice_axis, task=task, soft_gt=soft_gt)
+
+
+class BidsDataset(MRI2DSegmentationDataset):
+    """ BIDS specific dataset loader.
+
+    Args:
+        path_data (list) or (str): List of Paths to the BIDS datasets.
+        subject_lst (list): Subject names list.
+        target_suffix (list): List of suffixes for target masks.
+        contrast_params (dict): Contains image contrasts related parameters.
+        slice_axis (int): Indicates the axis used to extract slices: "axial": 2, "sagittal": 0, "coronal": 1.
+        cache (bool): If the data should be cached in memory or not.
+        transform (list): Transformation list (length 2) composed of preprocessing transforms (Compose) and transforms
+            to apply during training (Compose).
+        metadata_choice (str): Choice between "mri_params", "contrasts", the name of a column from the
+            participants.tsv file, None or False, related to FiLM.
+        slice_filter_fn (SliceFilter): Class that filters slices according to their content.
+        roi_params (dict): Dictionary containing parameters related to ROI image processing.
+        multichannel (bool): If True, the input contrasts are combined as input channels for the model. Otherwise, each
+            contrast is processed individually (ie different sample / tensor).
+        object_detection_params (dict): Object dection parameters.
+        task (str): Choice between segmentation or classification. If classification: GT is discrete values, \
+            If segmentation: GT is binary mask.
+        soft_gt (bool): If True, ground truths are not binarized before being fed to the network. Otherwise, ground
+        truths are thresholded (0.5) after the data augmentation operations.
+
+    Attributes:
+        bids_ds (BIDS): BIDS dataset.
+        filename_pairs (list): A list of tuples in the format (input filename list containing all modalities,ground \
+            truth filename, ROI filename, metadata).
+        metadata (dict): Dictionary containing FiLM metadata.
+
+    """
+
+    def __init__(self, path_data, subject_lst, target_suffix, contrast_params, slice_axis=2,
+                 cache=True, transform=None, metadata_choice=False, slice_filter_fn=None, roi_params=None,
+                 multichannel=False, object_detection_params=None, task="segmentation", soft_gt=False):
+
+        self.bids_ds = []
+        path_data = imed_utils.format_path_data(path_data)
+        for BIDSFolder in path_data:
+            self.bids_ds.append(bids.BIDS(BIDSFolder))
+
+        self.roi_params = roi_params if roi_params is not None else {"suffix": None, "slice_filter_roi": None}
+        self.soft_gt = soft_gt
+        self.filename_pairs = []
+        if metadata_choice == 'mri_params':
+            self.metadata = {"FlipAngle": [], "RepetitionTime": [],
+                             "EchoTime": [], "Manufacturer": []}
+
+        # Append subjects from all BIDSdatasets into a list
+        bids_subjects = []
+        for i_bids_folder in range(0, len(path_data)):
+            bids_subjects += [s for s in self.bids_ds[i_bids_folder].get_subjects() if s.record["subject_id"] in subject_lst]
+
+        # Create a list with the filenames for all contrasts and subjects
+        subjects_tot = []
+        for subject in bids_subjects:
+            subjects_tot.append(str(subject.record["absolute_path"]))
+
+        # Create a dictionary with the number of subjects for each contrast of contrast_balance
+
+        tot = {contrast: len([s for s in bids_subjects if s.record["modality"] == contrast])
+               for contrast in contrast_params["balance"].keys()}
+
+        # Create a counter that helps to balance the contrasts
+        c = {contrast: 0 for contrast in contrast_params["balance"].keys()}
+
+        multichannel_subjects = {}
+        if multichannel:
+            num_contrast = len(contrast_params["contrast_lst"])
+            idx_dict = {}
+            for idx, contrast in enumerate(contrast_params["contrast_lst"]):
+                idx_dict[contrast] = idx
+            multichannel_subjects = {subject: {"absolute_paths": [None] * num_contrast,
+                                               "deriv_path": None,
+                                               "roi_filename": None,
+                                               "metadata": [None] * num_contrast} for subject in subject_lst}
+
+        # Append get_subjects()
+        get_subjects_all = self.bids_ds[0].get_subjects()
+        for i_bids_folder in range(1, len(self.bids_ds)):
+            get_subjects_all.extend(self.bids_ds[i_bids_folder].get_subjects())
+
+        bounding_box_dict = imed_obj_detect.load_bounding_boxes(object_detection_params,
+                                                                    get_subjects_all,
+                                                                    slice_axis,
+                                                                    contrast_params["contrast_lst"])
+
+        for subject in tqdm(bids_subjects, desc="Loading dataset"):
+            if subject.record["modality"] in contrast_params["contrast_lst"]:
+                # Training & Validation: do not consider the contrasts over the threshold contained in contrast_balance
+                if subject.record["modality"] in contrast_params["balance"].keys():
+                    c[subject.record["modality"]] = c[subject.record["modality"]] + 1
+                    if c[subject.record["modality"]] / tot[subject.record["modality"]] > contrast_params["balance"][
+                        subject.record["modality"]]:
+                        continue
+
+                if not subject.has_derivative("labels"):
+                    print("Subject without derivative, skipping.")
+                    continue
+                derivatives = subject.get_derivatives("labels")
+                if isinstance(target_suffix[0], str):
+                    target_filename, roi_filename = [None] * len(target_suffix), None
+                else:
+                    target_filename, roi_filename = [[] for _ in range(len(target_suffix))], None
+
+                for deriv in derivatives:
+                    for idx, suffix_list in enumerate(target_suffix):
+                        # If suffix_list is a string, then only one rater annotation per class is available.
+                        # Otherwise, multiple raters segmented the same class.
+                        if isinstance(suffix_list, list):
+                            for suffix in suffix_list:
+                                if deriv.endswith(subject.record["modality"] + suffix + ".nii.gz"):
+                                    target_filename[idx].append(deriv)
+                        elif deriv.endswith(subject.record["modality"] + suffix_list + ".nii.gz"):
+                            target_filename[idx] = deriv
+
+                    if not (self.roi_params["suffix"] is None) and \
+                            deriv.endswith(subject.record["modality"] + self.roi_params["suffix"] + ".nii.gz"):
+                        roi_filename = [deriv]
+
+                if (not any(target_filename)) or (not (self.roi_params["suffix"] is None) and (roi_filename is None)):
+                    continue
+
+                if not subject.has_metadata():
+                    metadata = {}
+                else:
+                    metadata = subject.metadata()
+
+                # add contrast to metadata
+                metadata['contrast'] = subject.record["modality"]
+
+                if len(bounding_box_dict):
+                    # Take only one bounding box for cropping
+                    metadata['bounding_box'] = bounding_box_dict[str(subject.record["absolute_path"])][0]
+
+                if metadata_choice == 'mri_params':
+                    if not all([imed_film.check_isMRIparam(m, metadata, subject, self.metadata) for m in
+                                self.metadata.keys()]):
+                        continue
+
+                elif metadata_choice and metadata_choice != 'contrasts' and metadata_choice is not None:
+                    # add custom data to metadata
+                    subject_id = subject.record["subject_id"]
+
+                    df = imed_loader_utils.merge_bids_datasets(path_data)
+
+                    if metadata_choice not in df.columns:
+                        raise ValueError("The following metadata cannot be found in participants.tsv file: {}. "
+                                         "Invalid metadata choice.".format(metadata_choice))
+
+                    metadata[metadata_choice] = df[df['participant_id'] == subject_id][metadata_choice].values[0]
+
+                    # Create metadata dict for OHE
+                    data_lst = sorted(set(df[metadata_choice].values))
+                    metadata_dict = {}
+                    for idx, data in enumerate(data_lst):
+                        metadata_dict[data] = idx
+
+                    metadata['metadata_dict'] = metadata_dict
+
+                # Fill multichannel dictionary
+                if multichannel:
+                    idx = idx_dict[subject.record["modality"]]
+                    subj_id = subject.record["subject_id"]
+                    multichannel_subjects[subj_id]["absolute_paths"][idx] = subject.record.absolute_path
+                    multichannel_subjects[subj_id]["deriv_path"] = target_filename
+                    multichannel_subjects[subj_id]["metadata"][idx] = metadata
+                    if roi_filename:
+                        multichannel_subjects[subj_id]["roi_filename"] = roi_filename
+
+                else:
+                    self.filename_pairs.append(([subject.record.absolute_path],
+                                                target_filename, roi_filename, [metadata]))
+
+        if multichannel:
+            for subject in multichannel_subjects.values():
+                if None not in subject["absolute_paths"]:
+                    self.filename_pairs.append((subject["absolute_paths"], subject["deriv_path"],
+                                                subject["roi_filename"], subject["metadata"]))
+
+        if self.filename_pairs == []:
+            raise Exception('No subjects were selected - check selection of parameters on config.json (e.g. center selected + target_suffix)')
+
+        super().__init__(self.filename_pairs, slice_axis, cache, transform, slice_filter_fn, task, self.roi_params,
+                         self.soft_gt)

--- a/ivadomed/loader/loader_new.py
+++ b/ivadomed/loader/loader_new.py
@@ -799,7 +799,8 @@ class BidsDataset(MRI2DSegmentationDataset):
             self.metadata = {"FlipAngle": [], "RepetitionTime": [],
                              "EchoTime": [], "Manufacturer": []}
 
-        # Create a sub-dataframe from bids_df containing only subjects from subject_lst
+        # Sort subject_lst and create a sub-dataframe from bids_df containing only subjects from subject_lst
+        subject_lst = sorted(subject_lst)
         df_subjects = bids_df.df[bids_df.df['filename'].isin(subject_lst)]
 
         # Create a dictionary with the number of subjects for each contrast of contrast_balance

--- a/ivadomed/loader/loader_new.py
+++ b/ivadomed/loader/loader_new.py
@@ -12,7 +12,8 @@ from tqdm import tqdm
 from ivadomed import postprocessing as imed_postpro
 from ivadomed import transforms as imed_transforms
 from ivadomed import utils as imed_utils
-from ivadomed.loader import utils as imed_loader_utils, adaptative as imed_adaptative, film as imed_film
+# Here imed_adaptative refers temporarily to the adaptative_new.py, to fix when integrating in pipeline
+from ivadomed.loader import utils as imed_loader_utils, adaptative_new as imed_adaptative, film as imed_film
 # Here imed_obj_detect refers temporarily to the utils_new.py, to fix when integrating in pipeline
 from ivadomed.object_detection import utils_new as imed_obj_detect
 
@@ -808,6 +809,7 @@ class BidsDataset(MRI2DSegmentationDataset):
         # Create a dictionary with the number of subjects for each contrast of contrast_balance
         tot = {contrast: df_subjects['suffix'].str.fullmatch(contrast).value_counts()[True]
                for contrast in contrast_params["balance"].keys()}
+
         # Create a counter that helps to balance the contrasts
         c = {contrast: 0 for contrast in contrast_params["balance"].keys()}
 

--- a/ivadomed/loader/loader_new.py
+++ b/ivadomed/loader/loader_new.py
@@ -802,6 +802,10 @@ class BidsDataset(MRI2DSegmentationDataset):
         # Sort subject_lst and create a sub-dataframe from bids_df containing only subjects from subject_lst
         subject_lst = sorted(subject_lst)
         df_subjects = bids_df.df[bids_df.df['filename'].isin(subject_lst)]
+        # Backward compatibility for subject_lst containing participant_ids instead of filenames
+        if df_subjects.empty:
+            df_subjects = bids_df.df[bids_df.df['participant_id'].isin(subject_lst)]
+            subject_lst = sorted(df_subjects['filename'].to_list())
 
         # Create a dictionary with the number of subjects for each contrast of contrast_balance
         tot = {contrast: df_subjects['suffix'].str.fullmatch(contrast).value_counts()[True]

--- a/ivadomed/loader/loader_new.py
+++ b/ivadomed/loader/loader_new.py
@@ -76,7 +76,8 @@ def load_dataset(bids_df, data_list, path_data, transforms_params, model_params,
                                 soft_gt=soft_gt)
 
     elif model_params["name"] == "HeMISUnet":
-        dataset = imed_adaptative.HDF5Dataset(path_data=path_data,
+        dataset = imed_adaptative.HDF5Dataset(bids_df,
+                                              path_data=path_data,
                                               subject_lst=data_list,
                                               model_params=model_params,
                                               contrast_params=contrast_params,

--- a/ivadomed/loader/loader_new.py
+++ b/ivadomed/loader/loader_new.py
@@ -13,7 +13,8 @@ from ivadomed import postprocessing as imed_postpro
 from ivadomed import transforms as imed_transforms
 from ivadomed import utils as imed_utils
 from ivadomed.loader import utils as imed_loader_utils, adaptative as imed_adaptative, film as imed_film
-from ivadomed.object_detection import utils as imed_obj_detect
+# Here imed_obj_detect refers temporarily to the utils_new.py, to fix when integrating in pipeline
+from ivadomed.object_detection import utils_new as imed_obj_detect
 
 
 def load_dataset(bids_df, data_list, path_data, transforms_params, model_params, target_suffix, roi_params,
@@ -51,6 +52,7 @@ def load_dataset(bids_df, data_list, path_data, transforms_params, model_params,
     Note: For more details on the parameters transform_params, target_suffix, roi_params, contrast_params,
     slice_filter_params and object_detection_params see :doc:`configuration_file`.
     """
+
     # Compose transforms
     tranform_lst, _ = imed_transforms.prepare_transforms(copy.deepcopy(transforms_params), requires_undo)
 
@@ -784,11 +786,8 @@ class BidsDataset(MRI2DSegmentationDataset):
                  cache=True, transform=None, metadata_choice=False, slice_filter_fn=None, roi_params=None,
                  multichannel=False, object_detection_params=None, task="segmentation", soft_gt=False):
 
-        self.bids_ds = []
         path_data = imed_utils.format_path_data(path_data)
-        for BIDSFolder in path_data:
-            self.bids_ds.append(bids.BIDS(BIDSFolder))
-
+        self.bids_df = bids_df
         self.roi_params = roi_params if roi_params is not None else {"suffix": None, "slice_filter_roi": None}
         self.soft_gt = soft_gt
         self.filename_pairs = []
@@ -796,24 +795,23 @@ class BidsDataset(MRI2DSegmentationDataset):
             self.metadata = {"FlipAngle": [], "RepetitionTime": [],
                              "EchoTime": [], "Manufacturer": []}
 
-        # Append subjects from all BIDSdatasets into a list
-        bids_subjects = []
-        for i_bids_folder in range(0, len(path_data)):
-            bids_subjects += [s for s in self.bids_ds[i_bids_folder].get_subjects() if s.record["subject_id"] in subject_lst]
+        # TODO: Change output of split dataset to filename instead of ivadomed_id,
+        # then update df_subjects and subjects below
 
-        # Create a list with the filenames for all contrasts and subjects
-        subjects_tot = []
-        for subject in bids_subjects:
-            subjects_tot.append(str(subject.record["absolute_path"]))
+        # Create a sub-dataframe from bids_df containing only subjects from subject_lst
+        df_subjects = self.bids_df.df[self.bids_df.df['ivadomed_id'].isin(subject_lst)]
+        # Append subjects from subject list into a list of filenames
+        subjects = df_subjects['filename'].to_list()
 
         # Create a dictionary with the number of subjects for each contrast of contrast_balance
-
-        tot = {contrast: len([s for s in bids_subjects if s.record["modality"] == contrast])
+        tot = {contrast: df_subjects['suffix'].str.fullmatch(contrast).value_counts()[True]
                for contrast in contrast_params["balance"].keys()}
-
         # Create a counter that helps to balance the contrasts
         c = {contrast: 0 for contrast in contrast_params["balance"].keys()}
 
+        # Create multichannel_subjects dictionary
+        # subject_lst must be ivadomed_id
+        # TODO: Create ivadomed_id here from list of filenames
         multichannel_subjects = {}
         if multichannel:
             num_contrast = len(contrast_params["contrast_lst"])
@@ -825,102 +823,92 @@ class BidsDataset(MRI2DSegmentationDataset):
                                                "roi_filename": None,
                                                "metadata": [None] * num_contrast} for subject in subject_lst}
 
-        # Append get_subjects()
-        get_subjects_all = self.bids_ds[0].get_subjects()
-        for i_bids_folder in range(1, len(self.bids_ds)):
-            get_subjects_all.extend(self.bids_ds[i_bids_folder].get_subjects())
+        # Get all subjects path from bids_df for bounding box
+        get_all_subj_path = self.bids_df.df[self.bids_df.df['filename']
+                                .str.contains('|'.join(self.bids_df.get_subject_fnames()))]['path'].to_list()
 
+        # Load bounding box from list of path
         bounding_box_dict = imed_obj_detect.load_bounding_boxes(object_detection_params,
-                                                                    get_subjects_all,
-                                                                    slice_axis,
-                                                                    contrast_params["contrast_lst"])
+                                                                get_all_subj_path,
+                                                                slice_axis,
+                                                                contrast_params["contrast_lst"])
 
-        for subject in tqdm(bids_subjects, desc="Loading dataset"):
-            if subject.record["modality"] in contrast_params["contrast_lst"]:
-                # Training & Validation: do not consider the contrasts over the threshold contained in contrast_balance
-                if subject.record["modality"] in contrast_params["balance"].keys():
-                    c[subject.record["modality"]] = c[subject.record["modality"]] + 1
-                    if c[subject.record["modality"]] / tot[subject.record["modality"]] > contrast_params["balance"][
-                        subject.record["modality"]]:
-                        continue
+        # Get all derivatives filenames from bids_df
+        all_deriv = self.bids_df.get_deriv_fnames()
 
-                if not subject.has_derivative("labels"):
-                    print("Subject without derivative, skipping.")
+        # Create filename_pairs
+        for subject in tqdm(subjects, desc="Loading dataset"):
+
+            df_sub = df_subjects.loc[df_subjects['filename'] == subject]
+
+            # Training & Validation: do not consider the contrasts over the threshold contained in contrast_balance
+            contrast = df_sub['suffix'].values[0]
+            if contrast in (contrast_params["balance"].keys()):
+                c[contrast] = c[contrast] + 1
+                if c[contrast] / tot[contrast] > contrast_params["balance"][contrast]:
                     continue
-                derivatives = subject.get_derivatives("labels")
-                if isinstance(target_suffix[0], str):
-                    target_filename, roi_filename = [None] * len(target_suffix), None
-                else:
-                    target_filename, roi_filename = [[] for _ in range(len(target_suffix))], None
+            if isinstance(target_suffix[0], str):
+                target_filename, roi_filename = [None] * len(target_suffix), None
+            else:
+                target_filename, roi_filename = [[] for _ in range(len(target_suffix))], None
 
-                for deriv in derivatives:
-                    for idx, suffix_list in enumerate(target_suffix):
-                        # If suffix_list is a string, then only one rater annotation per class is available.
-                        # Otherwise, multiple raters segmented the same class.
-                        if isinstance(suffix_list, list):
-                            for suffix in suffix_list:
-                                if deriv.endswith(subject.record["modality"] + suffix + ".nii.gz"):
-                                    target_filename[idx].append(deriv)
-                        elif deriv.endswith(subject.record["modality"] + suffix_list + ".nii.gz"):
-                            target_filename[idx] = deriv
+            derivatives = self.bids_df.df[self.bids_df.df['filename']
+                          .str.contains('|'.join(self.bids_df.get_derivatives(subject, all_deriv)))]['path'].to_list()
 
-                    if not (self.roi_params["suffix"] is None) and \
-                            deriv.endswith(subject.record["modality"] + self.roi_params["suffix"] + ".nii.gz"):
-                        roi_filename = [deriv]
+            for deriv in derivatives:
+                for idx, suffix_list in enumerate(target_suffix):
+                    # If suffix_list is a string, then only one rater annotation per class is available.
+                    # Otherwise, multiple raters segmented the same class.
+                    if isinstance(suffix_list, list):
+                        for suffix in suffix_list:
+                            if suffix in deriv:
+                                target_filename[idx].append(deriv)
+                    elif suffix_list in deriv:
+                        target_filename[idx] = deriv
+                if not (self.roi_params["suffix"] is None) and self.roi_params["suffix"] in deriv:
+                    roi_filename = [deriv]
 
-                if (not any(target_filename)) or (not (self.roi_params["suffix"] is None) and (roi_filename is None)):
+            if (not any(target_filename)) or (not (self.roi_params["suffix"] is None) and (roi_filename is None)):
+                continue
+
+            metadata = df_sub.to_dict(orient='records')[0]
+            metadata['contrast'] = contrast
+
+            if len(bounding_box_dict):
+                # Take only one bounding box for cropping
+                metadata['bounding_box'] = bounding_box_dict[str(df_sub['path'].values[0])][0]
+
+            if metadata_choice == 'mri_params':
+                if not all([imed_film.check_isMRIparam(m, metadata, subject, self.metadata) for m in
+                            self.metadata.keys()]):
                     continue
+            elif metadata_choice and metadata_choice != 'contrasts' and metadata_choice is not None:
+                # add custom data to metadata
+                if metadata_choice not in df_sub.columns:
+                    raise ValueError("The following metadata cannot be found: {}. "
+                                     "Invalid metadata choice.".format(metadata_choice))
+                metadata[metadata_choice] = df_sub[metadata_choice].values[0]
+                # Create metadata dict for OHE
+                data_lst = sorted(set(self.bids_df.df[metadata_choice].dropna().values))
+                metadata_dict = {}
+                for idx, data in enumerate(data_lst):
+                    metadata_dict[data] = idx
+                metadata['metadata_dict'] = metadata_dict
 
-                if not subject.has_metadata():
-                    metadata = {}
-                else:
-                    metadata = subject.metadata()
-
-                # add contrast to metadata
-                metadata['contrast'] = subject.record["modality"]
-
-                if len(bounding_box_dict):
-                    # Take only one bounding box for cropping
-                    metadata['bounding_box'] = bounding_box_dict[str(subject.record["absolute_path"])][0]
-
-                if metadata_choice == 'mri_params':
-                    if not all([imed_film.check_isMRIparam(m, metadata, subject, self.metadata) for m in
-                                self.metadata.keys()]):
-                        continue
-
-                elif metadata_choice and metadata_choice != 'contrasts' and metadata_choice is not None:
-                    # add custom data to metadata
-                    subject_id = subject.record["subject_id"]
-
-                    df = imed_loader_utils.merge_bids_datasets(path_data)
-
-                    if metadata_choice not in df.columns:
-                        raise ValueError("The following metadata cannot be found in participants.tsv file: {}. "
-                                         "Invalid metadata choice.".format(metadata_choice))
-
-                    metadata[metadata_choice] = df[df['participant_id'] == subject_id][metadata_choice].values[0]
-
-                    # Create metadata dict for OHE
-                    data_lst = sorted(set(df[metadata_choice].values))
-                    metadata_dict = {}
-                    for idx, data in enumerate(data_lst):
-                        metadata_dict[data] = idx
-
-                    metadata['metadata_dict'] = metadata_dict
-
-                # Fill multichannel dictionary
-                if multichannel:
-                    idx = idx_dict[subject.record["modality"]]
-                    subj_id = subject.record["subject_id"]
-                    multichannel_subjects[subj_id]["absolute_paths"][idx] = subject.record.absolute_path
-                    multichannel_subjects[subj_id]["deriv_path"] = target_filename
-                    multichannel_subjects[subj_id]["metadata"][idx] = metadata
-                    if roi_filename:
-                        multichannel_subjects[subj_id]["roi_filename"] = roi_filename
-
-                else:
-                    self.filename_pairs.append(([subject.record.absolute_path],
-                                                target_filename, roi_filename, [metadata]))
+            # Fill multichannel dictionary
+            # subj_id is ivadomed_id
+            # TODO: Create ivadomed_id here from filename
+            if multichannel:
+                idx = idx_dict[df_sub['suffix'].values[0]]
+                subj_id = df_sub['ivadomed_id'].values[0]
+                multichannel_subjects[subj_id]["absolute_paths"][idx] = df_sub['path'].values[0]
+                multichannel_subjects[subj_id]["deriv_path"] = target_filename
+                multichannel_subjects[subj_id]["metadata"][idx] = metadata
+                if roi_filename:
+                    multichannel_subjects[subj_id]["roi_filename"] = roi_filename
+            else:
+                self.filename_pairs.append(([df_sub['path'].values[0]],
+                                            target_filename, roi_filename, [metadata]))
 
         if multichannel:
             for subject in multichannel_subjects.values():

--- a/ivadomed/loader/loader_new.py
+++ b/ivadomed/loader/loader_new.py
@@ -16,7 +16,7 @@ from ivadomed.loader import utils as imed_loader_utils, adaptative as imed_adapt
 from ivadomed.object_detection import utils as imed_obj_detect
 
 
-def load_dataset(data_list, path_data, transforms_params, model_params, target_suffix, roi_params,
+def load_dataset(bids_df, data_list, path_data, transforms_params, model_params, target_suffix, roi_params,
                  contrast_params, slice_filter_params, slice_axis, multichannel,
                  dataset_type="training", requires_undo=False, metadata_type=None,
                  object_detection_params=None, soft_gt=False, device=None,
@@ -25,6 +25,7 @@ def load_dataset(data_list, path_data, transforms_params, model_params, target_s
     BidsDataset for 2D data and HDF5Dataset for HeMIS.
 
     Args:
+        bids_df (BidsDataframe): Object containing dataframe with all BIDS image files and their metadata.
         data_list (list): Subject names list.
         path_data (list) or (str): Path to the BIDS dataset(s).
         transforms_params (dict): Dictionary containing transformations for "training", "validation", "testing" (keys),
@@ -58,7 +59,8 @@ def load_dataset(data_list, path_data, transforms_params, model_params, target_s
         roi_params["slice_filter_roi"] = None
 
     if model_params["name"] == "Modified3DUNet" or ('is_2d' in model_params and not model_params['is_2d']):
-        dataset = Bids3DDataset(path_data,
+        dataset = Bids3DDataset(bids_df,
+                                path_data,
                                 subject_lst=data_list,
                                 target_suffix=target_suffix,
                                 roi_params=roi_params,
@@ -90,7 +92,8 @@ def load_dataset(data_list, path_data, transforms_params, model_params, target_s
         # Task selection
         task = imed_utils.get_task(model_params["name"])
 
-        dataset = BidsDataset(path_data,
+        dataset = BidsDataset(bids_df,
+                              path_data,
                               subject_lst=data_list,
                               target_suffix=target_suffix,
                               roi_params=roi_params,
@@ -708,6 +711,7 @@ class Bids3DDataset(MRI3DSubVolumeSegmentationDataset):
     """BIDS specific dataset loader for 3D dataset.
 
     Args:
+        bids_df (BidsDataframe): Object containing dataframe with all BIDS image files and their metadata.
         path_data (list) or (str): List of Paths to the BIDS datasets.
         subject_lst (list): Subject names list.
         target_suffix (list): List of suffixes for target masks.
@@ -724,10 +728,11 @@ class Bids3DDataset(MRI3DSubVolumeSegmentationDataset):
         object_detection_params (dict): Object dection parameters.
     """
 
-    def __init__(self, path_data, subject_lst, target_suffix, model_params, contrast_params, slice_axis=2,
+    def __init__(self, bids_df, path_data, subject_lst, target_suffix, model_params, contrast_params, slice_axis=2,
                  cache=True, transform=None, metadata_choice=False, roi_params=None,
                  multichannel=False, object_detection_params=None, task="segmentation", soft_gt=False):
-        dataset = BidsDataset(path_data=path_data,
+        dataset = BidsDataset(bids_df=bids_df,
+                              path_data=path_data,
                               subject_lst=subject_lst,
                               target_suffix=target_suffix,
                               roi_params=roi_params,
@@ -746,6 +751,7 @@ class BidsDataset(MRI2DSegmentationDataset):
     """ BIDS specific dataset loader.
 
     Args:
+        bids_df (BidsDataframe): Object containing dataframe with all BIDS image files and their metadata.
         path_data (list) or (str): List of Paths to the BIDS datasets.
         subject_lst (list): Subject names list.
         target_suffix (list): List of suffixes for target masks.
@@ -774,7 +780,7 @@ class BidsDataset(MRI2DSegmentationDataset):
 
     """
 
-    def __init__(self, path_data, subject_lst, target_suffix, contrast_params, slice_axis=2,
+    def __init__(self, bids_df, path_data, subject_lst, target_suffix, contrast_params, slice_axis=2,
                  cache=True, transform=None, metadata_choice=False, slice_filter_fn=None, roi_params=None,
                  multichannel=False, object_detection_params=None, task="segmentation", soft_gt=False):
 

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -877,9 +877,8 @@ class BidsDataframe:
             # As per pybids, derivatives don't include parsed entities, only the "path" column
             df_next = layout.to_df(metadata=True)
 
-            # Add filename and parent_path columns
+            # Add filename column
             df_next['filename'] = df_next['path'].apply(os.path.basename)
-            df_next['parent_path'] = df_next['path'].apply(os.path.dirname)
 
             # Drop rows with json, tsv and LICENSE files in case no extensions are provided in config file for filtering
             df_next = df_next[~df_next['filename'].str.endswith(tuple(['.json', '.tsv', 'LICENSE']))]
@@ -900,11 +899,10 @@ class BidsDataframe:
             # Merge dataframes
             self.df = pd.concat([self.df, df_next], join='outer', ignore_index=True)
 
-        # Drop duplicated rows based on all columns except 'path and 'parent_path'
+        # Drop duplicated rows based on all columns except 'path'
         # Keep first occurence
         columns = self.df.columns.to_list()
         columns.remove('path')
-        columns.remove('parent_path')
         self.df = self.df[~(self.df.astype(str).duplicated(subset=columns, keep='first'))]
 
         # If indexing of derivatives is true

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -14,6 +14,7 @@ import nibabel as nib
 import bids as pybids  # "bids" is already taken by bids_neuropoly
 import itertools
 import random
+import copy
 
 __numpy_type_map = {
     'float64': torch.DoubleTensor,
@@ -819,7 +820,7 @@ class BidsDataframe:
         self.bids_config = None if 'bids_config' not in loader_params else loader_params['bids_config']
 
         # target_suffix and roi_suffix from loader parameters
-        self.target_suffix = loader_params['target_suffix']
+        self.target_suffix = copy.deepcopy(loader_params['target_suffix'])
         # If `target_suffix` is a list of lists convert to list
         if any(isinstance(t, list) for t in self.target_suffix):
             self.target_suffix = list(itertools.chain.from_iterable(self.target_suffix))

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -110,7 +110,7 @@ def split_dataset_new(df, split_method, data_testing, random_seed, train_frac=0.
         train_frac (float): Between 0 and 1. Represents the train set proportion.
         test_frac (float): Between 0 and 1. Represents the test set proportion.
     Returns:
-        list, list, list: Train, validation and test data_type list.
+        list, list, list: Train, validation and test filenames lists.
     """
 
     # Get data_type and data_value from split parameters
@@ -134,7 +134,7 @@ def split_dataset_new(df, split_method, data_testing, random_seed, train_frac=0.
         data_value = sorted(df[data_type].unique().tolist())
         test_frac = test_frac if test_frac >= 1 / len(data_value) else 1 / len(data_value)
         data_value, _ = train_test_split(data_value, train_size=test_frac, random_state=random_seed)
-    X_test = df[df[data_type].isin(data_value)]['ivadomed_id'].unique().tolist()
+    X_test = df[df[data_type].isin(data_value)]['filename'].unique().tolist()
     X_remain = df[~df[data_type].isin(data_value)][split_method].unique().tolist()
 
     # List dataset unique values according to split_method
@@ -148,9 +148,9 @@ def split_dataset_new(df, split_method, data_testing, random_seed, train_frac=0.
     # Split remainder in TRAIN and VALID sets according to train_frac_update using sklearn function
     X_train, X_val = train_test_split(X_remain, train_size=train_frac_update, random_state=random_seed)
 
-    # Convert train and valid sets from list of "split_method" to list of "ivadomed_id"
-    X_train = df[df[split_method].isin(X_train)]['ivadomed_id'].unique().tolist()
-    X_val = df[df[split_method].isin(X_val)]['ivadomed_id'].unique().tolist()
+    # Convert train and valid sets from list of "split_method" to list of "filename"
+    X_train = df[df[split_method].isin(X_train)]['filename'].unique().tolist()
+    X_val = df[df[split_method].isin(X_val)]['filename'].unique().tolist()
 
     # Make sure that test dataset is unseen during training
     # (in cases where there are multiple "data_type" for a same "split_method")
@@ -254,7 +254,7 @@ def get_new_subject_split_new(df, split_method, data_testing, random_seed,
         subject_selection (dict): Used to specify a custom subject selection from a dataset.
 
     Returns:
-        list, list list: Training, validation and testing subjects lists.
+        list, list list: Training, validation and testing filenames lists.
     """
     if subject_selection is not None:
         # Verify subject_selection format
@@ -344,7 +344,7 @@ def get_subdatasets_subjects_list_new(split_params, df, path_output, subject_sel
         subject_selection (dict): Used to specify a custom subject selection from a dataset.
 
     Returns:
-        list, list list: Training, validation and testing subjects lists.
+        list, list list: Training, validation and testing filenames lists.
     """
     if split_params["fname_split"]:
         # Load subjects lists

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -791,7 +791,7 @@ def merge_bids_datasets(path_data):
 
 class BidsDataframe:
     """
-    This class aims to create a dataframe containing all BIDS image files in a path_data and their metadata.
+    This class aims to create a dataframe containing all BIDS image files in a list of path_data and their metadata.
 
     Args:
         loader_params (dict): Loader parameters, see :doc:`configuration_file` for more details.
@@ -799,7 +799,7 @@ class BidsDataframe:
         path_output (str): Output folder.
 
     Attributes:
-        path_data (str): Path to the BIDS dataset.
+        path_data (list): Paths to the BIDS datasets.
         bids_config (str): Path to the custom BIDS configuration file.
         target_suffix (list of str): List of suffix of targetted structures.
         roi_suffix (str): List of suffix of ROI masks.
@@ -811,7 +811,8 @@ class BidsDataframe:
 
     def __init__(self, loader_params, derivatives, path_output):
 
-        # path_data from loader parameters
+        # paths_data from loader parameters
+        # TODO: when integrating in pipeline, remove format_path_data here (done before in main)
         self.paths_data = imed_utils.format_path_data(loader_params['path_data'])
 
         # bids_config from loader parameters

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -884,11 +884,6 @@ class BidsDataframe:
             # Drop rows with json, tsv and LICENSE files in case no extensions are provided in config file for filtering
             df_next = df_next[~df_next['filename'].str.endswith(tuple(['.json', '.tsv', 'LICENSE']))]
 
-            # Add ivadomed_id column corresponding to filename minus modality and extension for files that are not derivatives.
-            for index, row in df_next.iterrows():
-                if isinstance(row['suffix'], str):
-                    df_next.loc[index, 'ivadomed_id'] = re.sub(r'_' + row['suffix'] + '.*', '', row['filename'])
-
             # Update dataframe with subject files of chosen contrasts and extensions,
             # and with derivative files of chosen target_suffix from loader parameters
             df_next = df_next[(~df_next['path'].str.contains('derivatives')

--- a/ivadomed/object_detection/utils_new.py
+++ b/ivadomed/object_detection/utils_new.py
@@ -1,0 +1,326 @@
+import json
+import os
+import statistics
+
+import nibabel as nib
+import numpy as np
+from scipy import ndimage
+
+from ivadomed import postprocessing as imed_postpro
+from ivadomed import transforms as imed_transforms
+from ivadomed import utils as imed_utils
+from ivadomed import inference as imed_inference
+from ivadomed.loader import utils as imed_loader_utils
+
+
+def get_bounding_boxes(mask):
+    """Generates a 3D bounding box around a given mask.
+    Args:
+        mask (Numpy array): Mask of the ROI.
+
+    Returns:
+        list: Bounding box coordinate (x_min, x_max, y_min, y_max, z_min, z_max).
+
+    """
+
+    # Label the different objects in the mask
+    labeled_mask, _ = ndimage.measurements.label(mask)
+    object_labels = np.unique(labeled_mask)
+    bounding_boxes = []
+    for label in object_labels[1:]:
+        single_object = labeled_mask == label
+        coords = np.where(single_object)
+        dimensions = []
+        for i in range(len(coords)):
+            dimensions.append(int(coords[i].min()))
+            dimensions.append(int(coords[i].max()))
+        bounding_boxes.append(dimensions)
+
+    return bounding_boxes
+
+
+def adjust_bb_size(bounding_box, factor, resample=False):
+    """Modifies the bounding box dimensions according to a given factor.
+
+    Args:
+        bounding_box (list or tuple): Coordinates of bounding box (x_min, x_max, y_min, y_max, z_min, z_max).
+        factor (list or tuple): Multiplicative factor for each dimension (list or tuple of length 3).
+        resample (bool):  Boolean indicating if this resize is for resampling.
+
+    Returns:
+        list: New coordinates (x_min, x_max, y_min, y_max, z_min, z_max).
+    """
+    coord = []
+    for i in range(len(bounding_box) // 2):
+        d_min, d_max = bounding_box[2 * i: (2 * i) + 2]
+        if resample:
+            d_min, d_max = d_min * factor[i], d_max * factor[i]
+            dim_len = d_max - d_min
+        else:
+            dim_len = (d_max - d_min) * factor[i]
+
+        # new min and max coordinates
+        min_coord = d_min - (dim_len - (d_max - d_min)) // 2
+        coord.append(int(round(max(min_coord, 0))))
+        coord.append(int(coord[-1] + dim_len))
+
+    return coord
+
+
+def resize_to_multiple(shape, multiple, length):
+    """Modify a given shape so each dimension is a multiple of a given number. This is used to avoid dimension mismatch
+    with patch training. The return shape is always larger then the initial shape (no cropping).
+
+    Args:
+        shape (tuple or list): Initial shape to be modified.
+        multiple (tuple or list): Multiple for each dimension.
+        length (tuple or list): Patch length.
+
+    Returns:
+        list: New dimensions.
+    """
+    new_dim = []
+    for dim_len, m, l in zip(shape, multiple, length):
+        padding = (m - (dim_len - l) % m) if (m - (dim_len - l) % m) != m else 0
+        new_dim.append(dim_len + padding)
+    return new_dim
+
+
+def generate_bounding_box_file(subject_path_list, model_path, path_output, gpu_id=0, slice_axis=0, contrast_lst=None,
+                               keep_largest_only=True, safety_factor=None):
+    """Creates json file containing the bounding box dimension for each images. The file has the following format:
+    {"path/to/img.nii.gz": [[x1_min, x1_max, y1_min, y1_max, z1_min, z1_max],
+    [x2_min, x2_max, y2_min, y2_max, z2_min, z2_max]]}
+    where each list represents the coordinates of an object on the image (2 instance of a given object in this example).
+
+    Args:
+        subject_path_list (list): List of all subjects in all the BIDS directories.
+        model_path (string): Path to object detection model.
+        path_output (string): Output path.
+        gpu_id (int): If available, GPU number.
+        slice_axis (int): Slice axis (0: sagittal, 1: coronal, 2: axial).
+        contrast_lst (list): Contrasts.
+        keep_largest_only (bool): Boolean representing if only the largest object of the prediction is kept.
+        safety_factor (list or tuple): Factors to multiply each dimension of the bounding box.
+
+    Returns:
+        dict: Dictionary containing bounding boxes related to their image.
+
+    """
+    bounding_box_dict = {}
+    if safety_factor is None:
+        safety_factor = [1.0, 1.0, 1.0]
+    for subject_path in subject_path_list:
+        object_mask, _ = imed_inference.segment_volume(model_path, [subject_path], gpu_id=gpu_id)
+        object_mask = object_mask[0]
+        if keep_largest_only:
+            object_mask = imed_postpro.keep_largest_object(object_mask)
+        mask_path = os.path.join(path_output, "detection_mask")
+        if not os.path.exists(mask_path):
+            os.mkdir(mask_path)
+        nib.save(object_mask, os.path.join(mask_path, subject_path.split("/")[-1]))
+        ras_orientation = nib.as_closest_canonical(object_mask)
+        hwd_orientation = imed_loader_utils.orient_img_hwd(ras_orientation.get_fdata(), slice_axis)
+        bounding_boxes = get_bounding_boxes(hwd_orientation)
+        bounding_box_dict[subject_path] = [adjust_bb_size(bb, safety_factor) for bb in bounding_boxes]
+
+    file_path = os.path.join(path_output, 'bounding_boxes.json')
+    with open(file_path, 'w') as fp:
+        json.dump(bounding_box_dict, fp, indent=4)
+    return bounding_box_dict
+
+
+def resample_bounding_box(metadata, transform):
+    """Resample bounding box.
+
+    Args:
+        metadata (dict): Dictionary containing the metadata to be modified with the resampled coordinates.
+        transform (Compose): Transformations possibly containing the resample params.
+    """
+    for idx, transfo in enumerate(transform.transform["im"].transforms):
+        if "Resample" == transfo.__class__.__name__:
+            hspace, wspace, dspace = (transfo.hspace, transfo.wspace, transfo.dspace)
+            hfactor = metadata['input_metadata'][0]['zooms'][0] / hspace
+            wfactor = metadata['input_metadata'][0]['zooms'][1] / wspace
+            dfactor = metadata['input_metadata'][0]['zooms'][2] / dspace
+            factor = (hfactor, wfactor, dfactor)
+            coord = adjust_bb_size(metadata['input_metadata'][0]['bounding_box'], factor, resample=True)
+
+            for i in range(len(metadata['input_metadata'])):
+                metadata['input_metadata'][i]['bounding_box'] = coord
+
+            for i in range(len(metadata['gt_metadata'])):
+                metadata['gt_metadata'][i]['bounding_box'] = coord
+            break
+
+
+def adjust_transforms(transforms, seg_pair, length=None, stride=None):
+    """This function adapts the transforms by adding the BoundingBoxCrop transform according the specific parameters of
+    an image. The dimensions of the crop are also adapted to fit the length and stride parameters if the 3D loader is
+    used.
+
+    Args:
+        transforms (Compose): Prepreocessing transforms.
+        seg_pair (dict): Segmentation pair (input, gt and metadata).
+        length (list or tuple): Patch size of the 3D loader.
+        stride (list or tuple): Stride value of the 3D loader.
+
+    Returns:
+        Compose: Modified transforms.
+    """
+    resample_idx = [-1, -1, -1]
+    if transforms is None:
+        transforms = imed_transforms.Compose({})
+    for i, img_type in enumerate(transforms.transform):
+        for idx, transfo in enumerate(transforms.transform[img_type].transforms):
+            if "BoundingBoxCrop" == transfo.__class__.__name__:
+                transforms.transform[img_type].transforms.pop(idx)
+            if "Resample" == transfo.__class__.__name__:
+                resample_idx[i] = idx
+
+    resample_bounding_box(seg_pair, transforms)
+    index_shape = []
+    for i, img_type in enumerate(transforms.transform):
+        x_min, x_max, y_min, y_max, z_min, z_max = seg_pair['input_metadata'][0]['bounding_box']
+        size = [x_max - x_min, y_max - y_min, z_max - z_min]
+
+        if length is not None and stride is not None:
+            for idx, dim in enumerate(size):
+                if dim < length[idx]:
+                    size[idx] = length[idx]
+            # Adjust size according to stride to avoid dimension mismatch
+            size = resize_to_multiple(size, stride, length)
+        index_shape.append(tuple(size))
+        transform_obj = imed_transforms.BoundingBoxCrop(size=size)
+        transforms.transform[img_type].transforms.insert(resample_idx[i] + 1, transform_obj)
+
+    for metadata in seg_pair['input_metadata']:
+        assert len(set(index_shape)) == 1
+        metadata['index_shape'] = index_shape[0]
+    return transforms
+
+
+def adjust_undo_transforms(transforms, seg_pair, index=0):
+    """This function adapts the undo transforms by adding the BoundingBoxCrop to undo transform according the specific
+    parameters of an image.
+
+    Args:
+        transforms (Compose): Transforms.
+        seg_pair (dict): Segmentation pair (input, gt and metadata).
+        index (int): Batch index of the seg_pair.
+    """
+    for img_type in transforms.transform:
+        resample_idx = -1
+        for idx, transfo in enumerate(transforms.transform[img_type].transforms):
+            if "Resample" == transfo.__class__.__name__:
+                resample_idx = idx
+            if "BoundingBoxCrop" == transfo.__class__.__name__:
+                transforms.transform[img_type].transforms.pop(idx)
+        if "bounding_box" in seg_pair['input_metadata'][index][0]:
+            size = list(seg_pair['input_metadata'][index][0]['index_shape'])
+            transform_obj = imed_transforms.BoundingBoxCrop(size=size)
+            transforms.transform[img_type].transforms.insert(resample_idx + 1, transform_obj)
+
+
+def load_bounding_boxes(object_detection_params, subject_path_list, slice_axis, constrast_lst):
+    """Verifies if bounding_box.json exists in the output path, if so loads the data, else generates the file if a
+    valid detection model path exists.
+
+    Args:
+        object_detection_params (dict): Object detection parameters.
+        subject_path_list (list): List of all subjects in all the BIDS directories.
+        slice_axis (int): Slice axis (0: sagittal, 1: coronal, 2: axial).
+        constrast_lst (list): Contrasts.
+
+    Returns:
+        dict: bounding boxes for every subject in BIDS directory
+    """
+    # Load or generate bounding boxes and save them in json file
+    bounding_box_dict = {}
+    if object_detection_params is None or object_detection_params['object_detection_path'] is None:
+        return bounding_box_dict
+    bounding_box_path = os.path.join(object_detection_params['path_output'], 'bounding_boxes.json')
+    if os.path.exists(bounding_box_path):
+        with open(bounding_box_path, 'r') as fp:
+            bounding_box_dict = json.load(fp)
+    elif object_detection_params['object_detection_path'] is not None and \
+            os.path.exists(object_detection_params['object_detection_path']):
+        bounding_box_dict = generate_bounding_box_file(subject_path_list,
+                                                       object_detection_params['object_detection_path'],
+                                                       object_detection_params['path_output'],
+                                                       object_detection_params['gpu'],
+                                                       slice_axis,
+                                                       constrast_lst,
+                                                       safety_factor=object_detection_params['safety_factor'])
+    elif object_detection_params['object_detection_path'] is not None:
+        raise RuntimeError("Path to object detection model doesn't exist")
+
+    return bounding_box_dict
+
+
+def verify_metadata(metadata, has_bounding_box):
+    """Validates across all metadata that the 'bounding_box' param is present.
+
+    Args:
+        metadata (dict): Image metadata.
+        has_bounding_box (bool): If 'bounding_box' is present across all metadata, True, else False.
+
+    Returns:
+        bool: Boolean indicating if 'bounding_box' is present across all metadata.
+    """
+    index_has_bounding_box = all(['bounding_box' in metadata['input_metadata'][i]
+                                  for i in range(len(metadata['input_metadata']))])
+    for gt_metadata in metadata['gt_metadata']:
+        if gt_metadata is not None:
+            index_has_bounding_box &= 'bounding_box' in gt_metadata
+
+    has_bounding_box &= index_has_bounding_box
+    return has_bounding_box
+
+
+def bounding_box_prior(fname_mask, metadata, slice_axis, safety_factor=None):
+    """
+    Computes prior steps to a model requiring bounding box crop. This includes loading a mask of the ROI, orienting the
+    given mask into the following dimensions: (height, width, depth), extracting the bounding boxes and storing the
+    information in the metadata.
+
+    Args:
+        fname_mask (str): Filename containing the mask of the ROI
+        metadata (dict): Dictionary containing the image metadata
+        slice_axis (int): Slice axis (0: sagittal, 1: coronal, 2: axial)
+        safety_factor (list or tuple): Factors to multiply each dimension of the bounding box.
+
+    """
+    nib_prior = nib.load(fname_mask)
+    # orient image into HWD convention
+    nib_ras = nib.as_closest_canonical(nib_prior)
+    np_mask = nib_ras.get_fdata()[..., 0] if len(nib_ras.get_fdata().shape) == 4 else nib_ras.get_fdata()
+    np_mask = imed_loader_utils.orient_img_hwd(np_mask, slice_axis)
+    # Extract the bounding box from the list
+    bounding_box = get_bounding_boxes(np_mask)[0]
+    if safety_factor:
+        bounding_box = adjust_bb_size(bounding_box, safety_factor)
+    metadata['bounding_box'] = bounding_box
+
+
+def compute_bb_statistics(bounding_box_path):
+    """Measures min, max and average, height, width, depth and volume of bounding boxes from a json file
+
+    Args:
+        bounding_box_path (string): Path to json file.
+    """
+    with open(bounding_box_path, 'r') as fp:
+        bounding_box_dict = json.load(fp)
+
+    h, w, d, v = [], [], [], []
+    for box in bounding_box_dict:
+        x_min, x_max, y_min, y_max, z_min, z_max = bounding_box_dict[box]
+        h.append(x_max - x_min)
+        w.append(y_max - y_min)
+        d.append(z_max - z_min)
+        v.append((x_max - x_min) * (y_max - y_min) * (z_max - z_min))
+
+    print('Mean height: {} +/- {}, min: {}, max: {}'.format(statistics.mean(h), statistics.stdev(h), min(h), max(h)))
+    print('Mean width: {} +/- {}, min: {}, max: {}'.format(statistics.mean(w), statistics.stdev(w), min(w), max(w)))
+    print('Mean depth: {} +/- {}, min: {}, max: {}'.format(statistics.mean(d), statistics.stdev(d), min(d), max(d)))
+    print('Mean volume: {} +/- {}, min: {}, max: {}'.format(statistics.mean(v), statistics.stdev(v), min(v), max(v)))

--- a/testing/unit_tests/test_loader.py
+++ b/testing/unit_tests/test_loader.py
@@ -42,8 +42,8 @@ def test_bids_df_microscopy_png(loader_parameters, path_output):
     df_test = bids_df.df
     df_test = df_test.drop(columns=['path', 'parent_path'])
     # TODO: modify df_ref.csv file in data-testing dataset to include "participant_id"
-    # "sample_id" and "ivadomed_id" columns, then delete next line
-    df_test = df_test.drop(columns=['participant_id', 'sample_id', 'ivadomed_id'])
+    # and "sample_id" columns, then delete next line
+    df_test = df_test.drop(columns=['participant_id', 'sample_id'])
     df_test = df_test.sort_values(by=['filename']).reset_index(drop=True)
     csv_ref = os.path.join(path_data[0], "df_ref.csv")
     csv_test = os.path.join(path_data[0], "df_test.csv")
@@ -82,8 +82,8 @@ def test_bids_df_anat(loader_parameters, path_output):
     df_test = bids_df.df
     df_test = df_test.drop(columns=['path', 'parent_path'])
     # TODO: modify df_ref.csv file in data-testing dataset to include "participant_id"
-    # and "ivadomed_id" columns then delete next line
-    df_test = df_test.drop(columns=['participant_id', 'ivadomed_id'])
+    # column then delete next line
+    df_test = df_test.drop(columns=['participant_id'])
     df_test = df_test.sort_values(by=['filename']).reset_index(drop=True)
     csv_ref = os.path.join(path_data[0], "df_ref.csv")
     csv_test = os.path.join(path_data[0], "df_test.csv")

--- a/testing/unit_tests/test_loader.py
+++ b/testing/unit_tests/test_loader.py
@@ -40,7 +40,7 @@ def test_bids_df_microscopy_png(loader_parameters, path_output):
     derivatives = True
     bids_df = imed_loader_utils.BidsDataframe(loader_params, derivatives, path_output)
     df_test = bids_df.df
-    df_test = df_test.drop(columns=['path', 'parent_path'])
+    df_test = df_test.drop(columns=['path'])
     # TODO: modify df_ref.csv file in data-testing dataset to include "participant_id"
     # and "sample_id" columns, then delete next line
     df_test = df_test.drop(columns=['participant_id', 'sample_id'])
@@ -80,7 +80,7 @@ def test_bids_df_anat(loader_parameters, path_output):
     derivatives = True
     bids_df = imed_loader_utils.BidsDataframe(loader_params, derivatives, path_output)
     df_test = bids_df.df
-    df_test = df_test.drop(columns=['path', 'parent_path'])
+    df_test = df_test.drop(columns=['path'])
     # TODO: modify df_ref.csv file in data-testing dataset to include "participant_id"
     # column then delete next line
     df_test = df_test.drop(columns=['participant_id'])


### PR DESCRIPTION
### Context

Fixes #596 
This PR is part of the loader refactoring project to include microscopy data (#304) and to migrate to HDF5 loader (#474).

It aims to refactor `BidsDataset`, `Bids3DDataset` and `BIDStoHDF5` classes to use the new loader pipeline (i.e. BidsDataframe + new splitting methods) to create `filename_pairs`.
The resulting `filename_pairs` are the same as the `filename_pairs` in the current loader.

### Changes done in this PR:

As discussed previously, the changes are made in "new" files until they are integrated in the pipeline.
- Refactoring of `BidsDasaset` and `Bids3DDataset` in `loader/loader_new.py` file
- Refactoring of `load_bounding_box` and `generate_bounding_box_file` in `object_detection/utils_new.py` file.
- Refactoring of `BIDStoHDF5` and `HDF5Dataset` in `loader/adaptative_new.py`.
- Remove `ivadomed_id` column in `BidsDataframe`
- Split functions output lists of `filenames`  instead of list of `ivadomed_id`
- `BidsDataset` and `BIDStoHDF5` input lists of `filenames` instead of `participants_id` (I made it retrocompatible with partitcipant_id, old joblib files should work)
- All the other functions/classes in "_new" files are identical to the originals, except for some imports.

### To test the new pipeline:
- Since, this is not integrated with the current pipeline, you need to run the `dev/df_new_loader.py` script to load a validation dataset (works only for nifti files)
- The script uses `config_new_loader.json` config file. To use older config files, make sure to add the following parameters:
   - `"extensions": [".nii.gz"]` in loader_parameters
   -   `"split_method" : "participant_id"`, and `"data_testing": {"data_type": null, "data_value":[]}`, in split_dataset parameters
- I tested the `U-net 2D` with and without `roi_suffix`, `multichannel` and `bounding_box`, `FilmedUnet` with `mri_param metadata_choice` and `custom metadata_choice`, as well as `Unet-3D` and `Hemis`. It seems to work fine but it would be great to test with real experiment files in case I missed something.

### Next step:
- Integrate the changes made for the new loader in PR #538, #591, #648 and #687 to the current pipeline.

