### PR TITLE
Refactoring: reduce complexity of BIDStoHDF5 __init__

### DIFF
--- a/ivadomed/loader/adaptative.py
+++ b/ivadomed/loader/adaptative.py
@@ -223,6 +223,7 @@ class BIDStoHDF5:
         list_patients = []
 
         self.filename_pairs = []
+        self.metadata = {}
 
         if metadata_choice == 'mri_params':
             self.metadata = {"FlipAngle": [], "RepetitionTime": [],
@@ -253,8 +254,8 @@ class BIDStoHDF5:
         all_deriv = bids_df.get_deriv_fnames()
 
         for subject in tqdm(subject_file_lst, desc="Loading dataset"):
-            self.process_subject( bids_df, subject, df_subjects, c, tot, contrast_balance, target_suffix, 
-                                all_deriv, roi_params, bounding_box_dict, metadata_choice, list_patients)
+            self.process_subject(bids_df, subject, df_subjects, c, tot, contrast_balance, target_suffix, all_deriv,
+                                roi_params, bounding_box_dict, metadata_choice, list_patients)
 
         self.slice_axis = slice_axis
         self.slice_filter_fn = slice_filter_fn
@@ -271,8 +272,8 @@ class BIDStoHDF5:
         self._load_filenames()
         print("Files loaded.")
 
-    def process_subject(self, bids_df, subject, df_subjects, c, tot, contrast_balance, target_suffix, 
-                        all_deriv, roi_params, bounding_box_dict, metadata_choice, list_patients):
+    def process_subject(self, bids_df, subject, df_subjects, c, tot, contrast_balance, target_suffix, all_deriv,
+                        roi_params, bounding_box_dict, metadata_choice, list_patients):
         df_sub = df_subjects.loc[df_subjects['filename'] == subject]
 
         # Training & Validation: do not consider the contrasts over the threshold contained in contrast_balance
@@ -293,7 +294,7 @@ class BIDStoHDF5:
                 metadata['bounding_box'] = bounding_box_dict[str(df_sub['path'].values[0])][0]
 
             are_mri_params = all([imed_film.check_isMRIparam(m, metadata, subject, self.metadata) for m in self.metadata.keys()])
-            if metadata_choice == 'mri_params'and not are_mri_params:
+            if metadata_choice == 'mri_params' and not are_mri_params:
                 return
 
             # Get subj_id (prefix filename without modality suffix and extension)


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
As described in #694, the `__init__` function of the BIDStoHDF5 class has a high cognitive complexity making the code difficult to maintain and understand. The PR addresses these issues by abstracting creation of metadata in the `__init__` function.

## Linked issues
Closes #694
