### PR TITLE
Initialize the adoption of centralized management of keywords via keywords.py (Phase I: compilation of all keywords)

### DIFF
--- a/ivadomed/keywords.py
+++ b/ivadomed/keywords.py
@@ -1,0 +1,189 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class ConfigKW:
+    LOADER_PARAMETERS = "loader_parameters"
+    TRAINING_PARAMETERS = "training_parameters"
+    MODEL_NAME = "model_name"
+    MODIFIED3DUNET = "Modified3DUNet"
+    DEBUGGING = "debugging"
+    FILMEDUNET = "FiLMedUnet"
+    DEFAULT_MODEL = "default_model"
+    OBJECT_DETECTION_PARAMS = "object_detection_params"
+    GPU_IDS = "gpu_ids"
+    PATH_OUTPUT = "path_output"
+    POSTPROCESSING = "postprocessing"
+    COMMAND = "command"
+    LOG_FILE = "log_file"
+    TRANSFORMATION = "transformation"
+    SPLIT_DATASET = "split_dataset"
+    UNCERTAINTY = "uncertainty"
+    UNDO_TRANSFORMS = "undo_transforms"
+    ELEVATION_PARAMETERS = "elevation_parameters"
+    HEMISUNET = "HeMISUnet"
+    SPLIT_PATH = "split_path"
+    TRAINING_SHA256 = "training_sha256"
+
+
+@dataclass
+class LoaderParamsKW:
+    PATH_DATA = "path_data"
+    BIDS_CONFIG = "bids_config"
+    TARGET_SUFFIX = "target_suffix"
+    ROI_PARAMS = "roi_params"
+    CONTRAST_PARAMS = "contrast_params"
+    MULTICHANNEL = "multichannel"  # boolean key that is used to change the configuration file ever slightly.
+    EXTENSIONS = "extensions"
+    TARGET_GROUND_TRUTH = "target_ground_truth"
+    TARGET_SESSIONS = "target_sessions"  # the sessions to focus the analyses on
+    METADATA_TYPE = "metadata_type"
+    MODEL_PARAMS = "model_params"
+    SLICE_AXIS = "slice_axis"
+    IS_INPUT_DROPOUT = "is_input_dropout"
+    SLICE_FILTER_PARAMS = "slice_filter_params"
+
+
+@dataclass
+class SplitDatasetKW:
+    SPLIT_METHOD = "split_method"
+    FNAME_SPLIT = "fname_split"
+    DATA_TESTING = "data_testing"
+    RANDOM_SEED = "random_seed"
+    TRAIN_FRACTION = "train_fraction"
+    TEST_FRACTION = "test_fraction"
+    BALANCE = "balance"
+
+
+@dataclass
+class DataTestingKW:
+    DATA_TYPE = "data_type"
+    DATA_VALUE = "data_value"
+
+
+@dataclass
+class TrainingParamsKW:
+    BALANCE_SAMPLES = "balance_samples"
+    BATCH_SIZE = "batch_size"
+
+
+@dataclass
+class TransformationKW:
+    ROICROP = "ROICrop"
+    CENTERCROP = "CenterCrop"
+    RESAMPLE = "Resample"
+
+
+@dataclass
+class BalanceSamplesKW:
+    APPLIED = "applied"
+    TYPE = "type"
+
+
+@dataclass
+class ContrastParamsKW:
+    CONTRAST_LIST = "contrast_lst"  # The list help determine the number of model parameter inputs.
+    BALANCE = "balance"
+    TRAINING_VALIDATION = "training_validation"
+    TESTING = "testing"
+
+
+@dataclass
+class ModelParamsKW:
+    LENGTH_2D = "length_2D"
+    STRIDE_2D = "stride_2D"
+    LENGTH_3D = "length_3D"
+    STRIDE_3D = "stride_3D"
+    FILM_LAYERS = "film_layers"
+    FOLDER_NAME = "folder_name"
+    METADATA = "metadata"
+    FILM_ONEHOTENCODER = "film_onehotencoder"
+    N_METADATA = "n_metadata"
+    APPLIED = "applied"
+    NAME = "name"
+    IS_2D = "is_2d"
+    IN_CHANNEL = "in_channel"
+    OUT_CHANNEL = "out_channel"
+    TARGET_LIST = "target_list"
+    ROI_LIST = "roi_list"
+    PATH_HDF5 = "path_hdf5"
+    CSV_PATH = "csv_path"
+    RAM = "ram"
+    ATTENTION = "attention"
+    DEPTH = "depth"
+    MISSING_PROBABILITY = "missing_probability"
+    MISSING_PROBABILITY_GROWTH = "missing_probability_growth"
+
+
+@dataclass
+class SubjectDictKW:
+    ABSOLUTE_PATHS = "absolute_paths"
+    DERIV_PATH = "deriv_path"
+    ROI_FILENAME = "roi_filename"
+    METADATA = "metadata"
+    EXTENSIONS = "extensions"
+
+
+@dataclass
+class SubjectDataFrameKW:
+    FILENAME = "filename"
+
+
+@dataclass
+class BidsDataFrameKW:
+    # bids layout converted to dataframe during bids dataset creation
+    PATH = "path"   # full path.
+    FILENAME = "filename"  # the actual file's name (base)
+    PARTICIPANT_ID = "participant_id"  # i.e.    sub-unf01
+    SUBJECT = "subject"  # i.e.  unf01
+    SUFFIX = "suffix"   # T1w
+    SESSION = "session"  # session field (single int) in Bids DataFrame
+    EXTENSION = "extension"   # .nii.gz
+    DERIVATIVES = "derivatives"
+
+
+@dataclass
+class ROIParamsKW:
+    SUFFIX = "suffix"
+    SLICE_FILTER_ROI = "slice_filter_roi"
+
+
+@dataclass
+class MetadataParamsKW:
+    CONTRAST = "contrast"
+    BOUNDING_BOX = "bounding_box"
+
+
+@dataclass
+class MetadataChoiceKW:
+    MRI_PARAMS = "mri_params"
+    CONTRASTS = "contrasts"
+
+
+@dataclass
+class ObjectDetectionParamsKW:
+    GPU_IDS = "gpu_ids"
+    PATH_OUTPUT = "path_output"
+    OBJECT_DETECTION_PATH = "object_detection_path"
+    SAFETY_FACTOR = "safety_factor"
+
+
+@dataclass
+class UncertaintyKW:
+    ALEATORIC = 'aleatoric'
+    N_IT = "n_it"
+
+
+@dataclass
+class PostprocessingKW:
+    BINARIZE_PREDICTION = "binarize_prediction"
+
+
+@dataclass
+class BinarizeProdictionKW:
+    THR = "thr"
+
+
+@dataclass
+class SliceFilterParamsKW:
+    FILTER_EMPTY_MASK = "filter_empty_mask"


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [X] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [X] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [X] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [X] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

* Currently, we are using hard coded string to represent numerous settings/configurations and dictionary keys. This is easy to read but hard to maintain, manage and refactor as most IDEs are not smart enough to recognize string in its proper context consistently across the code base. Also, it poses a problem with explainability/readability of the code as the context of this string is usually lost. Here is a trivial example where a simple `some_dictionary["balance"]` is quite ambiguous in terms of its origin
![image](https://user-images.githubusercontent.com/6720068/128610149-ba56780d-c6f3-4515-8530-1b29a079c5e2.png) 
where as `some_dictionary[ContrastKW.BALANCE]` vs `some_dictionary[SplitDataSetKW.BALANCE]` will make it immediately apparent. More importantly, should we decide to be more specific in the keywords or refactoring them  down the road, a search and replacement of "balance" will cause lots of issues while a IDE driven refactoring based on `SplitDataSetKW.BALANCE` or the underlying string representation at `keywords.py` will be much less painful and error prone. 

* Phase 1 of this project is to collect and centralize all the known strings with special purposes, which is now centralized at `keywords.py`
* Phase 2 of this project is to gradually start phasing in the keywords adoption going forward to minimize disruption to existing long standing PRs and ongoing works. 

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
