### PR TITLE
Fix undo_transforms in image reconstruction

### DIFF
--- a/ivadomed/inference.py
+++ b/ivadomed/inference.py
@@ -629,12 +629,13 @@ def image_reconstruction(batch: dict, pred: tensor, undo_transforms: UndoCompose
         weight_matrix (tensor): Weights containing the number of predictions for each pixel
 
     Returns:
-        pred_undo (tensor): undone patch,
-        metadata (dict): metadata,
-        last_sample_bool (bool): boolean representing if its the last patch of the image
+        pred_undo (tensor): undone image
+        metadata (dict): metadata
+        last_patch_bool (bool): boolean representing if its the last patch of the image
         image (tensor): representing the image reconstructed
         weight_matrix (tensor): weight matrix
     """
+    pred_undo, metadata = None, None
     x_min, x_max, y_min, y_max = batch['input_metadata'][smp_idx][0]['coord']
     num_pred = pred[smp_idx].shape[0]
 
@@ -657,6 +658,6 @@ def image_reconstruction(batch: dict, pred: tensor, undo_transforms: UndoCompose
     weight_matrix[:, x_min:x_max, y_min:y_max] += 1
     if last_patch_bool:
         image /= weight_matrix
+        pred_undo, metadata = undo_transforms(image, batch['gt_metadata'][smp_idx], data_type='gt')
 
-    pred_undo, metadata = undo_transforms(image, batch['gt_metadata'][smp_idx], data_type='gt')
     return pred_undo, metadata, last_patch_bool, image, weight_matrix


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR fixes an issue where the `undo_transforms` function in `inference.py/image_reconstruction` was applied on each patch of an image instead of only once on the complete reconstructed image (when running inference i.e. `test` and `segment` command).

For a microscopy image of ~8000x6000 pixels, it reduces the segmentation time from ~50 minutes to ~6 minutes!
6 minutes is still a lot, further investigation is needed, for which I will open a dedicated issue shortly.

Also, the same bug is present with `sub-volumes` in `volume_reconstruction`, for which I'll open a separate PR.

## Linked issues
There is no open issue regarding this bug.