### PR TITLE
Fix undo_transforms in volume reconstruction

### DIFF
--- a/ivadomed/inference.py
+++ b/ivadomed/inference.py
@@ -528,7 +528,8 @@ def reconstruct_3d_object(context: dict, batch: dict, undo_transforms: UndoCompo
         if kernel_3D:
             preds_undo, metadata, last_sample_bool, volume, weight_matrix = \
                 volume_reconstruction(batch, preds, undo_transforms, i_slice, volume, weight_matrix)
-            preds_list = [np.array(preds_undo)]
+            if last_sample_bool:
+                preds_list = [np.array(preds_undo)]
         else:
             if is_2d_patch:
                 # undo transformations for patch and reconstruct slice
@@ -587,6 +588,7 @@ def volume_reconstruction(batch: dict, pred: tensor, undo_transforms: UndoCompos
         volume (tensor): representing the volume reconstructed
         weight_matrix (tensor): weight matrix
     """
+    pred_undo, metadata = None, None
     x_min, x_max, y_min, y_max, z_min, z_max = batch['input_metadata'][smp_idx][0]['coord']
     num_pred = pred[smp_idx].shape[0]
 
@@ -610,10 +612,9 @@ def volume_reconstruction(batch: dict, pred: tensor, undo_transforms: UndoCompos
 
     if last_sample_bool:
         volume /= weight_matrix
-
-    pred_undo, metadata = undo_transforms(volume,
-                                          batch['gt_metadata'][smp_idx],
-                                          data_type='gt')
+        pred_undo, metadata = undo_transforms(volume,
+                                              batch['gt_metadata'][smp_idx],
+                                              data_type='gt')
     return pred_undo, metadata, last_sample_bool, volume, weight_matrix
 
 

--- a/ivadomed/inference.py
+++ b/ivadomed/inference.py
@@ -413,7 +413,8 @@ def segment_volume(folder_model: str, fname_images: list, gpu_id: int = 0, optio
         ds = MRI3DSubVolumeSegmentationDataset(filename_pairs,
                                                transform=tranform_lst,
                                                length=context["Modified3DUNet"]["length_3D"],
-                                               stride=context["Modified3DUNet"]["stride_3D"])
+                                               stride=context["Modified3DUNet"]["stride_3D"],
+                                               slice_axis=slice_axis)
         logger.info(f"Loaded {len(ds)} {loader_params['slice_axis']} volumes of shape "
                      f"{context['Modified3DUNet']['length_3D']}.")
     else:

--- a/ivadomed/testing.py
+++ b/ivadomed/testing.py
@@ -272,10 +272,10 @@ def run_inference(test_loader, model, model_params, testing_params, ofolder, cud
                                                      preds_cpu,
                                                      testing_params['undo_transforms'],
                                                      smp_idx, volume, weight_matrix)
-                fname_ref = metadata[0]['gt_filenames'][0]
                 # Indicator of last batch
                 if last_sample_bool:
                     pred_undo = np.array(pred_undo)
+                    fname_ref = metadata[0]['gt_filenames'][0]
                     if ofolder:
                         fname_pred = str(Path(ofolder, Path(fname_ref).name))
                         fname_pred = fname_pred.split(testing_params['target_suffix'][0])[0] + '_pred.nii.gz'


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR fixes an issue where the `undo_transforms` function in `inference.py/volume_reconstruction` was applied on each sub-volume instead of only once on the complete reconstructed volume (when running inference i.e. `test` and `segment` command).

This is the same fix as for `image_reconstruction` in PR #956 and should speed-up the segmentation process.

In addition, I added the `slice_axis` argument in the call of `MRI3DSubVolumeSegmentationDataset` in `segment_volume.py`. The argument was absent and set to `0` (`sagittal`) by default. Passing the `slice_axis` argument is the only way I found to be able to run `--segment` on a trained model, otherwise it would fail with wrong dimensions.
Let me know if that change makes sense as I have no experience with 3DUnet and segmentation. Thanks!

## Linked issues
There is no open issue regarding this bug.
