### PR TITLE
Multichannel training for longitudinal studies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ log.txt
 # IvadoMed pytest downloaded data file, anywhere:
 data_testing/
 data_functional_testing/
+data_multi_sessions_contrasts_testing/
 
 # OS Specific hidden file
 .DS_Store

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -1111,14 +1111,28 @@ class BidsDataset(MRI2DSegmentationDataset):
         # Create multichannel_subjects dictionary for each subject_id
         multichannel_subjects = {}
         idx_dict = {}
+        sess_dict = {}
         if multichannel:
             num_contrast = len(contrast_params["contrast_lst"])
+            session_list = np.unique([d.split("_")[1] for d in df_subjects['filename'] if "ses-" in d])
+
             for idx, contrast in enumerate(contrast_params["contrast_lst"]):
                 idx_dict[contrast] = idx
-            multichannel_subjects = {subject: {"absolute_paths": [None] * num_contrast,
-                                               "deriv_path": None,
-                                               "roi_filename": None,
-                                               "metadata": [None] * num_contrast} for subject in subject_ids}
+            for idx, session in enumerate(session_list):
+                sess_dict[session] = idx
+            if session_list.size != 0:
+                multichannel_subjects = {subject: {"absolute_paths": [None] * num_contrast * len(session_list),
+                                                   "deriv_path": None,
+                                                   "roi_filename": None,
+                                                   "metadata": [None] * num_contrast * len(session_list)}
+                                         for subject in subject_ids}
+            else:
+                multichannel_subjects = {subject: {"absolute_paths": [None] * num_contrast,
+                                                   "deriv_path": None,
+                                                   "roi_filename": None,
+                                                   "metadata": [None] * num_contrast}
+                                         for subject in subject_ids}
+
 
         # Get all subjects path from bids_df for bounding box
         get_all_subj_path = bids_df.df[bids_df.df['filename']
@@ -1135,16 +1149,16 @@ class BidsDataset(MRI2DSegmentationDataset):
 
         # Create filename_pairs
         for subject in tqdm(subject_file_lst, desc="Loading dataset"):
-            df_sub, roi_filename, target_filename, metadata = self.create_filename_pair(multichannel_subjects, subject, 
-                                                                                        c, tot, multichannel, df_subjects, 
+            df_sub, roi_filename, target_filename, metadata = self.create_filename_pair(multichannel_subjects, subject,
+                                                                                        c, tot, multichannel, df_subjects,
                                                                                         contrast_params, target_suffix, 
                                                                                         all_deriv, bids_df, bounding_box_dict, 
                                                                                         idx_dict, metadata_choice)
             # Fill multichannel dictionary
             # subj_id is the filename without modality suffix and extension
             if multichannel:
-                multichannel_subjects = self.fill_multichannel_dict(multichannel_subjects, subject, idx_dict, df_sub, 
-                                                                    roi_filename, target_filename, metadata)
+                multichannel_subjects = self.fill_multichannel_dict(multichannel_subjects, subject, idx_dict, sess_dict,
+                                                                    df_sub, roi_filename, target_filename, metadata)
             else:
                 self.filename_pairs.append(([df_sub['path'].values[0]],
                                             target_filename, roi_filename, [metadata]))
@@ -1190,8 +1204,17 @@ class BidsDataset(MRI2DSegmentationDataset):
             metadata_dict[data] = idx
         metadata['metadata_dict'] = metadata_dict
 
-    def fill_multichannel_dict(self, multichannel_subjects, subject, idx_dict, df_sub, roi_filename, target_filename, metadata):
-        idx = idx_dict[df_sub['suffix'].values[0]]
+    def fill_multichannel_dict(self, multichannel_subjects, subject, idx_dict, sess_dict, df_sub,
+                               roi_filename, target_filename, metadata):
+
+        if "ses-" not in subject:
+            idx = idx_dict[df_sub['suffix'].values[0]]
+            file_session = []
+        else:
+            file_session = subject.split("_")[1]
+            idx = (len(sess_dict)-1)*sess_dict[file_session] + idx_dict[df_sub['suffix'].values[0]]
+
+
         subj_id = subject.split('.')[0].split('_')[0]
         multichannel_subjects[subj_id]["absolute_paths"][idx] = df_sub['path'].values[0]
         multichannel_subjects[subj_id]["deriv_path"] = target_filename
@@ -1201,7 +1224,7 @@ class BidsDataset(MRI2DSegmentationDataset):
         return multichannel_subjects
 
 
-    def create_filename_pair(self, multichannel_subjects, subject, c, tot, multichannel, df_subjects, contrast_params, 
+    def create_filename_pair(self, multichannel_subjects, subject, c, tot, multichannel, df_subjects, contrast_params,
                             target_suffix, all_deriv, bids_df, bounding_box_dict, idx_dict, metadata_choice):
         df_sub = df_subjects.loc[df_subjects['filename'] == subject]
 

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -1133,9 +1133,6 @@ class BidsDataset(MRI2DSegmentationDataset):
         # Get all derivatives filenames from bids_df
         all_deriv = bids_df.get_deriv_fnames()
 
-        filename_pairs_singlechannel = []
-        filename_pairs_multichannel = []
-
         # Create filename_pairs
         for subject in tqdm(subject_file_lst, desc="Loading dataset"):
             df_sub, roi_filename, target_filename, metadata = self.create_filename_pair(multichannel_subjects, subject, 
@@ -1148,11 +1145,6 @@ class BidsDataset(MRI2DSegmentationDataset):
             if multichannel:
                 multichannel_subjects = self.fill_multichannel_dict(multichannel_subjects, subject, idx_dict, df_sub, 
                                                                     roi_filename, target_filename, metadata)
-
-                filename_pairs_singlechannel.append(([df_sub['path'].values[0]],
-                                            target_filename, roi_filename, [metadata]))
-                filename_pairs_multichannel.append(([df_sub['path'].values[0]],
-                                                     target_filename, roi_filename, [metadata]))
             else:
                 self.filename_pairs.append(([df_sub['path'].values[0]],
                                             target_filename, roi_filename, [metadata]))

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -1133,6 +1133,9 @@ class BidsDataset(MRI2DSegmentationDataset):
         # Get all derivatives filenames from bids_df
         all_deriv = bids_df.get_deriv_fnames()
 
+        filename_pairs_singlechannel = []
+        filename_pairs_multichannel = []
+
         # Create filename_pairs
         for subject in tqdm(subject_file_lst, desc="Loading dataset"):
             df_sub, roi_filename, target_filename, metadata = self.create_filename_pair(multichannel_subjects, subject, 
@@ -1145,6 +1148,11 @@ class BidsDataset(MRI2DSegmentationDataset):
             if multichannel:
                 multichannel_subjects = self.fill_multichannel_dict(multichannel_subjects, subject, idx_dict, df_sub, 
                                                                     roi_filename, target_filename, metadata)
+
+                filename_pairs_singlechannel.append(([df_sub['path'].values[0]],
+                                            target_filename, roi_filename, [metadata]))
+                filename_pairs_multichannel.append(([df_sub['path'].values[0]],
+                                                     target_filename, roi_filename, [metadata]))
             else:
                 self.filename_pairs.append(([df_sub['path'].values[0]],
                                             target_filename, roi_filename, [metadata]))

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -596,7 +596,7 @@ class BidsDataframe:
         self.derivatives = derivatives
 
         # Multichannel
-        self.multichannel = loader_params['multichannel']
+        self.multichannel = bool(loader_params.get('multichannel'))
 
         # Create dataframe
         self.df = pd.DataFrame()

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -9,6 +9,7 @@ import sys
 import platform
 import multiprocessing
 import re
+import numpy as np
 
 from ivadomed.utils import logger
 from ivadomed import evaluation as imed_evaluation
@@ -238,23 +239,47 @@ def run_segment_command(context, model_params):
             # Get subject_id for multichannel
             df_sub = bids_df.df.loc[bids_df.df['filename'] == subject]
             subj_id = re.sub(r'_' + df_sub['suffix'].values[0] + '.*', '', subject)
+
+            if "ses-" in subj_id:
+                has_sessions = True
+                subj_id = subj_id.split("_")[0]
+            else:
+                has_sessions = False
+
             if subj_id not in seen_subj_ids:
                 # if subj_id has not been seen yet
                 fname_img = []
                 provided_contrasts = []
                 contrasts = context['loader_parameters']['contrast_params']['testing']
-                # Keep contrast order
-                for c in contrasts:
-                    df_tmp = bids_df.df[
-                        bids_df.df['filename'].str.contains(subj_id) & bids_df.df['suffix'].str.contains(c)]
-                    if ~df_tmp.empty:
-                        provided_contrasts.append(c)
-                        fname_img.append(df_tmp['path'].values[0])
-                seen_subj_ids.append(subj_id)
-                if len(fname_img) != len(contrasts):
-                    logger.warning("Missing contrast for subject {}. {} were provided but {} are required. Skipping "
-                                   "subject.".format(subj_id, provided_contrasts, contrasts))
-                    continue
+
+                if has_sessions:
+                    all_subject_images = [d for d in bids_df.df['filename'] if subj_id in d]
+                    session_list = np.unique([d.split("_")[1] for d in all_subject_images])
+                    for session in session_list:
+                        # Keep contrast order
+                        for c in contrasts:
+                            df_tmp = bids_df.df[
+                                bids_df.df['filename'].str.contains(subj_id) &
+                                bids_df.df['suffix'].str.contains(c) &
+                                bids_df.df['filename'].str.contains(session)]
+                            if ~df_tmp.empty:
+                                provided_contrasts.append(c)
+                                fname_img.append(df_tmp['path'].values[0])
+                    seen_subj_ids.append(subj_id)
+
+                else:
+                    # Keep contrast order
+                    for c in contrasts:
+                        df_tmp = bids_df.df[
+                            bids_df.df['filename'].str.contains(subj_id) & bids_df.df['suffix'].str.contains(c)]
+                        if ~df_tmp.empty:
+                            provided_contrasts.append(c)
+                            fname_img.append(df_tmp['path'].values[0])
+                    seen_subj_ids.append(subj_id)
+                    if len(fname_img) != len(contrasts):
+                        logger.warning("Missing contrast for subject {}. {} were provided but {} are required. Skipping "
+                                       "subject.".format(subj_id, provided_contrasts, contrasts))
+                        continue
             else:
                 # Returns an empty list for subj_id already seen
                 fname_img = []


### PR DESCRIPTION
This is PR to allow longitudinal studies/datasets to be trained when the Multichannel option is selected.

The file structure of these datasets includes folders and filenames with "ses-*" strings.


The derivatives are loaded in a straightforward way when they are present for all images.
However, since the multichannel training requires a single GT for multiple input images, there are a few options for associating a derivative to an image (the code follows this order):
1. The derivative of the image (normal approach)
2. The derivative of the same CONTRAST from a different session
3. The derivative from a different contrast (but also selected in the config file) from the same session
4. The derivative from a different contrast (but also selected in the config file) from a different session

The reasoning behind this is that with the previous structure of the code the images that didn't have a GT would be ignored.
However in the multi-channel training case we can still use them.

There is a display that is logged on luguru to inform the user/devs of the association of an image to a different GT.

The inspiration for accommodating these cases comes from the MS-Challenge dataset that only has a single GT for the second time point.
https://github.com/ivadomed/ms-challenge-2021

This is still in draft mode
The training/testing work
Segmenting is still WIP

Related to https://github.com/ivadomed/ivadomed/issues/788

Comments welcome.
