### PR TITLE
Fix multiclass evaluation bug

### DIFF
--- a/ivadomed/config/config_new_loader.json
+++ b/ivadomed/config/config_new_loader.json
@@ -46,7 +46,7 @@
             "name": "DiceLoss"
         },
         "training_time": {
-            "num_epochs": 5,
+            "num_epochs": 15,
             "early_stopping_patience": 50,
             "early_stopping_epsilon": 0.001
         },
@@ -82,6 +82,9 @@
         "applied": false,
         "metadata": "contrasts",
         "film_layers": [0, 1, 0, 0, 0, 0, 0, 0]
+    },
+    "postprocessing": {
+        "binarize_maxpooling": {}
     },
     "transformation": {
       "CenterCrop": {

--- a/ivadomed/evaluation.py
+++ b/ivadomed/evaluation.py
@@ -50,8 +50,14 @@ def evaluate(bids_df, path_output, target_suffix, eval_params):
     for subj_acq in tqdm(subj_acq_lst, desc="Evaluation"):
         # Fnames of pred and ground-truth
         fname_pred = os.path.join(path_preds, subj_acq + '_pred.nii.gz')
-        fname_gt = bids_df.df[bids_df.df['filename']
+        derivatives = bids_df.df[bids_df.df['filename']
                           .str.contains('|'.join(bids_df.get_derivatives(subj_acq, all_deriv)))]['path'].to_list()
+        # Ordering ground-truth the same as target_suffix
+        fname_gt = [None] * len(target_suffix)
+        for deriv in derivatives:
+            for idx, suffix in enumerate(target_suffix):
+                if suffix in deriv:
+                    fname_gt[idx] = deriv
 
         # Check fname_gt extentions and update paths if not NifTI
         fname_gt = [imed_loader_utils.update_filename_to_nifti(fname) for fname in fname_gt]


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR fixes the mixup issue between prediction and ground-truths in `evaluation.py` for multiclass models when sometimes the wrong GT was compared to the prediction. This happened because the list of ground-truth was not properly ordered to be the same as the order of `target_suffix`, bug introduced in PR #699.

## To test the PR:
1. On master branch, run a short training (CPU friendly) with `config_new_loader.json` and the [data_example_microscopy_sem](https://github.com/ivadomed/data_example_microscopy_sem) dataset.
2. Modify the command in config to `test` and run the test. There should be one prediction in `pred_masks` of `sub-rat3_sample-data10_SEM`. The "painted" predictions will most likely look like the following with a mismatch between predictions and GT (predictions are in the 256x256 crop in the center, elsewhere is GT):
**Volume 0 : axon prediction on myelin GT**
![axon_pred_myelin_gt](https://user-images.githubusercontent.com/54086142/123562305-f2d61e00-d77b-11eb-9c7e-ab8c50e2b81d.png)
**Volume 1 : myelin prediction on axon GT**
![myelin_pred_axon_gt](https://user-images.githubusercontent.com/54086142/123562318-15683700-d77c-11eb-993d-cd7a24e67ac8.png)

3. On this branch, re-run the command test, the "painted" predictions should now match the GT:
**Volume 0 : axon prediction on axon GT**
![axon_pred_axon_gt](https://user-images.githubusercontent.com/54086142/123562377-78f26480-d77c-11eb-9104-639570306500.png)
**Volume 1 : myelin prediction on myelin sub-rat3_sample-data10_SEM
![myelin_pred_myelin_gt](https://user-images.githubusercontent.com/54086142/123562378-7a239180-d77c-11eb-81c8-54bd33204541.png)

## Linked issues
Fixes #836 
