### PR TITLE
Pathlib adoption for utils.py

### DIFF
--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -1,9 +1,10 @@
-import os
 import sys
+import os
 import subprocess
 import hashlib
 from enum import Enum
 from loguru import logger
+from pathlib import Path
 
 from typing import List
 
@@ -207,7 +208,7 @@ def _git_info(commit_env='IVADOMED_COMMIT', branch_env='IVADOMED_BRANCH'):
     """
     ivadomed_commit = os.getenv(commit_env, "unknown")
     ivadomed_branch = os.getenv(branch_env, "unknown")
-    if check_exe("git") and os.path.isdir(os.path.join(__ivadomed_dir__, ".git")):
+    if check_exe("git") and Path(__ivadomed_dir__, ".git").is_dir():
         ivadomed_commit = __get_commit() or ivadomed_commit
         ivadomed_branch = __get_branch() or ivadomed_branch
 
@@ -216,8 +217,8 @@ def _git_info(commit_env='IVADOMED_COMMIT', branch_env='IVADOMED_BRANCH'):
     else:
         install_type = 'package'
 
-    path_version = os.path.join(__ivadomed_dir__, 'ivadomed', 'version.txt')
-    with open(path_version) as f:
+    path_version = Path(__ivadomed_dir__, 'ivadomed', 'version.txt')
+    with path_version.open() as f:
         version_ivadomed = f.read().strip()
 
     return install_type, ivadomed_commit, ivadomed_branch, version_ivadomed
@@ -233,15 +234,15 @@ def check_exe(name):
     """
 
     def is_exe(fpath):
-        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+        return Path(fpath).is_file() and os.access(fpath, os.X_OK)
 
-    fpath, fname = os.path.split(name)
+    fpath = Path(name).parent
     if fpath and is_exe(name):
         return fpath
     else:
         for path in os.environ["PATH"].split(os.pathsep):
             path = path.strip('"')
-            exe_file = os.path.join(path, name)
+            exe_file = str(Path(path, name))
             if is_exe(exe_file):
                 return exe_file
 
@@ -286,7 +287,7 @@ def __get_commit(path_to_git_folder=None):
     if path_to_git_folder is None:
         path_to_git_folder = __ivadomed_dir__
     else:
-        path_to_git_folder = os.path.abspath(os.path.expanduser(path_to_git_folder))
+        path_to_git_folder = Path(path_to_git_folder).expanduser().absolute()
 
     p = subprocess.Popen(["git", "rev-parse", "HEAD"], stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                          cwd=path_to_git_folder)
@@ -341,7 +342,7 @@ def _version_string():
         return "{install_type}-{ivadomed_branch}-{ivadomed_commit}".format(**locals())
 
 
-__ivadomed_dir__ = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+__ivadomed_dir__ = Path(__file__).resolve().parent.parent
 __version__ = _version_string()
 
 


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
Phased refactor adoption of loader/segmentation_pair.py as detailed in #872 using pathlib for using pathlib for using pathlib for utils.py

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Step wise remediation of #872