### PR TITLE
Pin PyParsing version to be compatible with pip 20

### DIFF
--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -1,3 +1,5 @@
+# workarounds for pip 20.0.2's buggy dependency resolver, which doesn't account for cross-package constraints
+pyparsing<3,>=2.0.2
 csv-diff>=1.0
 h5py==2.10.0 ; python_version < '3.9'
 h5py==3.2.1 ; python_version == '3.9'

--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -1,4 +1,9 @@
-# workarounds for pip 20.0.2's buggy dependency resolver, which doesn't account for cross-package constraints
+# workarounds for pip 20.0.2's buggy dependency resolver
+# which doesn't account for cross-package constraints: https://pip.pypa.io/en/stable/user_guide/#changes-to-the-pip-dependency-resolver-in-20-3-2020
+# matplotlib pulls in the latest pyparsing, nibabel pulls in the latest packaging, and the two latests are in conflict.
+# > ERROR: packaging 21.2 has requirement pyparsing<3,>=2.0.2, but you'll have pyparsing 3.0.5 which is incompatible.
+# This forces the older pip, if the user has the older pip, to behave itself.
+# This is to specially support users on Ubuntu 20.04 LTS; when Ubuntu 22.04 LTS comes out, this can be removed.
 pyparsing<3,>=2.0.2
 csv-diff>=1.0
 h5py==2.10.0 ; python_version < '3.9'


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [X] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

When testing `ivadomed` on Romane and other super computing clusters with pip 20, we ran into error that prevent scripts from being launched. See details at https://github.com/neuropoly/computers/issues/218
TLDR: pyparsing version conflict cause issue with registering binary commands such as `ivaodmed_download`

Note that this issue is not reproducible in CI which typically has updated PIP version. It only shows up when PIP version is at 20

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Resovles https://github.com/neuropoly/computers/issues/218