### PR TITLE
Hot patch a misconfigured Pytest Param that could fail local running of test_load_dataset_2d_png in venv

### DIFF
--- a/testing/unit_tests/test_loader.py
+++ b/testing/unit_tests/test_loader.py
@@ -136,7 +136,7 @@ def test_dropout_input(seg_pair):
 
 @pytest.mark.parametrize('loader_parameters', [{
     "path_data": [os.path.join(__data_testing_dir__, "microscopy_png")],
-    "bids_config": "ivadomed/config/config_bids.json",
+    "bids_config": f"{path_repo_root}/ivadomed/config/config_bids.json",
     "target_suffix": ["_seg-myelin-manual"],
     "extensions": [".png"],
     "roi_params": {"suffix": None, "slice_filter_roi": None},


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [X] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [X] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [X] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [X] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
For some very odd reason we are still not sure, despite the fact that [this line ](https://github.com/ivadomed/ivadomed/blob/master/testing/unit_tests/test_loader.py#L139) was not properly updated in an earlier PR on the absolute path to unit tests overhaul #744, the unit test was PASSING in CI/Ubuntu. Bizarre. 

During recent debugging with @konantian and on #768, this line caused Unit Test FAILURE and we reproduced this problem using VENV in both Mac and PC. 

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
None. No issues opened specifically for this. Minor bug but affecting VENV users mostly? 
