### PR TITLE
Update test_segment_volume_2d to use ROI

### DIFF
--- a/testing/functional_tests/test_segment_volume.py
+++ b/testing/functional_tests/test_segment_volume.py
@@ -44,7 +44,7 @@ def test_segment_volume_2d(download_functional_test_files):
                 "filter_empty_input": False
             },
             "roi_params": {
-                "suffix": None,
+                "suffix": "_seg-manual",
                 "slice_filter_roi": 10
             },
             "slice_axis": "axial"
@@ -70,7 +70,7 @@ def test_segment_volume_2d(download_functional_test_files):
     with open(PATH_CONFIG, 'w') as fp:
         json.dump(config, fp)
 
-    nib_lst, _ = imed_inference.segment_volume(PATH_MODEL, [IMAGE_PATH], ROI_PATH)
+    nib_lst, _ = imed_inference.segment_volume(PATH_MODEL, [IMAGE_PATH], options={'fname_prior': ROI_PATH})
     nib_img = nib_lst[0]
     assert np.squeeze(nib_img.get_fdata()).shape == nib.load(IMAGE_PATH).shape
     assert (nib_img.dataobj.max() <= 1.0) and (nib_img.dataobj.min() >= 0.0)


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR updates `test_segment_volume_2d` to use the `ROI_PATH` and `ROICrop` specified in the parameters as it was first intended. The ROI file was previously ignored and all the volume was segmented. The ROI is now taken into account.

The test would also previously fail on GPU because the ROI_PATH was assigned to `gpu_id`. The test now pass on both CPU and GPU, and uses the GPU 0 as intended.

## Linked issues
Fixes #802 
