### PR TITLE
Pathlib adoption for mixup.py

### DIFF
--- a/ivadomed/mixup.py
+++ b/ivadomed/mixup.py
@@ -1,7 +1,7 @@
-import os
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
+from pathlib import Path
 
 
 def mixup(data, targets, alpha, debugging=False, ofolder=None):
@@ -48,14 +48,14 @@ def save_mixup_sample(ofolder, input_data, labeled_data, lambda_tensor):
         lambda_tensor (Tensor):
     """
     # Mixup folder
-    mixup_folder = os.path.join(ofolder, 'mixup')
-    if not os.path.isdir(mixup_folder):
-        os.makedirs(mixup_folder)
+    mixup_folder = Path(ofolder, 'mixup')
+    if not mixup_folder.is_dir():
+        mixup_folder.mkdir(parents=True)
     # Random sample
     random_idx = np.random.randint(0, input_data.size()[0])
     # Output fname
     ofname = str(lambda_tensor.data.numpy()[0]) + '_' + str(random_idx).zfill(3) + '.png'
-    ofname = os.path.join(mixup_folder, ofname)
+    ofname = Path(mixup_folder, ofname)
     # Tensor to Numpy
     x = input_data.data.numpy()[random_idx, 0, :, :]
     y = labeled_data.data.numpy()[random_idx, 0, :, :]


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
Phased refactor adoption of loader/segmentation_pair.py as detailed in #872 using pathlib for using pathlib for using pathlib for using pathlib for mixup.py

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Step wise remediation of #872