### PR TITLE
Addressing Windows Path issue causing unit test_automated_training.py unit tests to fail

### DIFF
--- a/ivadomed/testing.py
+++ b/ivadomed/testing.py
@@ -1,6 +1,7 @@
 import os
 import copy
 import logging
+from pathlib import Path
 import nibabel as nib
 import numpy as np
 import torch
@@ -196,7 +197,7 @@ def run_inference(test_loader, model, model_params, testing_params, ofolder, cud
                 if pred_tmp_lst and (fname_ref != fname_tmp or last_sample_bool) and task != "classification":
                     # save the completely processed file as a nifti file
                     if ofolder:
-                        fname_pred = os.path.join(ofolder, fname_tmp.split('/')[-1])
+                        fname_pred = os.path.join(ofolder, Path(fname_tmp).name)
                         fname_pred = fname_pred.rsplit("_", 1)[0] + '_pred.nii.gz'
                         # If Uncertainty running, then we save each simulation result
                         if testing_params['uncertainty']['applied']:


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [X] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [X] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [X] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

TLDR: fixed Windows pathing related bug that causes prediction files not to be generated at the correct location (stuck in the old tmp location)

Identified the root cause of #604 for unit test output issues which prevented adding Windows CI to GitHub Action (that is coming soon). 
- Applied Pathlib approach to avoid manual str parsing. 
- This will no longer result in malformed file path on Windows
- _**Prior to this fix, no Windows users can generate test prediction in the proper location**_ (it will be left at the old source input folder... surprising we have not heard a single complaint from end users about this yet. 

## How to test this PR:
- Be on windows. 
- Pull down this PR branch and ensure all other Python ENV is setup. 
- Making SURE to `pip uninstall ivadomed` and then reinstall it via ` pip install -e .`
- Ensuring the test files have been downloaded
- Run pytest from repo root folder. 


## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Partially resolve #604 by unlocking GitHub Actions to be setup against Windows Environment as well going forward for all PRs and future automated CIs, first step towards ~world domination~ Windows 10 cross compatibility

