### PR TITLE
New loader: add support for CT-scan files

### DIFF
--- a/ivadomed/config/config_bids.json
+++ b/ivadomed/config/config_bids.json
@@ -13,12 +13,12 @@
             "directory": "{subject}{session}"
         },
         {
-            "name": "task",
-            "pattern": "[_/\\\\]+task-([a-zA-Z0-9]+)"
-        },
-        {
             "name": "sample",
             "pattern": "[_/\\\\]+sample-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "task",
+            "pattern": "[_/\\\\]+task-([a-zA-Z0-9]+)"
         },
         {
             "name": "acquisition",
@@ -54,6 +54,22 @@
             "pattern": "[_/\\\\]+echo-([0-9]+)"
         },
         {
+            "name": "flip",
+            "pattern": "[_/\\\\]+flip-([0-9]+)"
+        },
+        {
+            "name": "inv",
+            "pattern": "[_/\\\\]+inv-([0-9]+)"
+        },
+        {
+            "name": "mt",
+            "pattern": "[_/\\\\]+mt-(on|off)"
+        },
+        {
+            "name": "part",
+            "pattern": "[_/\\\\]+part-(imag|mag|phase|real)"
+        },
+        {
             "name": "recording",
             "pattern": "[_/\\\\]+recording-([a-zA-Z0-9]+)"
         },
@@ -62,8 +78,12 @@
             "pattern": "[_/\\\\]+space-([a-zA-Z0-9]+)"
         },
         {
+            "name": "chunk",
+            "pattern": "[_/\\\\]+chunk-([0-9]+)"
+        },
+        {
             "name": "downsampling",
-            "pattern": "[_/\\\\]+down-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]+down-([0-9]+)"
         },
         {
             "name": "suffix",
@@ -79,7 +99,7 @@
         },
         {
             "name": "datatype",
-            "pattern": "[/\\\\]+(func|anat|fmap|dwi|meg|eeg|microscopy)[/\\\\]+"
+            "pattern": "[/\\\\]+(func|anat|fmap|dwi|meg|eeg|microscopy|ct)[/\\\\]+"
         },
         {
             "name": "extension",
@@ -88,10 +108,11 @@
     ],
 
     "default_path_patterns": [
-        "sub-{subject}[/ses-{session}]/{datatype<anat>|anat}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}]_{suffix<T1w|T2w|T1rho|T1map|T2map|T2star|FLAIR|FLASH|PDmap|PD|PDT2|inplaneT[12]|angio>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
+        "sub-{subject}[/ses-{session}]/{datatype<anat>|anat}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_part-{part}]_{suffix<T1w|T2w|T1rho|T1map|T2map|T2star|FLAIR|FLASH|PDmap|PD|PDT2|inplaneT[12]|angio>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
         "sub-{subject}[/ses-{session}]/{datatype<anat>|anat}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_mod-{modality}]_{suffix<defacemask>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
-        "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}]_{suffix<bold|cbv|phase|sbref>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
-        "sub-{subject}[/ses-{session}]/{datatype<dwi>|dwi}/sub-{subject}[_ses-{session}][_acq-{acquisition}]_{suffix<dwi>}{extension<.bval|.bvec|.json|.nii.gz|.nii>|.nii.gz}",
+        "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_part-{part}]_{suffix<bold|cbv|sbref>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
+        "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}]_{suffix<phase>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
+        "sub-{subject}[/ses-{session}]/{datatype<dwi>|dwi}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_part-{part}]_{suffix<dwi>}{extension<.bval|.bvec|.json|.nii.gz|.nii>|.nii.gz}",
         "sub-{subject}[/ses-{session}]/{datatype<fmap>|fmap}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_dir-{direction}][_run-{run}]_{fmap<phasediff|magnitude[12]|phase[12]|fieldmap>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
         "sub-{subject}[/ses-{session}]/{datatype<fmap>|fmap}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}]_dir-{direction}[_run-{run}]_{fmap<epi>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
         "sub-{subject}[/ses-{session}]/[{datatype<func|meg|beh>|func}/]sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_recording-{recording}]_{suffix<events>}{extension<.tsv|.json>|.tsv}",

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -704,13 +704,25 @@ class BidsDataframe:
             # Initialize BIDSLayoutIndexer and BIDSLayout
             # validate=True by default for both indexer and layout, BIDS-validator is not skipped
             # Force index for samples tsv and json files, and for subject subfolders containing microscopy files based on extensions.
+            # Force index of subject subfolders containing CT-scan files under "anat" or "ct" folder based on extensions and modality suffix.
             # TODO: remove force indexing of microscopy files after BEP microscopy is merged in BIDS
+            # TODO: remove force indexing of CT-scan files after BEP CT-scan is merged in BIDS
             ext_microscopy = ('.png', '.ome.tif', '.ome.tiff', '.ome.tf2', '.ome.tf8', '.ome.btf')
-            force_index = ['samples.tsv', 'samples.json']
+            ext_ct = ('.nii.gz', '.nii')
+            suffix_ct = ('ct', 'CT')
+            force_index = []
             for root, dirs, files in os.walk(path_data):
                 for file in files:
-                    if file.endswith(ext_microscopy) and os.path.basename(root) == "microscopy" and \
-                    (root.replace(path_data, '').startswith("sub")):
+                    # Microscopy
+                    if file == "samples.tsv" or file == "samples.json":
+                        force_index.append(file)
+                    if (file.endswith(ext_microscopy) and os.path.basename(root) == "microscopy" and
+                            (root.replace(path_data, '').startswith("sub"))):
+                        force_index.append(os.path.join(root.replace(path_data, '')))
+                    # CT-scan
+                    if (file.endswith(ext_ct) and file.split('.')[0].endswith(suffix_ct) and
+                            (os.path.basename(root) == "anat" or os.path.basename(root) == "ct") and
+                            (root.replace(path_data, '').startswith("sub"))):
                         force_index.append(os.path.join(root.replace(path_data, '')))
             indexer = pybids.BIDSLayoutIndexer(force_index=force_index)
 


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

This PR adds CT-scan support for the new loader. This is necessary because the new loader uses validation of the dataset in `pybids` and don't index CT-scan files, as the modality is not yet include in the BIDS specs.

Similarly to microscopy files, the indexing of CT-scan files is now forced when creating the `BidsDataframe`.
Note: the BEP for CT-scan is fairly new, I chose to accept 2 modality suffix (`_ct` and `_CT`) and 2 data type (`ct` and `anat`) for the indexing, based on the state of the BEP and our needs. These conditions could change in the future.

I also updated the custom `config_bids.json` file with the latest version from `pybids` and added the required fields for `ct` and `microscopy`. This file is used for the parsing of entities and data_type not yet merged into the BIDS specs.

To load CT-scan datasets, add the [bids_config](https://ivadomed.org/en/latest/configuration_file.html#bids-config) parameter to the config file.

I did not include a test for this new feature, I will add it in another PR for issue #718 with other changes to `test_loader.py`.

## Linked issues
Fixes #716 