### PR TITLE
Implement CrossEntropyLoss

### DIFF
--- a/ivadomed/training.py
+++ b/ivadomed/training.py
@@ -416,8 +416,8 @@ def get_loss_function(params):
 
     # Check if implemented
     loss_function_available = ["DiceLoss", "FocalLoss", "GeneralizedDiceLoss", "FocalDiceLoss", "MultiClassDiceLoss",
-                               "BinaryCrossEntropyLoss", "TverskyLoss", "FocalTverskyLoss", "AdapWingLoss", "L2loss",
-                               "LossCombination"]
+                               "BinaryCrossEntropyLoss", "CrossEntropyLoss", "TverskyLoss", "FocalTverskyLoss",
+                               "AdapWingLoss", "L2loss", "LossCombination"]
     if loss_name not in loss_function_available:
         raise ValueError(
             "Unknown Loss function: {}, please choose between {}".format(loss_name, loss_function_available))


### PR DESCRIPTION
## Checklist

#### GitHub
- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've assigned a reviewer

#### PR contents
- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR aims to implement `CrossEntropyLoss`.
I implemented it and it works great on axon/myelin segmentation task. However, while reviewing my work, I think there is a mistake in the implementation and I would like to discuss it further, hence the draft PR.

So [CrossEntropyLoss](https://pytorch.org/docs/stable/generated/torch.nn.CrossEntropyLoss.html) is a combination of `LogSoftmax` and `NLLLoss` in one single class.
This brings 3 points:

1) I think it means that the final activation of the model should be a `LogSoftmax` (instead of `sigmoid` I am using), and the output of the model in `LogSoftmax` should be fed to the `NLLLoss` directly instead of `CrossEntropyLoss`.

Other options would be to use `Softmax` as the final activation of the model and a `log()` before `NLLLoss`, or to skip the final activation and go directly to `CrossEntropyLoss`.

2) In my current implementation, I have an option to add the background class in the same way as it is done in `GeneralizedDiceLoss`. However, I don't think it makes sense for `CrossEntropyLoss` to not have the background included.

3) Because of the previous point, I think we should keep the background class from the output predictions of the model for `CrossEntropyLoss`. Currently, the background class is removed from the model predictions in the decoder [here](https://github.com/ivadomed/ivadomed/blob/ac29c7cbe299e6478854823ed6bd818c0e5f9642/ivadomed/models.py#L465).

Please let me know if you have more insights on this. Thanks!
