### PR TITLE
Fix inverted dimensions in microscopy pixelsize

### DIFF
--- a/ivadomed/config/config_microscopy.json
+++ b/ivadomed/config/config_microscopy.json
@@ -9,7 +9,7 @@
         "safety_factor": [1.0, 1.0, 1.0]
     },
     "loader_parameters": {
-        "path_data": ["data_example_microscopy_sem"],
+        "path_data": ["data_axondeepseg_sem"],
         "bids_config": "ivadomed/config/config_bids.json",
         "subject_selection": {"n": [], "metadata": [], "value": []},
         "target_suffix": ["_seg-axon-manual", "_seg-myelin-manual"],

--- a/ivadomed/inference.py
+++ b/ivadomed/inference.py
@@ -335,7 +335,8 @@ def segment_volume(folder_model: str, fname_images: list, gpu_id: int = 0, optio
                               example: ["10", "20", "10vox"] (remove objects smaller than 10 voxels for class 1 and 3,
                               and smaller than 20 voxels for class 2).
             * 'pixel_size': (list of float) List of microscopy pixel size in micrometers.
-                            Length equals 2 [X, Y] for 2D or 3 [X, Y, Z] for 3D.
+                            Length equals 2 [PixelSizeX, PixelSizeY] for 2D or 3 [PixelSizeX, PixelSizeY, PixelSizeZ] for 3D,
+                            where X is the width, Y the height and Z the depth of the image.
             * 'overlap_2D': (list of int) List of overlaps in pixels for 2D patching. Length equals 2 [X, Y].
             * 'metadata': (str) Film metadata.
             * 'fname_prior': (str) An image filename (e.g., .nii.gz) containing processing information

--- a/ivadomed/loader/mri2d_segmentation_dataset.py
+++ b/ivadomed/loader/mri2d_segmentation_dataset.py
@@ -144,7 +144,7 @@ class MRI2DSegmentationDataset(Dataset):
                 if stride > length or stride <= 0:
                     raise RuntimeError('"stride_2D" must be greater than 0 and smaller or equal to "length_2D".')
                 if length > size:
-                    raise RuntimeError('"length_2D" must be smaller or equal to image dimensions.')
+                    raise RuntimeError('"length_2D" must be smaller or equal to image dimensions after resampling.')
 
             for x in range(0, (shape[0] - self.length[0] + self.stride[0]), self.stride[0]):
                 if x + self.length[0] > shape[0]:

--- a/ivadomed/loader/segmentation_pair.py
+++ b/ivadomed/loader/segmentation_pair.py
@@ -298,16 +298,6 @@ class SegmentationPair(object):
         This method is especially relevant for making microscopy data compatible with NifTI-only
         pipelines.
 
-        The implementation of this method is dependent on the development of the corresponding
-        microscopy BEP (github.com/ivadomed/ivadomed/issues/301, bids.neuroimaging.io/bep031):
-        * "pixdim" (zooms) for Nifti1Image object is extracted as follows:
-            * For train, test and segment commands, PixelSize is taken from the metadata in BIDS JSON sidecar file.
-            * For inference with the segment_volume function, PixelSize must be provided in the 'options' argument.
-        * PixelSize definition in example dataset is a scalar in micrometers (BIDS BEP031 v0.0.2)
-        * PixelSize definition changed for list of 2-numbers [X, Y] or 3-numbers [X, Y, Z] in micrometers
-          for 2D and 3D respectively (BIDS BEP031 v0.0.3)
-        * Both PixelSize definitions are supported in this function.
-
         TODO: (#739) implement OMETIFF behavior (if "ome" in extension)
 
         Args:
@@ -332,29 +322,12 @@ class SegmentationPair(object):
         # Convert numpy array to Nifti1Image object with 4x4 identity affine matrix
         img = nib.Nifti1Image(img, affine=np.eye(4))
 
-        # Get pixel size in um from json metadata and convert to mm
-        array_length = [2, 3]        # Accepted array length for 'PixelSize' metadata
-        conversion_factor = 0.001    # Conversion factor from um to mm
-        if 'PixelSize' in self.metadata[0]:
-            ps_in_um = self.metadata[0]['PixelSize']
-            if isinstance(ps_in_um, list) and (len(ps_in_um) in array_length):
-                ps_in_um = np.asarray(ps_in_um)
-            elif isinstance(ps_in_um, float):
-                ps_in_um = np.asarray([ps_in_um, ps_in_um])
-            else:
-                raise RuntimeError("'PixelSize' metadata type is not supported. Format must be 2D [X, Y] array,"
-                                   " 3D [X, Y, Z] array or float.")
-            # Note: pixdim[1,2,3] must be non-zero in Nifti objects even if there is only one slice.
-            # When ps_in_um[2] (pixdim[3]) is not present or 0, we assign the same PixelSize as ps_in_um[0] (pixdim[1])
-            ps_in_um = np.resize(ps_in_um, 3)
-            if ps_in_um[2] == 0:
-                ps_in_um[2] = ps_in_um[0]
-            ps_in_mm = tuple(ps_in_um * conversion_factor)
-        else:
-            raise RuntimeError("'PixelSize' is missing from metadata")
+        # Get PixelSize in millimeters in order (PixelSizeY, PixelSizeX, PixelSizeZ), where X is the width,
+        # Y the height and Z the depth of the image.
+        ps_in_mm = self.get_microscopy_pixelsize()
 
         # Set "pixdim" (zooms) in Nifti1Image object header
-        img.header.set_zooms((ps_in_mm))
+        img.header.set_zooms(ps_in_mm)
 
         # If it doesn't already exist, save NifTI file in path_data alongside PNG/TIF/JPG file
         fname_out = imed_loader_utils.update_filename_to_nifti(filename)
@@ -362,3 +335,62 @@ class SegmentationPair(object):
             nib.save(img, fname_out)
 
         return img
+
+
+    def get_microscopy_pixelsize(self):
+        """
+        Get the microscopy pixel size in millimeters from the metadata.
+
+        The implementation of this method is dependent on the development of the corresponding
+        microscopy BEP (github.com/ivadomed/ivadomed/issues/301, bids.neuroimaging.io/bep031):
+        * "pixdim" (zooms) for Nifti1Image object is extracted as follows:
+            * For train, test and segment commands, PixelSize is taken from the metadata in BIDS JSON sidecar file.
+            * For inference with the segment_volume function, PixelSize must be provided in the 'options' argument.
+        * PixelSize definition in example dataset is a scalar in micrometers (BIDS BEP031 v0.0.2)
+        * PixelSize definition changed for list of 2-numbers [PixelSizeX, PixelSizeY]
+          or 3-numbers [PixelSizeX, PixelSizeY, PixelSizeZ] in micrometers for 2D and 3D respectively,
+          where X is the width, Y the height and Z the depth of the image (BIDS BEP031 v0.0.4).
+        * Both PixelSize definitions are supported in this function.
+        * In BIDS BEP031 v0.0.5, a separate field PixelSizeUnits is used to describe the unit pf PixelSize. The only
+          accepted value is "um" but could be expand in the future. This function assumes that the unit is micrometers.
+
+        Returns:
+            ndrray: Pixel size in millimeters in order (PixelSizeY, PixelSizeX, PixelSizeZ), where Y is the height,
+                    X the width and Z the depth of the image.
+        """
+
+        # Get pixel size in um from json metadata and convert to mm
+        array_length = [2, 3]        # Accepted array length for 'PixelSize' metadata
+        conversion_factor = 0.001    # Conversion factor from um to mm
+
+        if 'PixelSize' in self.metadata[0]:
+            ps_in_um = self.metadata[0]['PixelSize']
+
+            if isinstance(ps_in_um, list) and (len(ps_in_um) in array_length):
+                # PixelSize array in order [PixelSizeX, PixelSizeY] or [PixelSizeX, PixelSizeY, PixelSizeZ]
+                ps_in_um = np.asarray(ps_in_um)
+
+                # Note: pixdim[3] (PixelSizeZ) must be non-zero in Nifti objects even if there is only one slice.
+                # When PixelSizeZ is not present or 0, we assign the same PixelSize as PixelSizeX
+                ps_in_um = np.resize(ps_in_um, 3)
+                if ps_in_um[2] == 0:
+                    ps_in_um[2] = ps_in_um[0]
+
+                # Swap PixelSizeX and PixelSizeY resulting in an array in order [PixelSizeY, PixelSizeX, PixelSizeZ]
+                # to match NIfTI pixdim[1,2,3] in [Height, Width, Depth] orientation with axial slice axis.
+                ps_in_um[[1, 0]] = ps_in_um[[0, 1]]
+
+            elif isinstance(ps_in_um, float):
+                ps_in_um = np.asarray([ps_in_um, ps_in_um, ps_in_um])
+
+            else:
+                raise RuntimeError("'PixelSize' metadata type is not supported. Format must be a float,"
+                                   " 2D [PixelSizeX, PixelSizeY] array or 3D [PixelSizeX, PixelSizeY, PixelSizeZ] array"
+                                   " where X is the width, Y the height and Z the depth of the image.")
+
+            ps_in_mm = tuple(ps_in_um * conversion_factor)
+
+        else:
+            raise RuntimeError("'PixelSize' is missing from metadata")
+
+        return ps_in_mm

--- a/ivadomed/loader/segmentation_pair.py
+++ b/ivadomed/loader/segmentation_pair.py
@@ -346,13 +346,12 @@ class SegmentationPair(object):
         * "pixdim" (zooms) for Nifti1Image object is extracted as follows:
             * For train, test and segment commands, PixelSize is taken from the metadata in BIDS JSON sidecar file.
             * For inference with the segment_volume function, PixelSize must be provided in the 'options' argument.
-        * PixelSize definition in example dataset is a scalar in micrometers (BIDS BEP031 v0.0.2)
-        * PixelSize definition changed for list of 2-numbers [PixelSizeX, PixelSizeY]
-          or 3-numbers [PixelSizeX, PixelSizeY, PixelSizeZ] in micrometers for 2D and 3D respectively,
-          where X is the width, Y the height and Z the depth of the image (BIDS BEP031 v0.0.4).
-        * Both PixelSize definitions are supported in this function.
-        * In BIDS BEP031 v0.0.5, a separate field PixelSizeUnits is used to describe the unit pf PixelSize. The only
-          accepted value is "um" but could be expand in the future. This function assumes that the unit is micrometers.
+        * The function supports the PixelSize definition of BIDS BEP031 v0.0.4 as a list of 2-numbers
+          [PixelSizeX, PixelSizeY] or 3-numbers [PixelSizeX, PixelSizeY, PixelSizeZ] in micrometers for 2D and 3D
+          respectively, where X is the width, Y the height and Z the depth of the image.
+        * The function also supports the previous definition of PixelSize as a float (BIDS BEP031 v0.0.2).
+        * In the future BIDS BEP031 v0.0.5 version, a separate field PixelSizeUnits will be used to describe the unit
+          of PixelSize. The only accepted value will be "um" but could be expand in the future.
 
         Returns:
             ndrray: Pixel size in millimeters in order (PixelSizeY, PixelSizeX, PixelSizeZ), where Y is the height,

--- a/ivadomed/scripts/download_data.py
+++ b/ivadomed/scripts/download_data.py
@@ -22,7 +22,7 @@ DICT_URL = {
             `Spine Generic <https://github.com/spine-generic/data-multi-subject>`_.
             Used for Tutorial and example in Ivadomed."""},
     "data_testing": {
-        "url": ["https://github.com/ivadomed/data-testing/archive/r20210628.zip"],
+        "url": ["https://github.com/ivadomed/data-testing/archive/r20210823.zip"],
         "description": "Data Used for integration/unit test in Ivadomed."},
     "t2_tumor": {
         "url": ["https://github.com/ivadomed/t2_tumor/archive/r20200621.zip"],

--- a/testing/unit_tests/test_loader.py
+++ b/testing/unit_tests/test_loader.py
@@ -195,20 +195,21 @@ def test_load_dataset_2d_png(download_data_testing_test_files,
     "bn_momentum": 0.1,
     "final_activation": "sigmoid",
     "depth": 3,
-    "length_2D": [256, 256],
-    "stride_2D": [244, 244]
+    "length_2D": [256, 128],
+    "stride_2D": [244, 116]
     }])
 @pytest.mark.parametrize('transform_parameters', [{
     "Resample": {
-        "wspace": 0.0001,
+        "wspace": 0.0002,
         "hspace": 0.0001
     },
     "NumpyToTensor": {},
     }])
-def test_2d_patches(download_data_testing_test_files,
-                    loader_parameters, model_parameters, transform_parameters):
+def test_2d_patches_and_resampling(download_data_testing_test_files,
+                                   loader_parameters, model_parameters, transform_parameters):
     """
-    Test to make sure load_dataset runs with 2D PNG data.
+    Test that 2d patching is done properly.
+    Test that microscopy pixelsize and resampling are applied on the right dimensions.
     """
     loader_parameters.update({"model_params": model_parameters})
     bids_df = imed_loader_utils.BidsDataframe(loader_parameters, __tmp_dir__, derivatives=True)
@@ -218,8 +219,9 @@ def test_2d_patches(download_data_testing_test_files,
                                                              'transforms_params': transform_parameters,
                                                              'dataset_type': 'training'}})
     assert ds.is_2d_patch == True
-    assert ds[0]['input'].shape == (1, 256, 256)
-    assert len(ds) == 16
+    assert ds[0]['input'].shape == (1, 256, 128)
+    assert ds[0]['input_metadata'][0].metadata['index_shape'] == (1512, 382)
+    assert len(ds) == 28
 
 
 @pytest.mark.parametrize('loader_parameters', [{


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR fixes the microscopy loader where the pixel size height and width order were not in the right order.

- The pixel size metadata from BIDS is in order `[PixelSizeX, PixelSizeY, PixelSizeZ]` where X is the width of the image, Y the height and Z the depth. In ivadomed, with the slice axis "axial" that we use for microscopy, the images are `hwd_oriented` [Height, Width, Depth].
- In `segmentation_pair.py`, I created a separate `get_microscopy_pixelsize` function outside of `convert_file_to_nifti` to deal with operations on the pixel size (they could still change in the future due to the progress of the microscopy BEP031). This function now re-order the pixel size to `[PixelSizeY, PixelSizeX, PixelSizeZ]` before they are written in the temporary NIFTI file with set_zooms.
- In `inference.py/segment_volume`, I updated the description of `overlap_2D` to explicit the orientation of the option `[OverlapX, OverlapY]`, later swapped to `[OverlapY, OverlapX]` to match `length_2D` an `stride_2D` [Height, Width] orientation.
- I added a test in the loader to make sure pixel size and resampling are applied on the right dimensions, ~~The test won't pass for now because the data-testing dataset has to be updated first [here](https://github.com/ivadomed/data-testing/pull/15), hence the draft PR.~~ EDIT: and updated the [data-testing](https://github.com/ivadomed/data-testing/releases/tag/r20210823) dataset accordingly.

## Linked issues
Fixes #907 
