### PR TITLE
Add link to GitHub wiki in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,5 @@ This project results from a collaboration between the [NeuroPoly Lab](https://ww
 and the [Mila](https://mila.quebec/en/). The main funding source is [IVADO](https://ivado.ca/en/).
 
 [List of contributors](https://github.com/neuropoly/ivadomed/graphs/contributors)
+
+## Consult our Wiki(https://github.com/ivadomed/ivadomed/wiki) here for more help


### PR DESCRIPTION
## Description
A link to the Github wiki has been added to the readme file as requested in issue #629 

## Linked issues
Closes #629
