### PR TITLE
Fix training_curve.py output

### DIFF
--- a/ivadomed/scripts/training_curve.py
+++ b/ivadomed/scripts/training_curve.py
@@ -48,19 +48,9 @@ def get_events_path_list(input_folder, learning_rate):
     Args:
         input_folder (str): Input folder path.
     Returns:
-        list : a sorted list of events paths
+        list : a list of events paths
     """
     events_path_list = []
-
-    if learning_rate:
-    # Check for events file at the root of input_folder
-        event_list = [f.name for f in Path(input_folder).iterdir() if f.name.startswith("events.out.tfevents.")]
-        if len(event_list):
-            if len(event_list) > 1:
-                raise ValueError(f"Multiple summary found in this folder: {Path(input_folder)}.\n"
-                                 f"Please keep only one before running this script again.")
-            else:
-                events_path_list.append(Path(input_folder))
 
     # Check for events file in sub-folders
     for fold_path in Path(input_folder).iterdir():
@@ -72,8 +62,21 @@ def get_events_path_list(input_folder, learning_rate):
                                      f"Please keep only one before running this script again.")
                 else:
                     events_path_list.append(fold_path)
+    # Sort events_path_list alphabetically
+    events_path_list = sorted(events_path_list)
 
-    return sorted(events_path_list)
+    if learning_rate:
+    # Check for events file at the root of input_folder (contains learning_rate)
+        event_list = [f.name for f in Path(input_folder).iterdir() if f.name.startswith("events.out.tfevents.")]
+        if len(event_list):
+            if len(event_list) > 1:
+                raise ValueError(f"Multiple summary found in this folder: {Path(input_folder)}.\n"
+                                 f"Please keep only one before running this script again.")
+            else:
+                # Append learning_rate events file at the end of event_path_list
+                events_path_list.append(Path(input_folder))
+
+    return events_path_list
 
 
 def plot_curve(data_list, y_label, fig_ax, subplot_title, y_lim=None):

--- a/ivadomed/scripts/training_curve.py
+++ b/ivadomed/scripts/training_curve.py
@@ -209,16 +209,20 @@ def tensorboard_retrieve_event(events_path_list):
         df: a panda dataframe where the columns are the metric or loss and the row are the epochs.
 
     """
-    # TODO : Find a way to not hardcode this list of metrics/loss
-    # These list of metrics and losses are in the same order as in the training file (where they are written)
-    list_metrics = ['dice_score', 'multiclass dice_score', 'hausdorff_score', 'precision_score',
-                    'recall_score', 'specificity_score', 'intersection_over_union', 'accuracy_score']
-
-    list_loss = ['train_loss', 'validation_loss']
+    # Lists of metrics and losses in the same order as in events_path_list
+    list_metrics = []
+    list_loss = []
+    for events in events_path_list:
+        if str(events.name).startswith("Validation_Metrics_"):
+            metric_name = str(events.name.split("Validation_Metrics_")[1])
+            list_metrics.append(metric_name)
+        elif str(events.name).startswith("losses_"):
+            loss_name = str(events.name.split("losses_")[1])
+            list_loss.append(loss_name)
 
     # Each element in the summary iterator represent an element (e.g., scalars, images..)
-    # stored in the summary for all epochs in the form of event.
-    summary_iterators = [EventAccumulator(str(dname)).Reload() for dname in Path(path_output).iterdir()]
+    # stored in the summary for all epochs in the form of event, in the same order as in events_path_list.
+    summary_iterators = [EventAccumulator(str(events)).Reload() for events in events_path_list]
 
     metrics = defaultdict(list)
     num_metrics = 0

--- a/ivadomed/scripts/training_curve.py
+++ b/ivadomed/scripts/training_curve.py
@@ -28,7 +28,8 @@ def get_parser():
                         help="""Indicates the limits on the y-axis for the loss plots, otherwise
                                 these limits are automatically defined. Please separate the lower
                                 and the upper limit by a comma, e.g. -1,0. Note: for the validation
-                                metrics: the y-limits are always 0.0 and 1.0.""",
+                                metrics: the y-limits are always 0.0 and 1.0 except for the hausdorff
+                                score where the limits are automatically defined.""",
                         metavar=imed_utils.Metavar.float)
     parser.add_argument("-o", "--output", required=True, type=str,
                         help="Output folder.", metavar=imed_utils.Metavar.file)
@@ -131,7 +132,10 @@ def run_plot_training_curves(input_folder, output_folder, multiple_training=Fals
             or not (``False``). Flag: ``--multiple``. All available folders with ``-i`` as prefix
             are considered. The plot represents the mean value (hard line) surrounded by the
             standard deviation (envelope).
-        y_lim_loss (list): List of the lower and upper limits of the y-axis of the loss plot.
+        y_lim_loss (list): List of the lower and upper limits of the y-axis of the loss plot, otherwise
+            these limits are automatically defined. Please separate the lower and the upper limit by a
+            comma, e.g. -1,0. Note: for the validation metrics: the y-limits are always 0.0 and 1.0 except
+            for the hausdorff score where the limits are automatically defined.
     """
     group_list = input_folder.split(",")
     plt_dict = {}
@@ -190,11 +194,12 @@ def run_plot_training_curves(input_folder, output_folder, multiple_training=Fals
                 if i_subplot == 0:  # Init plot
                     plt_dict[str(Path(output_folder, tag + ".png"))] = plt.figure(figsize=(10 * n_cols, 5 * n_rows))
                 ax = plt_dict[str(Path(output_folder, tag + ".png"))].add_subplot(n_rows, n_cols, i_subplot + 1)
+                y_lim = None if tag.startswith("hausdorff") else [0, 1]
                 plot_curve(data_list=[df[[tag]] for df in events_df_list],
                            y_label=tag,
                            fig_ax=ax,
                            subplot_title=prefix,
-                           y_lim=[0, 1])
+                           y_lim=y_lim)
 
     for fname_out in plt_dict:
         plt_dict[fname_out].savefig(fname_out)

--- a/ivadomed/scripts/training_curve.py
+++ b/ivadomed/scripts/training_curve.py
@@ -74,7 +74,7 @@ def get_events_path_list(input_folder, learning_rate):
                 raise ValueError(f"Multiple summary found in this folder: {Path(input_folder)}.\n"
                                  f"Please keep only one before running this script again.")
             else:
-                # Append learning_rate events file at the end of event_path_list
+                # Append learning_rate events file at the end of events_path_list
                 events_path_list.append(Path(input_folder))
 
     return events_path_list
@@ -122,7 +122,7 @@ def run_plot_training_curves(input_folder, output_folder, multiple_training=Fals
 
         - the training against the validation loss,
         - the metrics computed on the validation sub-dataset,
-        - the learning rate if the option --lr is selected.
+        - the learning rate if learning_rate is True.
 
     It could consider one output path at a time, for example:
 

--- a/ivadomed/scripts/training_curve.py
+++ b/ivadomed/scripts/training_curve.py
@@ -197,7 +197,7 @@ def run_plot_training_curves(input_folder, output_folder, multiple_training=Fals
 
             # Get data as dataframe and save as .csv file
             events_vals_df = tensorboard_retrieve_event(events_path_list)
-            events_vals_df.to_csv(output_folder + str(path_output.name) + "_training_values.csv")
+            events_vals_df.to_csv(Path(output_folder, str(path_output.name) + "_training_values.csv"))
 
             # Store data
             events_df_list.append(events_vals_df)

--- a/ivadomed/scripts/training_curve.py
+++ b/ivadomed/scripts/training_curve.py
@@ -48,6 +48,17 @@ def get_events_path_list(input_folder):
         list : a sorted list of events paths
     """
     events_path_list = []
+
+    # Check for events file at the root of input_folder
+    event_list = [f.name for f in Path(input_folder).iterdir() if f.name.startswith("events.out.tfevents.")]
+    if len(event_list):
+        if len(event_list) > 1:
+            raise ValueError(f"Multiple summary found in this folder: {Path(input_folder)}.\n"
+                             f"Please keep only one before running this script again.")
+        else:
+            events_path_list.append(Path(input_folder))
+
+    # Check for events file in sub-folders
     for fold_path in Path(input_folder).iterdir():
         if fold_path.is_dir():
             event_list = [f.name for f in fold_path.iterdir() if f.name.startswith("events.out.tfevents.")]
@@ -57,6 +68,7 @@ def get_events_path_list(input_folder):
                                      f"Please keep only one before running this script again.")
                 else:
                     events_path_list.append(fold_path)
+
     return sorted(events_path_list)
 
 

--- a/ivadomed/scripts/training_curve.py
+++ b/ivadomed/scripts/training_curve.py
@@ -167,7 +167,7 @@ def run_plot_training_curves(input_folder, output_folder, multiple_training=Fals
             events_path_list = get_events_path_list(str(path_output))
 
             # Get data as dataframe
-            events_vals_df = tensorboard_retrieve_event(str(path_output))
+            events_vals_df = tensorboard_retrieve_event(events_path_list)
 
             # Store data
             events_df_list.append(events_vals_df)
@@ -199,11 +199,11 @@ def run_plot_training_curves(input_folder, output_folder, multiple_training=Fals
         plt_dict[fname_out].savefig(fname_out)
 
 
-def tensorboard_retrieve_event(path_output):
+def tensorboard_retrieve_event(events_path_list):
     """Retrieve data from tensorboard summary event.
 
     Args:
-        path_output (str): output path where the event files are located
+        events_path_list (list): list of events paths
 
     Returns:
         df: a panda dataframe where the columns are the metric or loss and the row are the epochs.

--- a/ivadomed/scripts/training_curve.py
+++ b/ivadomed/scripts/training_curve.py
@@ -35,13 +35,16 @@ def get_parser():
     return parser
 
 
-def check_events_numbers(input_folder):
-    """Check to make sure there is at most one summary in any folder or any subfolder.
+def get_events_path_list(input_folder):
+    """Check to make sure there is at most one summary event in any folder or any subfolder,
+    and returns a list of summary event paths.
 
     A summary is defined as any file of the format ``events.out.tfevents.{...}```
 
     Args:
         input_folder (str): Input folder path.
+    Returns:
+        list : a sorted list of events paths
     """
     for fold_path in Path(input_folder).iterdir():
         if fold_path.is_dir():
@@ -50,6 +53,9 @@ def check_events_numbers(input_folder):
                 if len(event_list) > 1:
                     raise ValueError(f"Multiple summary found in this folder: {fold_path}.\n"
                                      f"Please keep only one before running this script again.")
+                else:
+                    events_path_list.append(fold_path)
+    return sorted(events_path_list)
 
 
 def plot_curve(data_list, y_label, fig_ax, subplot_title, y_lim=None):
@@ -158,7 +164,7 @@ def run_plot_training_curves(input_folder, output_folder, multiple_training=Fals
         events_df_list = []
         for path_output in input_folder_list:
             # Find tf folders
-            check_events_numbers(str(path_output))
+            events_path_list = get_events_path_list(str(path_output))
 
             # Get data as dataframe
             events_vals_df = tensorboard_retrieve_event(str(path_output))

--- a/ivadomed/scripts/training_curve.py
+++ b/ivadomed/scripts/training_curve.py
@@ -15,10 +15,10 @@ def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("-i", "--input", required=True, type=str,
                         help="""Input path. If using --multiple, this parameter indicates
-                                the suffix path of all log directories of interest. To compare
-                                trainings or set of trainings (using ``--multiple``) with subplots,
-                                please list the paths by separating them with commas, e.g.
-                                path_output1,path_output2.""",
+                                the prefix path of all log directories of interest. To compare
+                                trainings (not using ``--multiple``) or set of trainings
+                                (using ``--multiple``) with subplots, please list the paths by separating
+                                them with commas, e.g. path_output1,path_output2.""",
                         metavar=imed_utils.Metavar.str)
     parser.add_argument("--multiple", required=False, dest="multiple", action='store_true',
                         help="""Multiple log directories are considered: all available folders
@@ -124,9 +124,9 @@ def run_plot_training_curves(input_folder, output_folder, multiple_training=Fals
 
     Args:
         input_folder (str): Input path name. Flag: ``--input``, ``-i``. If using ``--multiple``,
-            this parameter indicates the suffix path of all log directories of interest. To compare
-            trainings or set of trainings (using ``--multiple``) with subplots, please list the
-            paths by separating them with commas, e.g. path_output1, path_output2
+            this parameter indicates the prefix path of all log directories of interest. To compare
+            trainings (not using ``--multiple``) or set of trainings (using ``--multiple``) with subplots,
+            please list the paths by separating them with commas, e.g. path_output1, path_output2
         output_folder (str): Output folder. Flag: ``--output``, ``-o``.
         multiple_training (bool): Indicates if multiple log directories are considered (``True``)
             or not (``False``). Flag: ``--multiple``. All available folders with ``-i`` as prefix

--- a/ivadomed/scripts/training_curve.py
+++ b/ivadomed/scripts/training_curve.py
@@ -95,7 +95,7 @@ def plot_curve(data_list, y_label, fig_ax, subplot_title, y_lim=None):
 
 
 def run_plot_training_curves(input_folder, output_folder, multiple_training=False, y_lim_loss=None):
-    """Utility function to plot the training curves.
+    """Utility function to plot the training curves and save data as .csv files.
 
     This function uses the TensorFlow summary that is generated during a training to plot for each epoch:
 
@@ -171,8 +171,9 @@ def run_plot_training_curves(input_folder, output_folder, multiple_training=Fals
             # Find tf folders
             events_path_list = get_events_path_list(str(path_output))
 
-            # Get data as dataframe
+            # Get data as dataframe and save as .csv file
             events_vals_df = tensorboard_retrieve_event(events_path_list)
+            events_vals_df.to_csv(output_folder + str(path_output.name) + "_training_values.csv")
 
             # Store data
             events_df_list.append(events_vals_df)

--- a/ivadomed/scripts/training_curve.py
+++ b/ivadomed/scripts/training_curve.py
@@ -47,6 +47,7 @@ def get_events_path_list(input_folder, learning_rate):
 
     Args:
         input_folder (str): Input folder path.
+        learning_rate (bool): Indicate if learning_rate is considered.
     Returns:
         list : a list of events paths
     """
@@ -212,7 +213,7 @@ def run_plot_training_curves(input_folder, output_folder, multiple_training=Fals
                    subplot_title=prefix,
                    y_lim=y_lim_loss)
 
-        # Plot each validation metric separetly
+        # Plot each validation metric and learning rate separately
         for tag in events_df_list[0].keys():
             if not tag.endswith("loss"):
                 if i_subplot == 0:  # Init plot

--- a/ivadomed/scripts/training_curve.py
+++ b/ivadomed/scripts/training_curve.py
@@ -46,6 +46,7 @@ def get_events_path_list(input_folder):
     Returns:
         list : a sorted list of events paths
     """
+    events_path_list = []
     for fold_path in Path(input_folder).iterdir():
         if fold_path.is_dir():
             event_list = [f.name for f in fold_path.iterdir() if f.name.startswith("events.out.tfevents.")]

--- a/testing/functional_tests/test_training_curve.py
+++ b/testing/functional_tests/test_training_curve.py
@@ -22,10 +22,11 @@ def test_training_curve(download_functional_test_files):
     assert os.path.exists(os.path.join(__output_dir__, "hausdorff_score.png"))
     assert os.path.exists(os.path.join(__output_dir__, "intersection_over_union.png"))
     assert os.path.exists(os.path.join(__output_dir__, "losses.png"))
-    assert os.path.exists(os.path.join(__output_dir__, "multiclass dice_score.png"))
+    assert os.path.exists(os.path.join(__output_dir__, "multi_class_dice_score.png"))
     assert os.path.exists(os.path.join(__output_dir__, "precision_score.png"))
     assert os.path.exists(os.path.join(__output_dir__, "recall_score.png"))
     assert os.path.exists(os.path.join(__output_dir__, "specificity_score.png"))
+    assert os.path.exists(os.path.join(__output_dir__, "tensorboard_events_training_values.csv"))
 
 
 def teardown_function():


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR fixes #915 where there were mismatches between the PNG titles and the plot's content. This was due to the order of the `iterdir` listing (responsible for the order of `EventAccumulator`) being different from one machine to another, and different than the hardcoded metrics and losses lists order.

**Fixes:**
- The function `check_event_number` was renamed `get_events_path_list` and now returns a list of events path in alphabetical order. This order is then used to compile the lists of metrics and losses and used by the EventAccumulator (there are no hardcoded lists to maintain anymore).
- The `y_limits` were `[0, 1]` on each metrics plots. This was not suitable for `hausdorff score` with values ~10 (on my models). The `y_limits` are now automatically defined for the `hausdorff score`, the `y_limits` for others metrics remain `[0, 1]`.
- Updates/clarifications on comments and docstrings.

**New features:**
- In addition to plotting the training curves, the scripts now also saves data as a `csv` file for each model considered.
- A new option/argument `--lr` allows to plot the `learning_rate` in addition to losses and metrics. This is optional because:
    - learning_rate may not be necessary for the user and is likely to be the same across multiple trainings with the `--multiple` option.
    - learning_rate data is in the "main" events file at the root of the input_folder. This file can take ~2 minutes to load which could be cumbersome with option `--multiple` or several input_folders (`-i`).
- The `y_limits` of the `learning_rate` plot are automatically defined.
- For consistency, the `learning_rate` column in the `csv` file is appended at the end (last column), so the first 10 columns (metrics and losses) are always in the same order, with or without the `--lr` option.

## Linked issues
Fixes #915 
