### PR TITLE
New loader: Load PNG/TIF/JPG microscopy files as numpy array

### DIFF
--- a/docs/source/configuration_file.rst
+++ b/docs/source/configuration_file.rst
@@ -363,7 +363,7 @@ See details in both ``train_validation`` and ``test`` for the contrasts that are
     {
         "$schema": "http://json-schema.org/draft-04/schema#",
         "title": "slice_axis",
-        "description": "Sets the slice orientation for on which the model will be used.",
+        "description": "Sets the slice orientation for 3D NIfTI files on which the model will be used.",
         "type": "string",
         "options": {"sagittal": "plane dividing body into left/right",
                     "coronal": "plane dividing body into front/back",

--- a/ivadomed/config/config_new_loader.json
+++ b/ivadomed/config/config_new_loader.json
@@ -9,18 +9,18 @@
         "safety_factor": [1.0, 1.0, 1.0]
     },
     "loader_parameters": {
-        "path_data": ["data_example_spinegeneric"],
+        "path_data": ["data_example_microscopy_sem"],
         "bids_config": "ivadomed/config/config_bids.json",
         "subject_selection": {"n": [], "metadata": [], "value": []},
-        "target_suffix": ["_seg-manual"],
-        "extensions": [".nii.gz"],
+        "target_suffix": ["_seg-myelin-manual"],
+        "extensions": [".png"],
         "roi_params": {
             "suffix": null,
             "slice_filter_roi": null
         },
         "contrast_params": {
-            "training_validation": ["T1w", "T2w"],
-            "testing": ["T1w", "T2w"],
+            "training_validation": ["SEM"],
+            "testing": ["SEM"],
             "balance": {}
         },
         "slice_filter_params": {
@@ -117,28 +117,8 @@
         "overlap": {"unit": "vox", "thr": 3}
     },
     "transformation": {
-        "Resample":
-        {
-            "wspace": 0.75,
-            "hspace": 0.75,
-            "dspace": 1
-        },
         "CenterCrop": {
             "size": [128, 128]},
-        "RandomAffine": {
-            "degrees": 5,
-            "scale": [0.1, 0.1],
-            "translate": [0.03, 0.03],
-            "applied_to": ["im", "gt"],
-            "dataset_type": ["training"]
-        },
-        "ElasticTransform": {
-            "alpha_range": [28.0, 30.0],
-            "sigma_range":  [3.5, 4.5],
-            "p": 0.1,
-            "applied_to": ["im", "gt"],
-            "dataset_type": ["training"]
-        },
       "NumpyToTensor": {},
       "NormalizeInstance": {"applied_to": ["im"]}
     }

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -204,16 +204,17 @@ class SegmentationPair(object):
         self.input_handle = []
 
         # Ordered list of supported file extensions
-        ext_lst = [".nii", ".nii.gz", ".tif", ".tiff", ".png", ".jpg", ".jpeg"]
-
-        # TODO: add the following items between ".nii" and ".tif" in ext_lst when implementing OMETIFF support (#739)
+        # TODO: Implement support of the following OMETIFF formats (#739):
         # [".ome.tif", ".ome.tiff", ".ome.tf2", ".ome.tf8", ".ome.btf"]
+        # They are included in the list to avoid a ".ome.tif" or ".ome.tiff" following the ".tif" or ".tiff" pipeline
+        ext_lst = [".nii", ".nii.gz", ".ome.tif", ".ome.tiff", ".ome.tf2", ".ome.tf8", ".ome.btf", ".tif",
+                   ".tiff", ".png", ".jpg", ".jpeg"]
 
         # Returns the first match from the list
         self.extension = next((ext for ext in ext_lst if input_filenames[0].endswith(ext)), None)
         # TODO: remove "ome" from condition when implementing OMETIFF support (#739)
         if (not self.extension) or ("ome" in self.extension):
-            raise RuntimeError("Input file type of '{}' not supported".format(input_filenames[0]))
+            raise RuntimeError("The input file type of '{}' is not supported".format(input_filenames[0]))
 
         # loop over the filenames (list)
         for input_file in self.input_filenames:

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -200,9 +200,19 @@ class SegmentationPair(object):
         self.slice_axis = slice_axis
         self.soft_gt = soft_gt
         self.prepro_transforms = prepro_transforms
-        self.extension = input_filenames[0].split('.', 1)[1]
         # list of the images
         self.input_handle = []
+
+        # Ordered list of supported file extensions
+        ext_lst = [".nii", ".nii.gz", ".tif", ".tiff", ".png", ".jpg", ".jpeg"]
+
+        # TODO: add the following items between ".nii" and ".tif" in ext_lst when implementing OME-TIFF support:
+        # [".ome.tif", ".ome.tiff", ".ome.tf2", ".ome.tf8", ".ome.btf"]
+
+        # Returns the first match from the list
+        self.extension = next((ext for ext in ext_lst if input_filenames[0].endswith(ext)), None)
+        if not self.extension:
+            raise RuntimeError("Input file type of '{}' not supported".format(input_filenames[0]))
 
         # loop over the filenames (list)
         for input_file in self.input_filenames:
@@ -439,9 +449,6 @@ class SegmentationPair(object):
             # Returns data from file as a 3D numpy array
             # Behavior for grayscale png only, behavior TBD for RGB or RBGA png
             return np.expand_dims(imageio.imread(filename, as_gray=True), axis=-1)
-
-        else:
-            raise RuntimeError("Input file type '{}' not supported".format(self.extension))
 
     def apply_canonical(self, data):
         """Apply nibabel as_closest_canonical function to nifti data only.

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -234,16 +234,16 @@ class SegmentationPair(object):
                 raise RuntimeError('Input and ground truth with different dimensions.')
 
         for idx, handle in enumerate(self.input_handle):
-            self.input_handle[idx] = nib.as_closest_canonical(handle)
+            self.input_handle[idx] = self.apply_canonical(handle)
 
         # Labeled data (ie not inference time)
         if self.gt_filenames is not None:
             for idx, gt in enumerate(self.gt_handle):
                 if gt is not None:
                     if not isinstance(gt, list):  # this tissue has annotation from only one rater
-                        self.gt_handle[idx] = nib.as_closest_canonical(gt)
+                        self.gt_handle[idx] = self.apply_canonical(gt)
                     else:  # this tissue has annotation from several raters
-                        self.gt_handle[idx] = [nib.as_closest_canonical(gt_rater) for gt_rater in gt]
+                        self.gt_handle[idx] = [self.apply_canonical(gt_rater) for gt_rater in gt]
 
         # If binary classification, then extract labels from GT mask
 
@@ -442,6 +442,19 @@ class SegmentationPair(object):
             return np.expand_dims(imageio.imread(filename, as_gray=True), axis=-1)
         else:
             raise RuntimeError('Input file type not supported')
+
+    def apply_canonical(self, data):
+        """Apply nibabel as_closest_canonical function to nifti data only.
+        Args:
+            data ('nibabel.nifti1.Nifti1Image' object or 'ndarray'):
+                for nifti or png file respectively.
+        """
+        if "nii" in self.extension:
+            # Returns 'nibabel.nifti1.Nifti1Image' object
+            return nib.as_closest_canonical(data)
+        if self.extension == "png":
+            # Returns data as is in numpy array
+            return data
 
 
 class MRI2DSegmentationDataset(Dataset):

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -335,7 +335,7 @@ class SegmentationPair(object):
                 else:
                     gt_meta_dict.append([imed_loader_utils.SampleMetadata({
                         "zooms": imed_loader_utils.orient_shapes_hwd(self.get_voxel_size(gt_rater), self.slice_axis),
-                        "data_shape": imed_loader_utils.orient_shapes_hwd(self.get_shape(gt), self.slice_axis),
+                        "data_shape": imed_loader_utils.orient_shapes_hwd(self.get_shape(gt_rater), self.slice_axis),
                         "gt_filenames": self.metadata[0]["gt_filenames"][idx_class][idx_rater],
                         "bounding_box": self.metadata[0]["bounding_box"] if 'bounding_box' in self.metadata[
                             0] else None,

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -38,7 +38,7 @@ def load_dataset(bids_df, data_list, transforms_params, model_params, target_suf
         contrast_params (dict): Contains image contrasts related parameters.
         slice_filter_params (dict): Contains slice_filter parameters, see :doc:`configuration_file` for more details.
         slice_axis (string): Choice between "axial", "sagittal", "coronal" ; controls the axis used to extract the 2D
-            data.
+            data from 3D nifti files. 2D png files use default "axial.
         multichannel (bool): If True, the input contrasts are combined as input channels for the model. Otherwise, each
             contrast is processed individually (ie different sample / tensor).
         metadata_type (str): Choice between None, "mri_params", "contrasts".
@@ -55,7 +55,6 @@ def load_dataset(bids_df, data_list, transforms_params, model_params, target_suf
     Note: For more details on the parameters transform_params, target_suffix, roi_params, contrast_params,
     slice_filter_params and object_detection_params see :doc:`configuration_file`.
     """
-
     # Compose transforms
     tranform_lst, _ = imed_transforms.prepare_transforms(copy.deepcopy(transforms_params), requires_undo)
 
@@ -174,7 +173,8 @@ class SegmentationPair(object):
         metadata (list): Metadata list with each item corresponding to an image (contrast) in input_filenames.
             For single channel, the list will contain metadata related to one image.
         cache (bool): If the data should be cached in memory or not.
-        slice_axis (int): Indicates the axis used to extract slices: "axial": 2, "sagittal": 0, "coronal": 1.
+        slice_axis (int): Indicates the axis used to extract 2D slices from 3D nifti files:
+            "axial": 2, "sagittal": 0, "coronal": 1. 2D png files use default "axial": 2.
         prepro_transforms (dict): Output of get_preprocessing_transforms.
 
     Attributes:
@@ -182,10 +182,11 @@ class SegmentationPair(object):
         gt_filenames (list): List of ground truth filenames.
         metadata (dict): Dictionary containing metadata of input and gt.
         cache (bool): If the data should be cached in memory or not.
-        slice_axis (int): Indicates the axis used to extract slices: "axial": 2, "sagittal": 0, "coronal": 1.
+        slice_axis (int): Indicates the axis used to extract 2D slices from 3D nifti files:
+            "axial": 2, "sagittal": 0, "coronal": 1. 2D png files use default "axial": 2.
         prepro_transforms (dict): Transforms to be applied before training.
-        input_handle (list): List of input nifty data.
-        gt_handle (list): List of gt nifty data.
+        input_handle (list): List of input nifty data as 'nibabel.nifti1.Nifti1Image' object or png data as 'ndarray'
+        gt_handle (list): List of gt nifty data as 'nibabel.nifti1.Nifti1Image' object or png data as 'ndarray'
         extension (str): File extension of input files
     """
 
@@ -508,7 +509,8 @@ class MRI2DSegmentationDataset(Dataset):
     Args:
         filename_pairs (list): a list of tuples in the format (input filename list containing all modalities,ground \
             truth filename, ROI filename, metadata).
-        slice_axis (int): axis to make the slicing (default axial).
+        slice_axis (int): Indicates the axis used to extract 2D slices from 3D nifti files:
+            "axial": 2, "sagittal": 0, "coronal": 1. 2D png files use default "axial": 2.
         cache (bool): if the data should be cached in memory or not.
         transform (torchvision.Compose): transformations to apply.
         slice_filter_fn (dict): Slice filter parameters, see :doc:`configuration_file` for more details.
@@ -526,7 +528,8 @@ class MRI2DSegmentationDataset(Dataset):
         prepro_transforms (Compose): Transformations to apply before training.
         transform (Compose): Transformations to apply during training.
         cache (bool): Tf the data should be cached in memory or not.
-        slice_axis (int): Indicates the axis used to extract slices: "axial": 2, "sagittal": 0, "coronal": 1.
+        slice_axis (int): Indicates the axis used to extract 2D slices from 3D nifti files:
+            "axial": 2, "sagittal": 0, "coronal": 1. 2D png files use default "axial": 2.
         slice_filter_fn (dict): Slice filter parameters, see :doc:`configuration_file` for more details.
         n_contrasts (int): Number of input contrasts.
         has_bounding_box (bool): True if bounding box in all metadata, else False.
@@ -891,7 +894,8 @@ class BidsDataset(MRI2DSegmentationDataset):
         subject_file_lst (list): Subject filenames list.
         target_suffix (list): List of suffixes for target masks.
         contrast_params (dict): Contains image contrasts related parameters.
-        slice_axis (int): Indicates the axis used to extract slices: "axial": 2, "sagittal": 0, "coronal": 1.
+        slice_axis (int): Indicates the axis used to extract 2D slices from 3D nifti files:
+            "axial": 2, "sagittal": 0, "coronal": 1. 2D png files use default "axial": 2.
         cache (bool): If the data should be cached in memory or not.
         transform (list): Transformation list (length 2) composed of preprocessing transforms (Compose) and transforms
             to apply during training (Compose).

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -439,7 +439,7 @@ class SegmentationPair(object):
             # Behavior for grayscale png only, behavior TBD for RGB or RBGA png
             return np.expand_dims(imageio.imread(filename, as_gray=True), axis=-1)
         else:
-            raise RuntimeError('Input file type not supported')
+            raise RuntimeError("Input file type '{}' not supported".format(self.extension))
 
     def apply_canonical(self, data):
         """Apply nibabel as_closest_canonical function to nifti data only.

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -211,7 +211,7 @@ class SegmentationPair(object):
                    ".tiff", ".png", ".jpg", ".jpeg"]
 
         # Returns the first match from the list
-        self.extension = next((ext for ext in ext_lst if input_filenames[0].endswith(ext)), None)
+        self.extension = next((ext for ext in ext_lst if input_filenames[0].lower().endswith(ext)), None)
         # TODO: remove "ome" from condition when implementing OMETIFF support (#739)
         if (not self.extension) or ("ome" in self.extension):
             raise RuntimeError("The input file type of '{}' is not supported".format(input_filenames[0]))

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -445,7 +445,9 @@ class SegmentationPair(object):
             # For '.nii' and '.nii.gz' extentions
             # Returns 'nibabel.nifti1.Nifti1Image' object
             return nib.load(filename)
+
         # TODO: (#739) implement OMETIFF behavior (elif "ome" in self.extension)
+
         else:
             # For '.png', '.tif', '.tiff', '.jpg' and 'jpeg' extentions
             # Returns data from file as a 3D numpy array
@@ -462,7 +464,9 @@ class SegmentationPair(object):
             # For '.nii' and '.nii.gz' extentions
             # Returns 'nibabel.nifti1.Nifti1Image' object
             return nib.as_closest_canonical(data)
+
         # TODO: (#739)  implement OMETIFF behavior (elif "ome" in self.extension)
+
         else:
             # For '.png', '.tif', '.tiff', '.jpg' and 'jpeg' extentions
             # Returns data as is in numpy array
@@ -479,7 +483,9 @@ class SegmentationPair(object):
         if "nii" in self.extension:
             # For '.nii' and '.nii.gz' extentions
             return data.header.get_data_shape()
+
         # TODO: (#739) implement OMETIFF behavior (elif "ome" in self.extension)
+
         else:
             # For '.png', '.tif', '.tiff', '.jpg' and 'jpeg' extentions
             return data.shape
@@ -496,7 +502,9 @@ class SegmentationPair(object):
             # For '.nii' and '.nii.gz' extentions
             # Read zooms metadata from nifti file header
             return data.header.get_zooms()
+
         # TODO: (#739) implement OMETIFF behavior (elif "ome" in self.extension)
+
         else:
             # For '.png', '.tif', '.tiff', '.jpg' and 'jpeg' extentions
             # Voxel size is extracted from PixelSize metadata (from BIDS JSON sidecar)
@@ -504,17 +512,20 @@ class SegmentationPair(object):
             # PixelSize definition may change for 2D [X, Y] and 3D [X, Y, Z] arrays in micrometers (BIDS BEP031 v 0.0.3)
             # This method supports both behaviors.
             # TODO: Update behavior to follow BEP microscopy development (#301)
+
+            array_length = [2, 3]        # Accepted array length for 'PixelSize' metadata
+            conversion_factor = 0.001    # Conversion factor from um to mm
             if 'PixelSize' in self.metadata[0]:
                 ps_in_um = self.metadata[0]['PixelSize']
-                if isinstance(ps_in_um, list) and (len(ps_in_um) == 2 or len(ps_in_um) == 3):
+                if isinstance(ps_in_um, list) and (len(ps_in_um) in array_length):
                     ps_in_um = np.asarray(ps_in_um)
                     ps_in_um.resize(3)
                 elif isinstance(ps_in_um, float):
                     ps_in_um = np.asarray([ps_in_um, ps_in_um, 0])
                 else:
-                    raise RuntimeError("'PixelSize' metadata type is not supported. Format must be 2D [X, Y] list, "
-                                       "3D [X, Y, Z] list or float.")
-                ps_in_mm = tuple(ps_in_um / 1000)
+                    raise RuntimeError("'PixelSize' metadata type is not supported. Format must be 2D [X, Y] array, "
+                                       "3D [X, Y, Z] array or float.")
+                ps_in_mm = tuple(ps_in_um * conversion_factor)
             else:
                 # TODO: Fix behavior for run_segment_command and inference, no BIDS metadata (#306)
                 raise RuntimeError("'PixelSize' is missing from metadata")
@@ -533,7 +544,9 @@ class SegmentationPair(object):
             # For '.nii' and '.nii.gz' extentions
             # Load data from file as numpy array
             return data.get_fdata(cache_mode, dtype=np.float32)
+
         # TODO: (#739) implement OME-TIFF behavior (elif "ome" in self.extension)
+
         else:
             # For '.png', '.tif', '.tiff', '.jpg' and 'jpeg' extentions
             # Returns data as is in numpy array

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -185,6 +185,7 @@ class SegmentationPair(object):
         prepro_transforms (dict): Transforms to be applied before training.
         input_handle (list): List of input nifty data.
         gt_handle (list): List of gt nifty data.
+        extension (str): File extension of input files
     """
 
     def __init__(self, input_filenames, gt_filenames, metadata=None, slice_axis=2, cache=True, prepro_transforms=None,
@@ -197,6 +198,7 @@ class SegmentationPair(object):
         self.slice_axis = slice_axis
         self.soft_gt = soft_gt
         self.prepro_transforms = prepro_transforms
+        self.extension = input_filenames[0].split('.', 1)[1]
         # list of the images
         self.input_handle = []
 

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -452,7 +452,11 @@ class SegmentationPair(object):
             # For '.png', '.tif', '.tiff', '.jpg' and 'jpeg' extentions
             # Returns data from file as a 3D numpy array
             # Behavior for grayscale only, behavior TBD for RGB or RBGA
-            return np.expand_dims(imageio.imread(filename, as_gray=True), axis=-1)
+            if "tif" in self.extension:
+                return np.expand_dims(imageio.imread(filename, format='tiff-pil', as_gray=True), axis=-1)
+            else:
+                return np.expand_dims(imageio.imread(filename, as_gray=True), axis=-1)
+
 
     def apply_canonical(self, data):
         """Apply nibabel as_closest_canonical function to nifti data only.

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -211,7 +211,8 @@ class SegmentationPair(object):
 
         # Returns the first match from the list
         self.extension = next((ext for ext in ext_lst if input_filenames[0].endswith(ext)), None)
-        if not self.extension:
+        # TODO: remove "ome" from condition when implementing OME-TIFF support
+        if (not self.extension) or ("ome" in self.extension):
             raise RuntimeError("Input file type of '{}' not supported".format(input_filenames[0]))
 
         # loop over the filenames (list)
@@ -441,13 +442,14 @@ class SegmentationPair(object):
             filename (str): Subject filename.
         """
         if "nii" in self.extension:
+            # For '.nii' and '.nii.gz' extentions
             # Returns 'nibabel.nifti1.Nifti1Image' object
-            # For 'nii' and 'nii.gz' extentions
             return nib.load(filename)
-
-        elif self.extension == "png":
+        # TODO: implement OME-TIFF behavior (elif "ome" in self.extension)
+        else:
+            # For '.png', '.tif', '.tiff', '.jpg' and 'jpeg' extentions
             # Returns data from file as a 3D numpy array
-            # Behavior for grayscale png only, behavior TBD for RGB or RBGA png
+            # Behavior for grayscale png only, behavior TBD for RGB or RBGA
             return np.expand_dims(imageio.imread(filename, as_gray=True), axis=-1)
 
     def apply_canonical(self, data):
@@ -457,10 +459,12 @@ class SegmentationPair(object):
                 for nifti or png file respectively.
         """
         if "nii" in self.extension:
+            # For '.nii' and '.nii.gz' extentions
             # Returns 'nibabel.nifti1.Nifti1Image' object
             return nib.as_closest_canonical(data)
-
-        elif self.extension == "png":
+        # TODO: implement OME-TIFF behavior (elif "ome" in self.extension)
+        else:
+            # For '.png', '.tif', '.tiff', '.jpg' and 'jpeg' extentions
             # Returns data as is in numpy array
             return data
 
@@ -473,9 +477,11 @@ class SegmentationPair(object):
             ndarray: Data shape.
         """
         if "nii" in self.extension:
+            # For '.nii' and '.nii.gz' extentions
             return data.header.get_data_shape()
-
-        elif self.extension == "png":
+        # TODO: implement OME-TIFF behavior (elif "ome" in self.extension)
+        else:
+            # For '.png', '.tif', '.tiff', '.jpg' and 'jpeg' extentions
             return data.shape
 
     def get_voxel_size(self, data):
@@ -487,16 +493,17 @@ class SegmentationPair(object):
             tuple: Voxel size in mm
         """
         if "nii" in self.extension:
+            # For '.nii' and '.nii.gz' extentions
             # Read zooms metadata from nifti file header
             return data.header.get_zooms()
-
-        elif self.extension == "png":
-            # Voxel size for PNG is extracted from PixelSize metadata (from BIDS JSON sidecar)
+        # TODO: implement OME-TIFF behavior (elif "ome" in self.extension)
+        else:
+            # For '.png', '.tif', '.tiff', '.jpg' and 'jpeg' extentions
+            # Voxel size is extracted from PixelSize metadata (from BIDS JSON sidecar)
             # PixelSize definition in example dataset is a scalar in micrometers (BIDS BEP031 v 0.0.2)
             # PixelSize definition may change for 2D [X, Y] and 3D [X, Y, Z] arrays in micrometers (BIDS BEP031 v 0.0.3)
             # This method supports both behaviors.
             # TODO: Update behavior to follow BEP microscopy development
-            # TODO: Review beahvior when implementing inference with PNG files (no BIDS metadata)
             if 'PixelSize' in self.metadata[0]:
                 ps_in_um = self.metadata[0]['PixelSize']
                 if isinstance(ps_in_um, list) and (len(ps_in_um) == 2 or len(ps_in_um) == 3):
@@ -509,6 +516,8 @@ class SegmentationPair(object):
                                        "3D [X, Y, Z] list or float.")
                 ps_in_mm = tuple(ps_in_um / 1000)
             else:
+                # TODO: Fix behavior for run_segment_command (no BIDS metadata)
+                # TODO: Review beahvior when implementing inference (no BIDS metadata)
                 raise RuntimeError("'PixelSize' is missing from metadata")
             return ps_in_mm
 
@@ -522,10 +531,12 @@ class SegmentationPair(object):
             ndarray: File data.
         """
         if "nii" in self.extension:
+            # For '.nii' and '.nii.gz' extentions
             # Load data from file as numpy array
             return data.get_fdata(cache_mode, dtype=np.float32)
-
-        elif self.extension == "png":
+        # TODO: implement OME-TIFF behavior (elif "ome" in self.extension)
+        else:
+            # For '.png', '.tif', '.tiff', '.jpg' and 'jpeg' extentions
             # Returns data as is in numpy array
             return data
 

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -285,8 +285,7 @@ class SegmentationPair(object):
 
         input_data = []
         for handle in self.input_handle:
-            hwd_oriented = imed_loader_utils.orient_img_hwd(handle.get_fdata(cache_mode, dtype=np.float32),
-                                                            self.slice_axis)
+            hwd_oriented = imed_loader_utils.orient_img_hwd(self.get_data(handle, cache_mode), self.slice_axis)
             input_data.append(hwd_oriented)
 
         gt_data = []
@@ -296,12 +295,11 @@ class SegmentationPair(object):
         for gt in self.gt_handle:
             if gt is not None:
                 if not isinstance(gt, list):  # this tissue has annotation from only one rater
-                    hwd_oriented = imed_loader_utils.orient_img_hwd(gt.get_fdata(cache_mode, dtype=np.float32),
-                                                                    self.slice_axis)
+                    hwd_oriented = imed_loader_utils.orient_img_hwd(self.get_data(gt, cache_mode), self.slice_axis)
                     gt_data.append(hwd_oriented)
                 else:  # this tissue has annotation from several raters
                     hwd_oriented_list = [
-                        imed_loader_utils.orient_img_hwd(gt_rater.get_fdata(cache_mode, dtype=np.float32),
+                        imed_loader_utils.orient_img_hwd(self.get_data(gt_rater, cache_mode),
                                                          self.slice_axis) for gt_rater in gt]
                     gt_data.append([hwd_oriented.astype(data_type) for hwd_oriented in hwd_oriented_list])
             else:
@@ -486,6 +484,22 @@ class SegmentationPair(object):
             # Behavior will have to be ajusted here to follow BEP development
             pixel_size_in_mm = self.metadata[0]['PixelSize'] / 1000
             return (pixel_size_in_mm, pixel_size_in_mm, 0)
+
+    def get_data(self, data, cache_mode):
+        """Get nifti file data.
+        Args:
+            data ('nibabel.nifti1.Nifti1Image' object or 'ndarray'):
+                for nifti and png file respectively.
+            cache_mode (str): cache mode for nifti files
+        Returns:
+            ndarray: File data.
+        """
+        if "nii" in self.extension:
+            # Load data from file as numpy array
+            return data.get_fdata(cache_mode, dtype=np.float32)
+        if self.extension == "png":
+            # Returns data as is in numpy array
+            return data
 
 
 class MRI2DSegmentationDataset(Dataset):

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -206,12 +206,12 @@ class SegmentationPair(object):
         # Ordered list of supported file extensions
         ext_lst = [".nii", ".nii.gz", ".tif", ".tiff", ".png", ".jpg", ".jpeg"]
 
-        # TODO: add the following items between ".nii" and ".tif" in ext_lst when implementing OME-TIFF support:
+        # TODO: add the following items between ".nii" and ".tif" in ext_lst when implementing OMETIFF support (#739)
         # [".ome.tif", ".ome.tiff", ".ome.tf2", ".ome.tf8", ".ome.btf"]
 
         # Returns the first match from the list
         self.extension = next((ext for ext in ext_lst if input_filenames[0].endswith(ext)), None)
-        # TODO: remove "ome" from condition when implementing OME-TIFF support
+        # TODO: remove "ome" from condition when implementing OMETIFF support (#739)
         if (not self.extension) or ("ome" in self.extension):
             raise RuntimeError("Input file type of '{}' not supported".format(input_filenames[0]))
 
@@ -445,7 +445,7 @@ class SegmentationPair(object):
             # For '.nii' and '.nii.gz' extentions
             # Returns 'nibabel.nifti1.Nifti1Image' object
             return nib.load(filename)
-        # TODO: implement OME-TIFF behavior (elif "ome" in self.extension)
+        # TODO: (#739) implement OMETIFF behavior (elif "ome" in self.extension)
         else:
             # For '.png', '.tif', '.tiff', '.jpg' and 'jpeg' extentions
             # Returns data from file as a 3D numpy array
@@ -462,7 +462,7 @@ class SegmentationPair(object):
             # For '.nii' and '.nii.gz' extentions
             # Returns 'nibabel.nifti1.Nifti1Image' object
             return nib.as_closest_canonical(data)
-        # TODO: implement OME-TIFF behavior (elif "ome" in self.extension)
+        # TODO: (#739)  implement OMETIFF behavior (elif "ome" in self.extension)
         else:
             # For '.png', '.tif', '.tiff', '.jpg' and 'jpeg' extentions
             # Returns data as is in numpy array
@@ -479,7 +479,7 @@ class SegmentationPair(object):
         if "nii" in self.extension:
             # For '.nii' and '.nii.gz' extentions
             return data.header.get_data_shape()
-        # TODO: implement OME-TIFF behavior (elif "ome" in self.extension)
+        # TODO: (#739) implement OMETIFF behavior (elif "ome" in self.extension)
         else:
             # For '.png', '.tif', '.tiff', '.jpg' and 'jpeg' extentions
             return data.shape
@@ -496,14 +496,14 @@ class SegmentationPair(object):
             # For '.nii' and '.nii.gz' extentions
             # Read zooms metadata from nifti file header
             return data.header.get_zooms()
-        # TODO: implement OME-TIFF behavior (elif "ome" in self.extension)
+        # TODO: (#739) implement OMETIFF behavior (elif "ome" in self.extension)
         else:
             # For '.png', '.tif', '.tiff', '.jpg' and 'jpeg' extentions
             # Voxel size is extracted from PixelSize metadata (from BIDS JSON sidecar)
             # PixelSize definition in example dataset is a scalar in micrometers (BIDS BEP031 v 0.0.2)
             # PixelSize definition may change for 2D [X, Y] and 3D [X, Y, Z] arrays in micrometers (BIDS BEP031 v 0.0.3)
             # This method supports both behaviors.
-            # TODO: Update behavior to follow BEP microscopy development
+            # TODO: Update behavior to follow BEP microscopy development (#301)
             if 'PixelSize' in self.metadata[0]:
                 ps_in_um = self.metadata[0]['PixelSize']
                 if isinstance(ps_in_um, list) and (len(ps_in_um) == 2 or len(ps_in_um) == 3):
@@ -516,8 +516,7 @@ class SegmentationPair(object):
                                        "3D [X, Y, Z] list or float.")
                 ps_in_mm = tuple(ps_in_um / 1000)
             else:
-                # TODO: Fix behavior for run_segment_command (no BIDS metadata)
-                # TODO: Review beahvior when implementing inference (no BIDS metadata)
+                # TODO: Fix behavior for run_segment_command and inference, no BIDS metadata (#306)
                 raise RuntimeError("'PixelSize' is missing from metadata")
             return ps_in_mm
 
@@ -534,7 +533,7 @@ class SegmentationPair(object):
             # For '.nii' and '.nii.gz' extentions
             # Load data from file as numpy array
             return data.get_fdata(cache_mode, dtype=np.float32)
-        # TODO: implement OME-TIFF behavior (elif "ome" in self.extension)
+        # TODO: (#739) implement OME-TIFF behavior (elif "ome" in self.extension)
         else:
             # For '.png', '.tif', '.tiff', '.jpg' and 'jpeg' extentions
             # Returns data as is in numpy array

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -38,7 +38,7 @@ def load_dataset(bids_df, data_list, transforms_params, model_params, target_suf
         contrast_params (dict): Contains image contrasts related parameters.
         slice_filter_params (dict): Contains slice_filter parameters, see :doc:`configuration_file` for more details.
         slice_axis (string): Choice between "axial", "sagittal", "coronal" ; controls the axis used to extract the 2D
-            data from 3D nifti files. 2D png files use default "axial.
+            data from 3D nifti files. 2D png/tif/jpg files use default "axial.
         multichannel (bool): If True, the input contrasts are combined as input channels for the model. Otherwise, each
             contrast is processed individually (ie different sample / tensor).
         metadata_type (str): Choice between None, "mri_params", "contrasts".
@@ -174,7 +174,7 @@ class SegmentationPair(object):
             For single channel, the list will contain metadata related to one image.
         cache (bool): If the data should be cached in memory or not.
         slice_axis (int): Indicates the axis used to extract 2D slices from 3D nifti files:
-            "axial": 2, "sagittal": 0, "coronal": 1. 2D png files use default "axial": 2.
+            "axial": 2, "sagittal": 0, "coronal": 1. 2D png/tif/jpg files use default "axial": 2.
         prepro_transforms (dict): Output of get_preprocessing_transforms.
 
     Attributes:
@@ -183,10 +183,10 @@ class SegmentationPair(object):
         metadata (dict): Dictionary containing metadata of input and gt.
         cache (bool): If the data should be cached in memory or not.
         slice_axis (int): Indicates the axis used to extract 2D slices from 3D nifti files:
-            "axial": 2, "sagittal": 0, "coronal": 1. 2D png files use default "axial": 2.
+            "axial": 2, "sagittal": 0, "coronal": 1. 2D png/tif/jpg files use default "axial": 2.
         prepro_transforms (dict): Transforms to be applied before training.
-        input_handle (list): List of input nifty data as 'nibabel.nifti1.Nifti1Image' object or png data as 'ndarray'
-        gt_handle (list): List of gt nifty data as 'nibabel.nifti1.Nifti1Image' object or png data as 'ndarray'
+        input_handle (list): List of input nifty data as 'nibabel.nifti1.Nifti1Image' object or png/tif/jpg data as 'ndarray'
+        gt_handle (list): List of gt nifty data as 'nibabel.nifti1.Nifti1Image' object or png/tif/jpg data as 'ndarray'
         extension (str): File extension of input files
     """
 
@@ -449,14 +449,14 @@ class SegmentationPair(object):
         else:
             # For '.png', '.tif', '.tiff', '.jpg' and 'jpeg' extentions
             # Returns data from file as a 3D numpy array
-            # Behavior for grayscale png only, behavior TBD for RGB or RBGA
+            # Behavior for grayscale only, behavior TBD for RGB or RBGA
             return np.expand_dims(imageio.imread(filename, as_gray=True), axis=-1)
 
     def apply_canonical(self, data):
         """Apply nibabel as_closest_canonical function to nifti data only.
         Args:
             data ('nibabel.nifti1.Nifti1Image' object or 'ndarray'):
-                for nifti or png file respectively.
+                for nifti or png/tif/jpg file respectively.
         """
         if "nii" in self.extension:
             # For '.nii' and '.nii.gz' extentions
@@ -472,7 +472,7 @@ class SegmentationPair(object):
         """Returns data shape according to file type.
         Args:
             data ('nibabel.nifti1.Nifti1Image' object or 'ndarray'):
-                for nifti or png file respectively.
+                for nifti or png/tif/jpg file respectively.
         Returns:
             ndarray: Data shape.
         """
@@ -488,7 +488,7 @@ class SegmentationPair(object):
         """Returns voxel sizes in mm according to file type.
         Args:
             data ('nibabel.nifti1.Nifti1Image' object or 'ndarray'):
-                for nifti and png file respectively.
+                for nifti and png/tif/jpg file respectively.
         Returns:
             tuple: Voxel size in mm
         """
@@ -525,7 +525,7 @@ class SegmentationPair(object):
         """Get nifti file data.
         Args:
             data ('nibabel.nifti1.Nifti1Image' object or 'ndarray'):
-                for nifti and png file respectively.
+                for nifti and png/tif/jpg file respectively.
             cache_mode (str): cache mode for nifti files
         Returns:
             ndarray: File data.
@@ -548,7 +548,7 @@ class MRI2DSegmentationDataset(Dataset):
         filename_pairs (list): a list of tuples in the format (input filename list containing all modalities,ground \
             truth filename, ROI filename, metadata).
         slice_axis (int): Indicates the axis used to extract 2D slices from 3D nifti files:
-            "axial": 2, "sagittal": 0, "coronal": 1. 2D png files use default "axial": 2.
+            "axial": 2, "sagittal": 0, "coronal": 1. 2D png/tif/jpg files use default "axial": 2.
         cache (bool): if the data should be cached in memory or not.
         transform (torchvision.Compose): transformations to apply.
         slice_filter_fn (dict): Slice filter parameters, see :doc:`configuration_file` for more details.
@@ -567,7 +567,7 @@ class MRI2DSegmentationDataset(Dataset):
         transform (Compose): Transformations to apply during training.
         cache (bool): Tf the data should be cached in memory or not.
         slice_axis (int): Indicates the axis used to extract 2D slices from 3D nifti files:
-            "axial": 2, "sagittal": 0, "coronal": 1. 2D png files use default "axial": 2.
+            "axial": 2, "sagittal": 0, "coronal": 1. 2D png/tif/jpg files use default "axial": 2.
         slice_filter_fn (dict): Slice filter parameters, see :doc:`configuration_file` for more details.
         n_contrasts (int): Number of input contrasts.
         has_bounding_box (bool): True if bounding box in all metadata, else False.
@@ -933,7 +933,7 @@ class BidsDataset(MRI2DSegmentationDataset):
         target_suffix (list): List of suffixes for target masks.
         contrast_params (dict): Contains image contrasts related parameters.
         slice_axis (int): Indicates the axis used to extract 2D slices from 3D nifti files:
-            "axial": 2, "sagittal": 0, "coronal": 1. 2D png files use default "axial": 2.
+            "axial": 2, "sagittal": 0, "coronal": 1. 2D png/tif/jpg files use default "axial": 2.
         cache (bool): If the data should be cached in memory or not.
         transform (list): Transformation list (length 2) composed of preprocessing transforms (Compose) and transforms
             to apply during training (Compose).

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -450,7 +450,7 @@ class SegmentationPair(object):
         if "nii" in self.extension:
             # Returns 'nibabel.nifti1.Nifti1Image' object
             return nib.as_closest_canonical(data)
-        if self.extension == "png":
+        elif self.extension == "png":
             # Returns data as is in numpy array
             return data
 
@@ -464,7 +464,7 @@ class SegmentationPair(object):
         """
         if "nii" in self.extension:
             return data.header.get_data_shape()
-        if self.extension == "png":
+        elif self.extension == "png":
             return data.shape
 
     def get_voxel_size(self, data):
@@ -478,7 +478,7 @@ class SegmentationPair(object):
         if "nii" in self.extension:
             # Read zooms metadata from nifti file header
             return data.header.get_zooms()
-        if self.extension == "png":
+        elif self.extension == "png":
             # Voxel size for PNG is extracted from PixelSize metadata (from BIDS JSON sidecar)
             # PixelSize definition in example dataset is a scalar in micrometers (BIDS BEP031 v 0.0.2)
             # PixelSize definition will change, 2D (XY) or 3D (XYZ) array in micrometers (BIDS BEP031 v 0.0.3)
@@ -498,7 +498,7 @@ class SegmentationPair(object):
         if "nii" in self.extension:
             # Load data from file as numpy array
             return data.get_fdata(cache_mode, dtype=np.float32)
-        if self.extension == "png":
+        elif self.extension == "png":
             # Returns data as is in numpy array
             return data
 

--- a/testing/unit_tests/test_loader.py
+++ b/testing/unit_tests/test_loader.py
@@ -133,5 +133,41 @@ def test_dropout_input(seg_pair):
         assert sum(empty_channels) == 0
 
 
+@pytest.mark.parametrize('loader_parameters', [{
+    "path_data": [os.path.join(__data_testing_dir__, "microscopy_png")],
+    "bids_config": "ivadomed/config/config_bids.json",
+    "target_suffix": ["_seg-myelin-manual"],
+    "extensions": [".png"],
+    "roi_params": {"suffix": None, "slice_filter_roi": None},
+    "contrast_params": {"contrast_lst": [], "balance": {}},
+    "slice_axis": "axial",
+    "slice_filter_params": {"filter_empty_mask": False, "filter_empty_input": True},
+    "multichannel": False
+    }])
+@pytest.mark.parametrize('model_parameters', [{
+        "name": "Unet",
+        "dropout_rate": 0.3,
+        "bn_momentum": 0.1,
+        "final_activation": "sigmoid",
+        "depth": 3
+    }])
+@pytest.mark.parametrize('transform_parameters', [{
+    "NumpyToTensor": {},
+    }])
+def test_load_dataset_2d_png(loader_parameters, model_parameters, transform_parameters):
+    """
+    Test to make sure load_dataset runs with 2D PNG data.
+    """
+    loader_parameters.update({"model_params": model_parameters})
+    bids_df = imed_loader_utils.BidsDataframe(loader_parameters, __tmp_dir__, derivatives=True)
+    data_lst = ['sub-rat3_ses-01_sample-data9_SEM.png']
+    ds = imed_loader.load_dataset(bids_df,
+                                  **{**loader_parameters, **{'data_list': data_lst,
+                                                             'transforms_params': transform_parameters,
+                                                             'dataset_type': 'training'}})
+    assert ds[0]['input'].shape == (1, 756, 764)
+    assert ds[0]['gt'].shape == (1, 756, 764)
+
+
 def teardown_function():
     remove_tmp_dir()


### PR DESCRIPTION
#### GitHub
- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents
- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR enables the loading of microsocpy PNG files as numpy arrays for training, as well as PNG/TIF/JPG files for inference.
I added 5 methods to the `SegmentationPair` class to replace functions from nibabel library specific to nifti files.

Nibabel functions `nib.load`, `nib.as_closest_canonical`, `handle.header.get_data_shape`, `handle.header.get_zooms`, `handle.get_fdata` are replaced respectively by `read_file`, `apply_canonical`, `get_shape`, `get_voxel_size` and `get_data` throughout the class.

These new methods include a "per file format" behavior based on file extension. For nifti files, the nibabel functions are used as they were before. For PNG/TIF/JPG files, a corresponding behavior is applied. Adding a new modalities of file formats in the future would require to update those 5 functions.

I chose this "minimally invasive" approach because of the complexity of the SegmentationPair class where each nibabel functions is called several times, which I think would require a major refactoring to avoid.
@Drulex, @joshuacwnewton, @ahill187, @gisellemartel, @dyt811 Let us know if you have advice for us on how to approach this refactoring. Thanks!

## To test the PR:
- Any job with nifti files should work as usual
- To test with PNG, use `config_new_loader.json` and the `ivadomed/data_example_microscopy_sem` dataset.

## Linked issues
Fixes #733 
