### PR TITLE
Fix GeneralizedDiceLoss with `include_background=true` and `batch_size > 1` 

### DIFF
--- a/ivadomed/losses.py
+++ b/ivadomed/losses.py
@@ -198,8 +198,8 @@ class GeneralizedDiceLoss(nn.Module):
             input_background = torch.zeros(size_background, dtype=input.dtype)
             target_background = torch.zeros(size_background, dtype=target.dtype)
             # fill with opposite
-            input_background[input.sum(1).expand_as(input_background) == 0] = 1
-            target_background[target.sum(1).expand_as(input_background) == 0] = 1
+            input_background[input.sum(1)[:, None, :, :] == 0] = 1
+            target_background[target.sum(1)[:, None, :, :] == 0] = 1
             # Concat
             input = torch.cat([input, input_background.to(input.device)], dim=1)
             target = torch.cat([target, target_background.to(target.device)], dim=1)

--- a/ivadomed/losses.py
+++ b/ivadomed/losses.py
@@ -176,11 +176,11 @@ class GeneralizedDiceLoss(nn.Module):
 
     Args:
         epsilon (float): Epsilon to avoid division by zero.
-        include_background (float): If True, then an extra channel is added, which represents the background class.
+        include_background (bool): If True, then an extra channel is added, which represents the background class.
 
     Attributes:
         epsilon (float): Epsilon to avoid division by zero.
-        include_background (float): If True, then an extra channel is added, which represents the background class.
+        include_background (bool): If True, then an extra channel is added, which represents the background class.
     """
 
     def __init__(self, epsilon=1e-5, include_background=True):


### PR DESCRIPTION
## Checklist

#### GitHub
- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents
- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR fixes a bug where `GeneralizedDiceLoss` would not work with `include_background=true` and `batch_size > 1`. Details in issue #960.

