### PR TITLE
New loader: Load PNG/TIF/JPG microscopy files as Nibabel objects

### DIFF
--- a/docs/source/configuration_file.rst
+++ b/docs/source/configuration_file.rst
@@ -287,7 +287,7 @@ will be randomly chosen.
         "$schema": "http://json-schema.org/draft-04/schema#",
         "title": "extensions",
         "description": "Used to specify a list of file extensions to be selected for
-            training/testing.",
+            training/testing. Extensions are required when different from `.nii` or `.nii.gz`",
         "type": "list, string"
     }
 
@@ -297,7 +297,7 @@ will be randomly chosen.
 
     {
         "loader_parameters": {
-            "extensions": [".nii.gz"]
+            "extensions": [".png"]
         }
     }
 

--- a/docs/source/configuration_file.rst
+++ b/docs/source/configuration_file.rst
@@ -287,7 +287,7 @@ will be randomly chosen.
         "$schema": "http://json-schema.org/draft-04/schema#",
         "title": "extensions",
         "description": "Used to specify a list of file extensions to be selected for
-            training/testing. Extensions are required when different from `.nii` or `.nii.gz`",
+            training/testing. If not specified, then `.nii` and `.nii.gz` will be used by default.",
         "type": "list, string"
     }
 

--- a/ivadomed/config/config_new_loader.json
+++ b/ivadomed/config/config_new_loader.json
@@ -9,18 +9,18 @@
         "safety_factor": [1.0, 1.0, 1.0]
     },
     "loader_parameters": {
-        "path_data": ["data_example_spinegeneric"],
+        "path_data": ["data_example_microscopy_sem"],
         "bids_config": "ivadomed/config/config_bids.json",
         "subject_selection": {"n": [], "metadata": [], "value": []},
-        "target_suffix": ["_seg-manual"],
-        "extensions": [],
+        "target_suffix": ["_seg-axon-manual", "_seg-myelin-manual"],
+        "extensions": [".png"],
         "roi_params": {
             "suffix": null,
             "slice_filter_roi": null
         },
         "contrast_params": {
-            "training_validation": ["T2w"],
-            "testing": ["T2w"],
+            "training_validation": ["SEM"],
+            "testing": ["SEM"],
             "balance": {}
         },
         "slice_filter_params": {
@@ -34,11 +34,11 @@
     "split_dataset": {
         "fname_split": null,
         "random_seed": 6,
-        "split_method" : "participant_id",
+        "split_method" : "sample_id",
         "data_testing": {"data_type": null, "data_value":[]},
         "balance": null,
-        "train_fraction": 0.1,
-        "test_fraction": 0.8
+        "train_fraction": 0.2,
+        "test_fraction": 0.2
     },
     "training_parameters": {
         "batch_size": 18,
@@ -46,7 +46,7 @@
             "name": "DiceLoss"
         },
         "training_time": {
-            "num_epochs": 1,
+            "num_epochs": 5,
             "early_stopping_patience": 50,
             "early_stopping_epsilon": 0.001
         },
@@ -75,8 +75,8 @@
         "bn_momentum": 0.1,
         "final_activation": "sigmoid",
         "depth": 3,
-        "length_2D": [50, 50],
-        "stride_2D": [45, 45]
+        "length_2D": [],
+        "stride_2D": []
     },
     "FiLMedUnet": {
         "applied": false,
@@ -85,7 +85,8 @@
     },
     "transformation": {
       "CenterCrop": {
-            "size": [128, 128]},
+            "size": [256, 256]
+      },
       "NumpyToTensor": {},
       "NormalizeInstance": {"applied_to": ["im"]}
     }

--- a/ivadomed/evaluation.py
+++ b/ivadomed/evaluation.py
@@ -9,6 +9,7 @@ from tqdm import tqdm
 
 from ivadomed import metrics as imed_metrics
 from ivadomed import postprocessing as imed_postpro
+from ivadomed.loader import utils as imed_loader_utils
 
 # labels of paint_objects method
 TP_COLOUR = 1
@@ -51,6 +52,9 @@ def evaluate(bids_df, path_output, target_suffix, eval_params):
         fname_pred = os.path.join(path_preds, subj_acq + '_pred.nii.gz')
         fname_gt = bids_df.df[bids_df.df['filename']
                           .str.contains('|'.join(bids_df.get_derivatives(subj_acq, all_deriv)))]['path'].to_list()
+
+        # Check fname_gt extentions and update paths if not NifTI
+        fname_gt = [imed_loader_utils.update_filename_to_nifti(fname) for fname in fname_gt]
 
         # Uncertainty
         data_uncertainty = None

--- a/ivadomed/inference.py
+++ b/ivadomed/inference.py
@@ -136,6 +136,10 @@ def pred_to_nib(data_lst: List[np.ndarray], z_lst: List[int], fname_ref: str, fn
     Returns:
         nibabel.Nifti1Image: NiBabel object containing the Network prediction.
     """
+
+    # Check fname_ref extention and update path if not NifTI
+    fname_ref = imed_loader_utils.update_filename_to_nifti(fname_ref)
+
     # Load reference nibabel object
     nib_ref = nib.load(fname_ref)
     nib_ref_can = nib.as_closest_canonical(nib_ref)
@@ -192,7 +196,7 @@ def pred_to_nib(data_lst: List[np.ndarray], z_lst: List[int], fname_ref: str, fn
         affine=None,
         header=nib_ref.header.copy()
     )
-    # save as nifti file
+    # save as NifTI file
     if fname_out is not None:
         nib.save(nib_pred, fname_out)
 
@@ -341,6 +345,7 @@ def segment_volume(folder_model: str, fname_images: list, gpu_id: int = 0, optio
         logger.warning("fname_roi has not been specified, then the entire volume is processed.")
         loader_params["slice_filter_params"]["filter_empty_mask"] = False
 
+    # TODO: Add PixelSize from options to filename_pairs metadata for microscopy inference (issue #306)
     filename_pairs = [(fname_images, None, fname_roi, metadata if isinstance(metadata, list) else [metadata])]
 
     kernel_3D = bool('Modified3DUNet' in context and context['Modified3DUNet']['applied']) or \

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -493,7 +493,7 @@ class SegmentationPair(object):
                                    " 3D [X, Y, Z] array or float.")
             # Note: pixdim[1,2,3] must be non-zero in Nifti objects even if there is only one slice.
             # When ps_in_um[2] (pixdim[3]) is not present or 0, we assign the same PixelSize as ps_in_um[0] (pixdim[1])
-            ps_in_um.resize(3)
+            ps_in_um = np.resize(ps_in_um, 3)
             if ps_in_um[2] == 0:
                 ps_in_um[2] = ps_in_um[0]
             ps_in_mm = tuple(ps_in_um * conversion_factor)

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -250,16 +250,16 @@ class SegmentationPair(object):
                 raise RuntimeError('Input and ground truth with different dimensions.')
 
         for idx, handle in enumerate(self.input_handle):
-            self.input_handle[idx] = self.apply_canonical(handle)
+            self.input_handle[idx] = nib.as_closest_canonical(handle)
 
         # Labeled data (ie not inference time)
         if self.gt_filenames is not None:
             for idx, gt in enumerate(self.gt_handle):
                 if gt is not None:
                     if not isinstance(gt, list):  # this tissue has annotation from only one rater
-                        self.gt_handle[idx] = self.apply_canonical(gt)
+                        self.gt_handle[idx] = nib.as_closest_canonical(gt)
                     else:  # this tissue has annotation from several raters
-                        self.gt_handle[idx] = [self.apply_canonical(gt_rater) for gt_rater in gt]
+                        self.gt_handle[idx] = [nib.as_closest_canonical(gt_rater) for gt_rater in gt]
 
         # If binary classification, then extract labels from GT mask
 
@@ -461,24 +461,6 @@ class SegmentationPair(object):
             else:
                 return np.expand_dims(imageio.imread(filename, as_gray=True), axis=-1)
 
-
-    def apply_canonical(self, data):
-        """Apply nibabel as_closest_canonical function to nifti data only.
-        Args:
-            data ('nibabel.nifti1.Nifti1Image' object or 'ndarray'):
-                for nifti or png/tif/jpg file respectively.
-        """
-        if "nii" in self.extension:
-            # For '.nii' and '.nii.gz' extentions
-            # Returns 'nibabel.nifti1.Nifti1Image' object
-            return nib.as_closest_canonical(data)
-
-        # TODO: (#739)  implement OMETIFF behavior (elif "ome" in self.extension)
-
-        else:
-            # For '.png', '.tif', '.tiff', '.jpg' and 'jpeg' extentions
-            # Returns data as is in numpy array
-            return data
 
     def get_shape(self, data):
         """Returns data shape according to file type.

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -437,7 +437,9 @@ class SegmentationPair(object):
         extension = imed_loader_utils.get_file_extension(filename)
         # TODO: remove "ome" from condition when implementing OMETIFF support (#739)
         if (not extension) or ("ome" in extension):
-            raise RuntimeError("The input file type of '{}' is not supported".format(filename))
+            raise RuntimeError("The input file extension '{}' of '{}' is not supported. ivadomed supports the following "
+                               "file extensions: '.nii', '.nii.gz', '.png', '.tif', '.tiff', '.jpg' and '.jpeg'."
+                               .format(extension, os.path.basename(filename)))
 
         if "nii" in extension:
             # For '.nii' and '.nii.gz' extentions

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -427,8 +427,6 @@ class SegmentationPair(object):
 
     def read_file(self, filename):
         """Read file according to file extension and returns 'nibabel.nifti1.Nifti1Image' object.
-        If different from NifTI file, convert to 'nibabel.nifti1.Nifti1Image' object, set zooms in object
-        with PixelSize from metadata and write NifTI file.
 
         Args:
             filename (str): Subject filename.

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -483,8 +483,8 @@ class SegmentationPair(object):
             # Above, when ps_in_um[2] (pixdim[3]) is 0, we assign the same PixelSize as ps_in_um[0] (pixdim[1])
             img.header.set_zooms((ps_in_mm))
 
-            # if it doesn't already exist, save NifTI file in path_data alongside PNG file
-            fname_out = filename.split('.')[0] + ".nii.gz"
+            # if it doesn't already exist, save NifTI file in path_data alongside PNG/TIF/JPG file
+            fname_out = imed_loader_utils.update_filename_to_nifti(filename)
             if not os.path.exists(fname_out):
                 nib.save(img, fname_out)
 

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -438,6 +438,10 @@ class SegmentationPair(object):
         """
         extension = imed_loader_utils.get_file_extension(filename)
 
+        # TODO: remove "ome" from condition when implementing OMETIFF support (#739)
+        if (not extension) or ("ome" in extension):
+            raise RuntimeError("The input file type of '{}' is not supported".format(filename))
+
         if "nii" in extension:
             # For '.nii' and '.nii.gz' extentions
             return nib.load(filename)

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -274,7 +274,7 @@ class SegmentationPair(object):
         """Return the tuple (input, ground truth) representing both the input and ground truth shapes."""
         input_shape = []
         for handle in self.input_handle:
-            shape = imed_loader_utils.orient_shapes_hwd(self.get_shape(handle), self.slice_axis)
+            shape = imed_loader_utils.orient_shapes_hwd(handle.header.get_data_shape(), self.slice_axis)
             input_shape.append(tuple(shape))
 
             if not len(set(input_shape)):
@@ -287,7 +287,7 @@ class SegmentationPair(object):
                 if not isinstance(gt, list):  # this tissue has annotation from only one rater
                     gt = [gt]
                 for gt_rater in gt:
-                    shape = imed_loader_utils.orient_shapes_hwd(self.get_shape(gt_rater), self.slice_axis)
+                    shape = imed_loader_utils.orient_shapes_hwd(gt_rater.header.get_data_shape(), self.slice_axis)
                     gt_shape.append(tuple(shape))
 
                 if not len(set(gt_shape)):
@@ -341,7 +341,7 @@ class SegmentationPair(object):
                 if not isinstance(gt, list):  # this tissue has annotation from only one rater
                     gt_meta_dict.append(imed_loader_utils.SampleMetadata({
                         "zooms": imed_loader_utils.orient_shapes_hwd(gt.header.get_zooms(), self.slice_axis),
-                        "data_shape": imed_loader_utils.orient_shapes_hwd(self.get_shape(gt), self.slice_axis),
+                        "data_shape": imed_loader_utils.orient_shapes_hwd(gt.header.get_data_shape(), self.slice_axis),
                         "gt_filenames": self.metadata[0]["gt_filenames"],
                         "bounding_box": self.metadata[0]["bounding_box"] if 'bounding_box' in self.metadata[
                             0] else None,
@@ -351,7 +351,7 @@ class SegmentationPair(object):
                 else:
                     gt_meta_dict.append([imed_loader_utils.SampleMetadata({
                         "zooms": imed_loader_utils.orient_shapes_hwd(gt_rater.header.get_zooms(), self.slice_axis),
-                        "data_shape": imed_loader_utils.orient_shapes_hwd(self.get_shape(gt_rater), self.slice_axis),
+                        "data_shape": imed_loader_utils.orient_shapes_hwd(gt_rater.header.get_data_shape(), self.slice_axis),
                         "gt_filenames": self.metadata[0]["gt_filenames"][idx_class][idx_rater],
                         "bounding_box": self.metadata[0]["bounding_box"] if 'bounding_box' in self.metadata[
                             0] else None,
@@ -372,7 +372,7 @@ class SegmentationPair(object):
         for handle in self.input_handle:
             input_meta_dict.append(imed_loader_utils.SampleMetadata({
                 "zooms": imed_loader_utils.orient_shapes_hwd(handle.header.get_zooms(), self.slice_axis),
-                "data_shape": imed_loader_utils.orient_shapes_hwd(self.get_shape(handle), self.slice_axis),
+                "data_shape": imed_loader_utils.orient_shapes_hwd(handle.header.get_data_shape(), self.slice_axis),
                 "data_type": 'im',
                 "crop_params": {}
             }))
@@ -460,25 +460,6 @@ class SegmentationPair(object):
                 return np.expand_dims(imageio.imread(filename, format='tiff-pil', as_gray=True), axis=-1)
             else:
                 return np.expand_dims(imageio.imread(filename, as_gray=True), axis=-1)
-
-
-    def get_shape(self, data):
-        """Returns data shape according to file type.
-        Args:
-            data ('nibabel.nifti1.Nifti1Image' object or 'ndarray'):
-                for nifti or png/tif/jpg file respectively.
-        Returns:
-            ndarray: Data shape.
-        """
-        if "nii" in self.extension:
-            # For '.nii' and '.nii.gz' extentions
-            return data.header.get_data_shape()
-
-        # TODO: (#739) implement OMETIFF behavior (elif "ome" in self.extension)
-
-        else:
-            # For '.png', '.tif', '.tiff', '.jpg' and 'jpeg' extentions
-            return data.shape
 
     def get_data(self, data, cache_mode):
         """Get nifti file data.

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -301,7 +301,7 @@ class SegmentationPair(object):
 
         input_data = []
         for handle in self.input_handle:
-            hwd_oriented = imed_loader_utils.orient_img_hwd(self.get_data(handle, cache_mode), self.slice_axis)
+            hwd_oriented = imed_loader_utils.orient_img_hwd(handle.get_fdata(cache_mode, dtype=np.float32), self.slice_axis)
             input_data.append(hwd_oriented)
 
         gt_data = []
@@ -311,11 +311,11 @@ class SegmentationPair(object):
         for gt in self.gt_handle:
             if gt is not None:
                 if not isinstance(gt, list):  # this tissue has annotation from only one rater
-                    hwd_oriented = imed_loader_utils.orient_img_hwd(self.get_data(gt, cache_mode), self.slice_axis)
+                    hwd_oriented = imed_loader_utils.orient_img_hwd(gt.get_fdata(cache_mode, dtype=np.float32), self.slice_axis)
                     gt_data.append(hwd_oriented)
                 else:  # this tissue has annotation from several raters
                     hwd_oriented_list = [
-                        imed_loader_utils.orient_img_hwd(self.get_data(gt_rater, cache_mode),
+                        imed_loader_utils.orient_img_hwd(gt_rater.get_fdata(cache_mode, dtype=np.float32),
                                                          self.slice_axis) for gt_rater in gt]
                     gt_data.append([hwd_oriented.astype(data_type) for hwd_oriented in hwd_oriented_list])
             else:
@@ -460,27 +460,6 @@ class SegmentationPair(object):
                 return np.expand_dims(imageio.imread(filename, format='tiff-pil', as_gray=True), axis=-1)
             else:
                 return np.expand_dims(imageio.imread(filename, as_gray=True), axis=-1)
-
-    def get_data(self, data, cache_mode):
-        """Get nifti file data.
-        Args:
-            data ('nibabel.nifti1.Nifti1Image' object or 'ndarray'):
-                for nifti and png/tif/jpg file respectively.
-            cache_mode (str): cache mode for nifti files
-        Returns:
-            ndarray: File data.
-        """
-        if "nii" in self.extension:
-            # For '.nii' and '.nii.gz' extentions
-            # Load data from file as numpy array
-            return data.get_fdata(cache_mode, dtype=np.float32)
-
-        # TODO: (#739) implement OME-TIFF behavior (elif "ome" in self.extension)
-
-        else:
-            # For '.png', '.tif', '.tiff', '.jpg' and 'jpeg' extentions
-            # Returns data as is in numpy array
-            return data
 
 
 class MRI2DSegmentationDataset(Dataset):

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -593,7 +593,7 @@ class BidsDataframe:
             self.target_suffix.append(self.roi_suffix)
 
         # extensions from loader parameters
-        self.extensions = loader_params['extensions']
+        self.extensions = loader_params['extensions'] if loader_params['extensions'] else [".nii", ".nii.gz"]
 
         # contrast_lst from loader parameters
         self.contrast_lst = [] if 'contrast_lst' not in loader_params['contrast_params'] \

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -648,7 +648,7 @@ class BidsDataframe:
             # Force index of subject subfolders containing CT-scan files under "anat" or "ct" folder based on extensions and modality suffix.
             # TODO: remove force indexing of microscopy files after BEP microscopy is merged in BIDS
             # TODO: remove force indexing of CT-scan files after BEP CT-scan is merged in BIDS
-            ext_microscopy = ('.png', '.ome.tif', '.ome.tiff', '.ome.tf2', '.ome.tf8', '.ome.btf')
+            ext_microscopy = ('.png', '.tif', '.tiff', '.ome.tif', '.ome.tiff', '.ome.tf2', '.ome.tf8', '.ome.btf')
             ext_ct = ('.nii.gz', '.nii')
             suffix_ct = ('ct', 'CT')
             force_index = []

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -856,11 +856,6 @@ def get_file_extension(filename):
     """
     # Find the first match from the list of supported file extensions
     extension = next((ext for ext in EXT_LST if filename.lower().endswith(ext)), None)
-
-    # TODO: remove "ome" from condition when implementing OMETIFF support (#739)
-    if (not extension) or ("ome" in extension):
-        raise RuntimeError("The input file type of '{}' is not supported".format(filename))
-
     return extension
 
 

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -884,3 +884,18 @@ def get_file_extension(filename):
         raise RuntimeError("The input file type of '{}' is not supported".format(filename))
 
     return extension
+
+
+def update_filename_to_nifti(filename):
+    """ Update filename extension to 'nii.gz' if not NifTI file.
+
+    Args:
+        filename (str): Path of original file.
+
+    Returns:
+        str: Path of the corresponding NifTI file.
+    """
+    extension = get_file_extension(filename)
+    if not "nii" in extension:
+        filename.replace(extension, ".nii.gz")
+    return filename

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -897,5 +897,5 @@ def update_filename_to_nifti(filename):
     """
     extension = get_file_extension(filename)
     if not "nii" in extension:
-        filename.replace(extension, ".nii.gz")
+        filename = filename.replace(extension, ".nii.gz")
     return filename

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -668,9 +668,8 @@ class BidsDataframe:
                                | (df_next['path'].str.contains('derivatives')
                                & df_next['filename'].str.contains('|'.join(self.target_suffix)))]
 
-            # Update dataframe with files of chosen extensions if present
-            if self.extensions:
-                df_next = df_next[df_next['filename'].str.endswith(tuple(self.extensions))]
+            # Update dataframe with files of chosen extensions
+            df_next = df_next[df_next['filename'].str.endswith(tuple(self.extensions))]
 
             # Warning if no subject files are found in path_data
             if df_next[~df_next['path'].str.contains('derivatives')].empty:

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -859,7 +859,13 @@ def get_file_extension(filename):
 
 
 def update_filename_to_nifti(filename):
-    """ Update filename extension to 'nii.gz' if not NifTI file.
+    """ 
+    Update filename extension to 'nii.gz' if not a NifTI file.
+    
+    This function is used to help make non-NifTI files (e.g. PNG/TIF/JPG)
+    compatible with NifTI-only pipelines. The expectation is that a NifTI
+    version of the file has been created alongside the original file, which
+    allows the extension to be cleanly swapped for a `.nii.gz` extension.
 
     Args:
         filename (str): Path of original file.

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -29,6 +29,13 @@ __numpy_type_map = {
 TRANSFORM_PARAMS = ['elastic', 'rotation', 'scale', 'offset', 'crop_params', 'reverse',
                     'translation', 'gaussian_noise']
 
+# Ordered list of supported file extensions
+# TODO: Implement support of the following OMETIFF formats (#739):
+# [".ome.tif", ".ome.tiff", ".ome.tf2", ".ome.tf8", ".ome.btf"]
+# They are included in the list to avoid a ".ome.tif" or ".ome.tiff" following the ".tif" or ".tiff" pipeline
+EXT_LST = [".nii", ".nii.gz", ".ome.tif", ".ome.tiff", ".ome.tf2", ".ome.tf8", ".ome.btf", ".tif",
+           ".tiff", ".png", ".jpg", ".jpeg"]
+
 
 def split_dataset(df, split_method, data_testing, random_seed, train_frac=0.8, test_frac=0.1):
     """Splits dataset into training, validation and testing sets by applying train, test and validation fractions
@@ -859,3 +866,21 @@ class BidsDataframe:
             f = open(deriv_desc_file, 'w')
             f.write('{"Name": "Example dataset", "BIDSVersion": "1.0.2", "PipelineDescription": {"Name": "Example pipeline"}}')
             f.close()
+
+
+def get_file_extension(filename):
+    """ Get file extension if it is supported
+    Args:
+        filename (str): Path of the file.
+
+    Returns:
+        str: File extension
+    """
+    # Find the first match from the list of supported file extensions
+    extension = next((ext for ext in EXT_LST if filename.lower().endswith(ext)), None)
+
+    # TODO: remove "ome" from condition when implementing OMETIFF support (#739)
+    if (not extension) or ("ome" in extension):
+        raise RuntimeError("The input file type of '{}' is not supported".format(filename))
+
+    return extension

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -676,18 +676,20 @@ class BidsDataframe:
             # Drop rows with json, tsv and LICENSE files in case no extensions are provided in config file for filtering
             df_next = df_next[~df_next['filename'].str.endswith(tuple(['.json', '.tsv', 'LICENSE']))]
 
-            # Update dataframe with subject files of chosen contrasts and extensions,
-            # and with derivative files of chosen target_suffix from loader parameters
+            # Update dataframe with subject files of chosen contrasts
+            # and with derivative files of chosen target_suffix
             df_next = df_next[(~df_next['path'].str.contains('derivatives')
-                               & df_next['suffix'].str.contains('|'.join(self.contrast_lst))
-                               & df_next['extension'].str.contains('|'.join(self.extensions)))
+                               & df_next['suffix'].str.contains('|'.join(self.contrast_lst)))
                                | (df_next['path'].str.contains('derivatives')
                                & df_next['filename'].str.contains('|'.join(self.target_suffix)))]
 
-            if df_next[~df_next['path'].str.contains('derivatives')].empty:
-                # Warning if no subject files are found in path_data
-                logger.warning("No subject files were found in '{}' dataset. Skipping dataset.".format(path_data))
+            # Update dataframe with files of chosen extensions if present
+            if self.extensions:
+                df_next = df_next[df_next['filename'].str.endswith(tuple(self.extensions))]
 
+            # Warning if no subject files are found in path_data
+            if df_next[~df_next['path'].str.contains('derivatives')].empty:
+                logger.warning("No subject files were found in '{}' dataset. Skipping dataset.".format(path_data))
             else:
                 # Add tsv files metadata to dataframe
                 df_next = self.add_tsv_metadata(df_next, path_data, layout)

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -265,6 +265,7 @@ def run_segment_command(context, model_params):
             metadata = bids_df.df[bids_df.df['filename'] == subject][model_params['metadata']].values[0]
             options = {'metadata': metadata}
 
+        # TODO: Add PixelSize to options for microscopy inference (issue #306)
         if fname_img:
             pred_list, target_list = imed_inference.segment_volume(path_model,
                                                                    fname_images=fname_img,

--- a/ivadomed/testing.py
+++ b/ivadomed/testing.py
@@ -212,7 +212,7 @@ def run_inference(test_loader, model, model_params, testing_params, ofolder, cud
 
                 # NEW COMPLETE VOLUME
                 if pred_tmp_lst and (fname_ref != fname_tmp or last_sample_bool) and task != "classification":
-                    # save the completely processed file as a nifti file
+                    # save the completely processed file as a NifTI file
                     if ofolder:
                         fname_pred = os.path.join(ofolder, Path(fname_tmp).name)
                         fname_pred = fname_pred.rsplit("_", 1)[0] + '_pred.nii.gz'
@@ -410,6 +410,9 @@ def get_gt(filenames):
     Returns:
         ndarray: 4D numpy array.
     """
+    # Check filenames extentions and update paths if not NifTI
+    filenames = [imed_loader_utils.update_filename_to_nifti(fname) for fname in filenames]
+
     gt_lst = []
     for gt in filenames:
         # For multi-label, if all labels are not in every image

--- a/testing/unit_tests/test_loader.py
+++ b/testing/unit_tests/test_loader.py
@@ -158,7 +158,7 @@ def test_dropout_input(seg_pair):
 def test_load_dataset_2d_png(download_data_testing_test_files,
                              loader_parameters, model_parameters, transform_parameters):
     """
-    Test to make sure load_dataset runs with 2D PNG data.
+    Test to make sure load_dataset runs with 2D PNG file and write corresponding NifTI file.
     """
     loader_parameters.update({"model_params": model_parameters})
     bids_df = imed_loader_utils.BidsDataframe(loader_parameters, __tmp_dir__, derivatives=True)
@@ -167,6 +167,9 @@ def test_load_dataset_2d_png(download_data_testing_test_files,
                                   **{**loader_parameters, **{'data_list': data_lst,
                                                              'transforms_params': transform_parameters,
                                                              'dataset_type': 'training'}})
+    fname_png = bids_df.df[bids_df.df['filename'] == data_lst[0]]['path'].values[0]
+    fname_nii = imed_loader_utils.update_filename_to_nifti(fname_png)
+    assert os.path.exists(fname_nii) == 1
     assert ds[0]['input'].shape == (1, 756, 764)
     assert ds[0]['gt'].shape == (1, 756, 764)
 


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR aims to load PNG microscopy files for training and load PNG/TIF/JPG files as Nibabel objects for inference.
Earlier in PR #734, those files were load as numpy arrays. However, we decided to change the loader for Nibabel objects to facilitate the integration of microscopy in the inference pipeline (reference thread in issue #306).

## TODO:
- [x] Load png/tif/jpg as Nibabel objects
- [x] Set "zooms" aka "pixdim" in Nibabel object based on PixelSize metadata from json sidecar files
- [x] Check if Nibabel objects need to be saved as NifTI files for inference pipeline --> answer: yes
- [x] If yes, save the NifTI files in an appropriate data structure --> Nifti files are written directly in the bids dataset alongside PNGs.

## Linked issues
Fixes #812 
