### PR TITLE
Change archive links to repository links for pre-trained models

### DIFF
--- a/docs/source/pretrained_models.rst
+++ b/docs/source/pretrained_models.rst
@@ -3,13 +3,13 @@ Pre-trained models
 
 For convenience, the following pre-trained models are ready-to-use:
 
-- `t2-tumor <https://github.com/ivadomed/t2_tumor/archive/r20200621.zip>`_: Cord tumor segmentation model, trained on T2-weighted contrast.
-- `t2star_sc <https://github.com/ivadomed/t2star_sc/archive/r20200622.zip>`_: Spinal cord segmentation model, trained on T2-star contrast.
-- `mice_uqueensland_gm <https://github.com/ivadomed/mice_uqueensland_gm/archive/r20200622.zip>`_: Gray matter segmentation model on mouse MRI. Data from University of Queensland.
-- `mice_uqueensland_sc <https://github.com/ivadomed/mice_uqueensland_sc/archive/r20200622.zip>`_: Cord segmentation model on mouse MRI. Data from University of Queensland.
-- `findcord_tumor <https://github.com/ivadomed/findcord_tumor/archive/r20200621.zip>`_: Cord localisation model, trained on T2-weighted images with tumor.
-- `model_find_disc_t1 <https://github.com/ivadomed/model_find_disc_t1/archive/r20201013.zip>`_: Intervertebral disc detection model trained on T1-weighted images.
-- `model_find_disc_t2 <https://github.com/ivadomed/model_find_disc_t2/archive/r20200928.zip>`_: Intervertebral disc detection model trained on T2-weighted images.
+- `t2-tumor <https://github.com/ivadomed/t2_tumor>`_: Cord tumor segmentation model, trained on T2-weighted contrast.
+- `t2star_sc <https://github.com/ivadomed/t2star_sc>`_: Spinal cord segmentation model, trained on T2-star contrast.
+- `mice_uqueensland_gm <https://github.com/ivadomed/mice_uqueensland_gm>`_: Gray matter segmentation model on mouse MRI. Data from University of Queensland.
+- `mice_uqueensland_sc <https://github.com/ivadomed/mice_uqueensland_sc>`_: Cord segmentation model on mouse MRI. Data from University of Queensland.
+- `findcord_tumor <https://github.com/ivadomed/findcord_tumor>`_: Cord localisation model, trained on T2-weighted images with tumor.
+- `model_find_disc_t1 <https://github.com/ivadomed/model_find_disc_t1>`_: Intervertebral disc detection model trained on T1-weighted images.
+- `model_find_disc_t2 <https://github.com/ivadomed/model_find_disc_t2>`_: Intervertebral disc detection model trained on T2-weighted images.
 
 Packaged model format
 ---------------------


### PR DESCRIPTION
## Description
In the RST docs, the pre-trained model links were downloadable zip packages. Since these are difficult to maintain, the links are now redirected to the respective github repository.

## Linked issues
#697 