### PR TITLE
Fix last slice missing in testing bug

### DIFF
--- a/ivadomed/config/config_new_loader.json
+++ b/ivadomed/config/config_new_loader.json
@@ -75,8 +75,8 @@
         "bn_momentum": 0.1,
         "final_activation": "sigmoid",
         "depth": 3,
-        "length_2D": [],
-        "stride_2D": []
+        "length_2D": [128, 128],
+        "stride_2D": [104, 104]
     },
     "FiLMedUnet": {
         "applied": false,

--- a/ivadomed/config/config_new_loader.json
+++ b/ivadomed/config/config_new_loader.json
@@ -46,7 +46,7 @@
             "name": "DiceLoss"
         },
         "training_time": {
-            "num_epochs": 5,
+            "num_epochs": 15,
             "early_stopping_patience": 50,
             "early_stopping_epsilon": 0.001
         },
@@ -82,6 +82,9 @@
         "applied": false,
         "metadata": "contrasts",
         "film_layers": [0, 1, 0, 0, 0, 0, 0, 0]
+    },
+    "postprocessing": {
+        "binarize_maxpooling": {}
     },
     "transformation": {
       "CenterCrop": {

--- a/ivadomed/testing.py
+++ b/ivadomed/testing.py
@@ -182,6 +182,9 @@ def run_inference(test_loader, model, model_params, testing_params, ofolder, cud
 
             if model_params["is_2d"]:
                 preds_idx_arr = None
+                idx_slice = batch['input_metadata'][smp_idx][0]['slice_index']
+                n_slices = batch['input_metadata'][smp_idx][0]['data_shape'][-1]
+                last_slice_bool = (idx_slice + 1 == n_slices)
                 last_sample_bool = (last_batch_bool and smp_idx == len(preds_cpu) - 1)
 
                 length_2D = model_params["length_2D"] if "length_2D" in model_params else []
@@ -191,30 +194,34 @@ def run_inference(test_loader, model, model_params, testing_params, ofolder, cud
                     preds_idx_undo, metadata_idx, last_patch_bool, image, weight_matrix = \
                         imed_inference.image_reconstruction(batch, preds_cpu, testing_params['undo_transforms'],
                                                             smp_idx, image, weight_matrix)
-                    # If last patch of the slice
-                    if last_patch_bool:
-                        # preds_idx_undo is a list n_label arrays
-                        preds_idx_arr = np.array(preds_idx_undo)
-
-                        # TODO: gt_filenames should not be a list
-                        fname_ref = list(filter(None, metadata_idx[0]['gt_filenames']))[0]
-
                 else:
+                    # Set last_patch_bool to True (only one patch per slice)
+                    last_patch_bool = True
                     # undo transformations for slice
                     preds_idx_undo, metadata_idx = testing_params["undo_transforms"](preds_cpu[smp_idx],
                                                                                      batch['gt_metadata'][smp_idx],
                                                                                      data_type='gt')
+                if last_patch_bool:
                     # preds_idx_undo is a list n_label arrays
                     preds_idx_arr = np.array(preds_idx_undo)
 
                     # TODO: gt_filenames should not be a list
                     fname_ref = list(filter(None, metadata_idx[0]['gt_filenames']))[0]
 
+                if preds_idx_arr is not None:
+                    # add new sample to pred_tmp_lst, of size n_label X h X w ...
+                    pred_tmp_lst.append(preds_idx_arr)
+
+                    # TODO: slice_index should be stored in gt_metadata as well
+                    z_tmp_lst.append(int(idx_slice))
+                    filenames = metadata_idx[0]['gt_filenames']
+
                 # NEW COMPLETE VOLUME
-                if pred_tmp_lst and (fname_ref != fname_tmp or last_sample_bool) and task != "classification":
+                if (pred_tmp_lst and ((last_patch_bool and last_slice_bool) or last_sample_bool)
+                    and task != "classification"):
                     # save the completely processed file as a NifTI file
                     if ofolder:
-                        fname_pred = os.path.join(ofolder, Path(fname_tmp).name)
+                        fname_pred = os.path.join(ofolder, Path(fname_ref).name)
                         fname_pred = fname_pred.rsplit("_", 1)[0] + '_pred.nii.gz'
                         # If Uncertainty running, then we save each simulation result
                         if testing_params['uncertainty']['applied']:
@@ -224,7 +231,7 @@ def run_inference(test_loader, model, model_params, testing_params, ofolder, cud
                         fname_pred = None
                     output_nii = imed_inference.pred_to_nib(data_lst=pred_tmp_lst,
                                                         z_lst=z_tmp_lst,
-                                                        fname_ref=fname_tmp,
+                                                        fname_ref=fname_ref,
                                                         fname_out=fname_pred,
                                                         slice_axis=slice_axis,
                                                         kernel_dim='2d',
@@ -247,17 +254,10 @@ def run_inference(test_loader, model, model_params, testing_params, ofolder, cud
                         #                              fname_pred.split(".nii.gz")[0] + '_color.nii.gz',
                         #                              imed_utils.AXIS_DCT[testing_params['slice_axis']])
 
-                    # re-init pred_stack_lst
+
+                    # re-init pred_stack_lst and last_slice_bool
                     pred_tmp_lst, z_tmp_lst = [], []
-
-                if preds_idx_arr is not None:
-                    # add new sample to pred_tmp_lst, of size n_label X h X w ...
-                    pred_tmp_lst.append(preds_idx_arr)
-
-                    # TODO: slice_index should be stored in gt_metadata as well
-                    z_tmp_lst.append(int(batch['input_metadata'][smp_idx][0]['slice_index']))
-                    fname_tmp = fname_ref
-                    filenames = metadata_idx[0]['gt_filenames']
+                    last_slice_bool = False
 
             else:
                 pred_undo, metadata, last_sample_bool, volume, weight_matrix = \

--- a/testing/unit_tests/test_testing.py
+++ b/testing/unit_tests/test_testing.py
@@ -10,7 +10,7 @@ from ivadomed import testing as imed_testing
 from ivadomed import models as imed_models
 from ivadomed.loader import utils as imed_loader_utils, loader as imed_loader
 import logging
-from testing.unit_tests.t_utils import create_tmp_dir, __data_testing_dir__, __tmp_dir__, download_data_testing_test_files
+from testing.unit_tests.t_utils import create_tmp_dir, __data_testing_dir__, __tmp_dir__, download_data_testing_test_files, path_repo_root
 from testing.common_testing_util import remove_tmp_dir
 logger = logging.getLogger(__name__)
 
@@ -122,6 +122,103 @@ def test_inference(download_data_testing_test_files, transforms_dict, test_lst, 
     metrics_dict = metric_mgr.get_results()
     metric_mgr.reset()
     print(metrics_dict)
+
+
+@pytest.mark.parametrize('transforms_dict', [{
+        "CenterCrop": {
+                "size": [128, 128]
+            },
+        "NormalizeInstance": {"applied_to": ["im"]}
+    }])
+@pytest.mark.parametrize('test_lst',
+    [['sub-rat3_ses-01_sample-data9_SEM.png', 'sub-rat3_ses-02_sample-data10_SEM.png']])
+@pytest.mark.parametrize('target_lst', [["_seg-axon-manual"]])
+@pytest.mark.parametrize('roi_params', [{"suffix": None, "slice_filter_roi": None}])
+@pytest.mark.parametrize('testing_params', [{
+    "binarize_maxpooling": {},
+    "uncertainty": {
+        "applied": False,
+        "epistemic": False,
+        "aleatoric": False,
+        "n_it": 0
+    }}])
+def test_inference_2d_microscopy(download_data_testing_test_files, transforms_dict, test_lst, target_lst, roi_params,
+        testing_params):
+    """
+    This test checks if number of predictions equals number of test subjects on 2d microscopy data
+    Used to catch a bug where the last slice of the last volume wasn't appended to the prediction
+    (see: https://github.com/ivadomed/ivadomed/issues/823)
+    """
+    cuda_available, device = imed_utils.define_device(GPU_ID)
+
+    model_params = {"name": "Unet", "is_2d": True}
+    loader_params = {
+        "transforms_params": transforms_dict,
+        "data_list": test_lst,
+        "dataset_type": "testing",
+        "requires_undo": True,
+        "contrast_params": {"contrast_lst": ['SEM'], "balance": {}},
+        "path_data": [os.path.join(__data_testing_dir__, "microscopy_png")],
+        "bids_config": f"{path_repo_root}/ivadomed/config/config_bids.json",
+        "target_suffix": target_lst,
+        "extensions": [".png"],
+        "roi_params": roi_params,
+        "slice_filter_params": {
+            "filter_empty_mask": False,
+            "filter_empty_input": True
+        },
+        "slice_axis": SLICE_AXIS,
+        "multichannel": False
+    }
+    loader_params.update({"model_params": model_params})
+
+    bids_df = imed_loader_utils.BidsDataframe(loader_params, __tmp_dir__, derivatives=True)
+
+    # Get Testing dataset
+    ds_test = imed_loader.load_dataset(bids_df, **loader_params)
+    test_loader = DataLoader(ds_test, batch_size=BATCH_SIZE,
+                             shuffle=False, pin_memory=True,
+                             collate_fn=imed_loader_utils.imed_collate,
+                             num_workers=0)
+
+    # Undo transform
+    val_undo_transform = imed_transforms.UndoCompose(imed_transforms.Compose(transforms_dict))
+
+    # Update testing_params
+    testing_params.update({
+        "slice_axis": loader_params["slice_axis"],
+        "target_suffix": loader_params["target_suffix"],
+        "undo_transforms": val_undo_transform
+    })
+
+    # Model
+    model = imed_models.Unet()
+
+    if cuda_available:
+        model.cuda()
+    model.eval()
+
+    metric_fns = [imed_metrics.dice_score,
+                  imed_metrics.hausdorff_score,
+                  imed_metrics.precision_score,
+                  imed_metrics.recall_score,
+                  imed_metrics.specificity_score,
+                  imed_metrics.intersection_over_union,
+                  imed_metrics.accuracy_score]
+
+    metric_mgr = imed_metrics.MetricManager(metric_fns)
+
+    if not os.path.isdir(__output_dir__):
+        os.makedirs(__output_dir__)
+
+    preds_npy, gt_npy = imed_testing.run_inference(test_loader=test_loader,
+                                                   model=model,
+                                                   model_params=model_params,
+                                                   testing_params=testing_params,
+                                                   ofolder=__output_dir__,
+                                                   cuda_available=cuda_available)
+
+    assert len(os.listdir(__output_dir__)) == len(test_lst)
 
 
 def teardown_function():


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR fixes a bug in testing where the predictions of the last slice of the last volume of a batch were not appended in the `_pred` NifTI file, and therefore not taken into account in evaluation metrics.

For 2d microscopy, that meant that the last prediction for the last subject was entirely missing in the predictions.

### Changes made in this PR:
- The predictions for each slice are now appended to `pred_tmp_lst` before entering the "new complete volume" block where the reconstruction and saving of the NifTI takes place.
- I removed `fname_tmp` from the loop and the previous trigger for "new complete volume" which was a `fname_ref != fname_tmp` . Because `fname_tmp` had to be assigned after "new complete volume", it would not work with 2d microscopy with only 1 slice per volume.
- I replaced the trigger with `last_slice_bool`, which compare the slice index with the number of slice of each volume. Hence, "new complete volume" is triggered when the prediction is for the last patch of the last slice of each volume, instead of when the filename changes. **My understanding is that it is going to work with all axis (axial, sagittal, coronal) but I only tested with axial, I would appreciate some insights on this.**
- I added a test in `test_testing.py` for 2d microscopy. This test ensures the testing is working with volumes of only one slice and would fail without the fix.

### To test the PR:
**On 3D MRI without patches:**
1. On master branch: Run a 2D model with command `test` and check the last volume resulting nifti file (last slice (top) is all zeros).
2. On this branch: Run the same command, check the last volume resulting nifti file (no missing slice in the prediction).

**On 2D Microscopy with patches:**
1. On master branch, run a short training (CPU friendly) with `config_new_loader.json` and the [data_example_microscopy_sem](https://github.com/ivadomed/data_example_microscopy_sem) dataset.
2. Modify the command in config to `test` and run the test. The test fraction is 0.2 and there should be 2 predictions in the `output_path/preds_mask`. However, there is only 1 because of the bug.
3. On this branch, re-run the command `test`. This time, 2 predictions should be in `preds_mask`.

## Linked issues
Fixes #823 
