### PR TITLE
Update config_bids.json following changes in microscopy BEP

### DIFF
--- a/ivadomed/config/config_bids.json
+++ b/ivadomed/config/config_bids.json
@@ -29,6 +29,10 @@
             "pattern": "[_/\\\\]+ce-([a-zA-Z0-9]+)"
         },
         {
+            "name": "staining",
+            "pattern": "[_/\\\\]+stain-([a-zA-Z0-9]+)"
+        },
+        {
             "name": "reconstruction",
             "pattern": "[_/\\\\]+rec-([a-zA-Z0-9]+)"
         },
@@ -82,10 +86,6 @@
             "pattern": "[_/\\\\]+chunk-([0-9]+)"
         },
         {
-            "name": "downsampling",
-            "pattern": "[_/\\\\]+down-([0-9]+)"
-        },
-        {
             "name": "suffix",
             "pattern": "[._]*([a-zA-Z0-9]*?)\\.[^/\\\\]+$"
         },
@@ -99,7 +99,7 @@
         },
         {
             "name": "datatype",
-            "pattern": "[/\\\\]+(func|anat|fmap|dwi|meg|eeg|microscopy|ct)[/\\\\]+"
+            "pattern": "[/\\\\]+(anat|beh|dwi|eeg|fmap|func|ieeg|meg|perf|microscopy|ct)[/\\\\]+"
         },
         {
             "name": "extension",


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
The `config_bids.json` file is used to index files from non-BIDS compliant modalities like Microscopy and CT-scan with `pybids`.

This small PR updates the config to the latest changes in the Microscopy BEP, i.e. removing the `downsampling` entity and adding the `staining` entity.

It also includes an update of the datatype pattern from an update in `pybids` config file.
There is no related issue and no specific test to do for the PR, the indexing is already tested in `test_loader.py`.

