### PR TITLE
Fix bug in loader for multiple raters

### DIFF
--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -735,9 +735,9 @@ class MRI2DSegmentationDataset(Dataset):
                 seg_pair_slice['gt'][idx_class] = seg_pair_slice['gt'][idx_class][idx_rater]
                 seg_pair_slice['gt_metadata'][idx_class] = seg_pair_slice['gt_metadata'][idx_class][idx_rater]
 
-        metadata_input = seg_pair_slice['input_metadata']
-        metadata_roi = roi_pair_slice['gt_metadata']
-        metadata_gt = seg_pair_slice['gt_metadata']
+        metadata_input = seg_pair_slice['input_metadata'] if seg_pair_slice['input_metadata'] is not None else []
+        metadata_roi = roi_pair_slice['gt_metadata'] if roi_pair_slice['gt_metadata'] is not None else []
+        metadata_gt = seg_pair_slice['gt_metadata'] if seg_pair_slice['gt_metadata'] is not None else []
 
         # Run transforms on ROI
         # ROI goes first because params of ROICrop are needed for the followings
@@ -941,8 +941,8 @@ class MRI3DSubVolumeSegmentationDataset(Dataset):
                 seg_pair['gt'][idx_class] = seg_pair['gt'][idx_class][idx_rater]
                 seg_pair['gt_metadata'][idx_class] = seg_pair['gt_metadata'][idx_class][idx_rater]
 
-        metadata_input = seg_pair['input_metadata']
-        metadata_gt = seg_pair['gt_metadata']
+        metadata_input = seg_pair['input_metadata'] if seg_pair['input_metadata'] is not None else []
+        metadata_gt = seg_pair['gt_metadata'] if seg_pair['gt_metadata'] is not None else []
 
         # Run transforms on images
         stack_input, metadata_input = self.transform(sample=seg_pair['input'],

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -923,6 +923,10 @@ class MRI3DSubVolumeSegmentationDataset(Dataset):
         Args:
             index (int): Subvolume index.
         """
+
+        # copy.deepcopy is used to have different coordinates for reconstruction for a given handler,
+        # to allow a different rater at each iteration of training, and to clean transforms params from previous
+        # transforms i.e. remove params from previous iterations so that the coming transforms are different
         coord = self.indexes[index]
         seg_pair, _ = copy.deepcopy(self.handlers[coord['handler_index']])
 
@@ -936,11 +940,8 @@ class MRI3DSubVolumeSegmentationDataset(Dataset):
                 seg_pair['gt'][idx_class] = seg_pair['gt'][idx_class][idx_rater]
                 seg_pair['gt_metadata'][idx_class] = seg_pair['gt_metadata'][idx_class][idx_rater]
 
-        # Clean transforms params from previous transforms
-        # i.e. remove params from previous iterations so that the coming transforms are different
-        # Use copy to have different coordinates for reconstruction for a given handler
-        metadata_input = imed_loader_utils.clean_metadata(seg_pair['input_metadata'])
-        metadata_gt = imed_loader_utils.clean_metadata(seg_pair['gt_metadata'])
+        metadata_input = seg_pair['input_metadata']
+        metadata_gt = seg_pair['gt_metadata']
 
         # Run transforms on images
         stack_input, metadata_input = self.transform(sample=seg_pair['input'],

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -719,9 +719,9 @@ class MRI2DSegmentationDataset(Dataset):
 
         if self.is_2d_patch:
             coord = self.indexes[index]
-            seg_pair_slice, roi_pair_slice = self.handlers[coord['handler_index']]
+            seg_pair_slice, roi_pair_slice = copy.deepcopy(self.handlers[coord['handler_index']])
         else:
-            seg_pair_slice, roi_pair_slice = self.indexes[index]
+            seg_pair_slice, roi_pair_slice = copy.deepcopy(self.indexes[index])
 
         # In case multiple raters
         if seg_pair_slice['gt'] is not None and isinstance(seg_pair_slice['gt'][0], list):
@@ -736,9 +736,9 @@ class MRI2DSegmentationDataset(Dataset):
         # Clean transforms params from previous transforms
         # i.e. remove params from previous iterations so that the coming transforms are different
         # Use copy to have different coordinates for reconstruction for a given handler with patch
-        metadata_input = imed_loader_utils.clean_metadata(copy.deepcopy(seg_pair_slice['input_metadata']))
-        metadata_roi = imed_loader_utils.clean_metadata(copy.deepcopy(roi_pair_slice['gt_metadata']))
-        metadata_gt = imed_loader_utils.clean_metadata(copy.deepcopy(seg_pair_slice['gt_metadata']))
+        metadata_input = imed_loader_utils.clean_metadata(seg_pair_slice['input_metadata'])
+        metadata_roi = imed_loader_utils.clean_metadata(roi_pair_slice['gt_metadata'])
+        metadata_gt = imed_loader_utils.clean_metadata(seg_pair_slice['gt_metadata'])
 
         # Run transforms on ROI
         # ROI goes first because params of ROICrop are needed for the followings
@@ -926,7 +926,7 @@ class MRI3DSubVolumeSegmentationDataset(Dataset):
             index (int): Subvolume index.
         """
         coord = self.indexes[index]
-        seg_pair, _ = self.handlers[coord['handler_index']]
+        seg_pair, _ = copy.deepcopy(self.handlers[coord['handler_index']])
 
         # In case multiple raters
         if seg_pair['gt'] is not None and isinstance(seg_pair['gt'][0], list):
@@ -941,8 +941,8 @@ class MRI3DSubVolumeSegmentationDataset(Dataset):
         # Clean transforms params from previous transforms
         # i.e. remove params from previous iterations so that the coming transforms are different
         # Use copy to have different coordinates for reconstruction for a given handler
-        metadata_input = imed_loader_utils.clean_metadata(copy.deepcopy(seg_pair['input_metadata']))
-        metadata_gt = imed_loader_utils.clean_metadata(copy.deepcopy(seg_pair['gt_metadata']))
+        metadata_input = imed_loader_utils.clean_metadata(seg_pair['input_metadata'])
+        metadata_gt = imed_loader_utils.clean_metadata(seg_pair['gt_metadata'])
 
         # Run transforms on images
         stack_input, metadata_input = self.transform(sample=seg_pair['input'],

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -317,7 +317,7 @@ class SegmentationPair(object):
                     hwd_oriented_list = [
                         imed_loader_utils.orient_img_hwd(self.get_data(gt_rater, cache_mode),
                                                          self.slice_axis) for gt_rater in gt]
-                    gt_data.append([hwd_oriented.astype(data_type) for hwd_oriented in hwd_oriented_list])
+                    gt_data.append([hwd_oriented for hwd_oriented in hwd_oriented_list])
             else:
                 gt_data.append(
                     np.zeros(imed_loader_utils.orient_shapes_hwd(self.input_handle[0].shape, self.slice_axis),

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -715,6 +715,9 @@ class MRI2DSegmentationDataset(Dataset):
             index (int): Slice index.
         """
 
+        # copy.deepcopy is used to have different coordinates for reconstruction for a given handler with patch,
+        # to allow a different rater at each iteration of training, and to clean transforms params from previous
+        # transforms i.e. remove params from previous iterations so that the coming transforms are different
         if self.is_2d_patch:
             coord = self.indexes[index]
             seg_pair_slice, roi_pair_slice = copy.deepcopy(self.handlers[coord['handler_index']])
@@ -731,12 +734,9 @@ class MRI2DSegmentationDataset(Dataset):
                 seg_pair_slice['gt'][idx_class] = seg_pair_slice['gt'][idx_class][idx_rater]
                 seg_pair_slice['gt_metadata'][idx_class] = seg_pair_slice['gt_metadata'][idx_class][idx_rater]
 
-        # Clean transforms params from previous transforms
-        # i.e. remove params from previous iterations so that the coming transforms are different
-        # Use copy to have different coordinates for reconstruction for a given handler with patch
-        metadata_input = imed_loader_utils.clean_metadata(seg_pair_slice['input_metadata'])
-        metadata_roi = imed_loader_utils.clean_metadata(roi_pair_slice['gt_metadata'])
-        metadata_gt = imed_loader_utils.clean_metadata(seg_pair_slice['gt_metadata'])
+        metadata_input = seg_pair_slice['input_metadata']
+        metadata_roi = roi_pair_slice['gt_metadata']
+        metadata_gt = seg_pair_slice['gt_metadata']
 
         # Run transforms on ROI
         # ROI goes first because params of ROICrop are needed for the followings

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -752,7 +752,7 @@ class MRI2DSegmentationDataset(Dataset):
                                                      metadata=metadata_input,
                                                      data_type="im")
 
-        # Update metadata_input with metadata_roi
+        # Update metadata_gt with metadata_input
         metadata_gt = imed_loader_utils.update_metadata(metadata_input, metadata_gt)
 
         if self.task == "segmentation":

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -435,28 +435,6 @@ class BalancedSampler(torch.utils.data.sampler.Sampler):
         return self.num_samples
 
 
-def clean_metadata(metadata_lst):
-    """Remove keys from metadata. The keys to be deleted are stored in a list.
-
-    Args:
-        metadata_lst (list): List of SampleMetadata.
-
-    Returns:
-        list: List of SampleMetadata with removed keys.
-    """
-    metadata_out = []
-
-    if metadata_lst is not None:
-        TRANSFORM_PARAMS.remove('crop_params')
-        for metadata_cur in metadata_lst:
-            for key_ in list(metadata_cur.keys()):
-                if key_ in TRANSFORM_PARAMS:
-                    del metadata_cur.metadata[key_]
-            metadata_out.append(metadata_cur)
-        TRANSFORM_PARAMS.append('crop_params')
-    return metadata_out
-
-
 def update_metadata(metadata_src_lst, metadata_dest_lst):
     """Update metadata keys with a reference metadata.
 

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -364,7 +364,7 @@ def run_command(context, n_gif=0, thr_increment=None, resume_training=False):
         imed_utils.display_selected_transfoms(transformation_dict, dataset_type=["testing"])
 
     # Check if multiple raters
-    check_multiple_raters(command != "train", loader_params)
+    check_multiple_raters(command == "train", loader_params)
 
     if command == 'train':
         # Get Validation dataset

--- a/testing/unit_tests/test_loader.py
+++ b/testing/unit_tests/test_loader.py
@@ -210,7 +210,6 @@ def test_2d_patches(download_data_testing_test_files,
                                   **{**loader_parameters, **{'data_list': data_lst,
                                                              'transforms_params': transform_parameters,
                                                              'dataset_type': 'training'}})
-
     assert ds.is_2d_patch == True
     assert ds[0]['input'].shape == (1, 256, 256)
     assert len(ds) == 16
@@ -244,13 +243,50 @@ def test_get_target_filename_list(loader_parameters, model_parameters, transform
     bids_df = imed_loader_utils.BidsDataframe(loader_parameters, __tmp_dir__, derivatives=True)
     data_lst = ['sub-rat3_ses-01_sample-data9_SEM.png']
     test_ds = imed_loader.load_dataset(bids_df,
-                                  **{**loader_parameters, **{'data_list': data_lst,
-                                                             'transforms_params': transform_parameters,
-                                                             'dataset_type': 'training'}})
-
+                                       **{**loader_parameters, **{'data_list': data_lst,
+                                                                  'transforms_params': transform_parameters,
+                                                                  'dataset_type': 'training'}})
     target_filename = test_ds.filename_pairs[0][1]
     
     assert len(target_filename) == len(loader_parameters["target_suffix"])
+
+
+@pytest.mark.parametrize('loader_parameters', [{
+    "path_data": [os.path.join(__data_testing_dir__, "microscopy_png")],
+    "bids_config": f"{path_repo_root}/ivadomed/config/config_bids.json",
+    "target_suffix": [["_seg-myelin-manual", "_seg-axon-manual"], ["_seg-myelin-manual", "_seg-axon-manual"]],
+    "extensions": [".png"],
+    "roi_params": {"suffix": None, "slice_filter_roi": None},
+    "contrast_params": {"contrast_lst": [], "balance": {}},
+    "slice_axis": "axial",
+    "slice_filter_params": {"filter_empty_mask": False, "filter_empty_input": True},
+    "multichannel": False
+    }])
+@pytest.mark.parametrize('model_parameters', [{
+    "name": "Unet",
+    "dropout_rate": 0.3,
+    "bn_momentum": 0.1,
+    "depth": 2
+    }])
+@pytest.mark.parametrize('transform_parameters', [{
+    "NumpyToTensor": {},
+    }])
+def test_get_target_filename_list_multiple_raters(loader_parameters, model_parameters, transform_parameters):
+    """
+    Test that all target_suffix are considered for target filename when list
+    """
+    loader_parameters.update({"model_params": model_parameters})
+    bids_df = imed_loader_utils.BidsDataframe(loader_parameters, __tmp_dir__, derivatives=True)
+    data_lst = ['sub-rat3_ses-01_sample-data9_SEM.png']
+    test_ds = imed_loader.load_dataset(bids_df,
+                                       **{**loader_parameters, **{'data_list': data_lst,
+                                                                  'transforms_params': transform_parameters,
+                                                                  'dataset_type': 'training'}})
+    target_filename = test_ds.filename_pairs[0][1]
+
+    assert len(target_filename) == len(loader_parameters["target_suffix"])
+    assert len(target_filename[0]) == len(loader_parameters["target_suffix"][0])
+    assert len(target_filename[1]) == len(loader_parameters["target_suffix"][1])
 
 
 def teardown_function():


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR fixes a bug when providing multiple raters annotations for training. For some reason, the flag `is_train` passed to the command `check_multiple_raters` was wrong in `main.py`. This was resulting in a error when providing `target_suffix` as a list of list with the command `train` instead of an error with the command `test`.

In addition, in `loader.py`, the GT was cast as type `data_type` for multiple raters but `data_type` was not defined. I removed it since the casting to `data_type = np.float32 if self.soft_gt else np.uint8` was removed in an earlier PR (#624) for preserving soft GT.

The error was first spotted while writing a test for PR #765. Now that the behavior is fixed, I also added a test to make sure the `get_target_filename` returns `target_filename` with the same dimensions as `target_suffix`.

## Linked issues
Fixes #789 
