### PR TITLE
Add forced indexation of "micr" datatype

### DIFF
--- a/ivadomed/config/config_bids.json
+++ b/ivadomed/config/config_bids.json
@@ -99,7 +99,7 @@
         },
         {
             "name": "datatype",
-            "pattern": "[/\\\\]+(anat|beh|dwi|eeg|fmap|func|ieeg|meg|perf|microscopy|ct)[/\\\\]+"
+            "pattern": "[/\\\\]+(anat|beh|dwi|eeg|fmap|func|ieeg|meg|perf|micr|microscopy|ct)[/\\\\]+"
         },
         {
             "name": "extension",

--- a/ivadomed/loader/bids_dataframe.py
+++ b/ivadomed/loader/bids_dataframe.py
@@ -94,8 +94,8 @@ class BidsDataframe:
                     subject_path = path_object.parts[subject_path_index]
                     if path_object.name == "samples.tsv" or path_object.name == "samples.json":
                         force_index.append(path_object.name)
-                    if (path_object.name.endswith(ext_microscopy) and path_object.parent.name == "microscopy" and
-                            subject_path.startswith('sub')):
+                    if (path_object.name.endswith(ext_microscopy) and (path_object.parent.name == "microscopy" or
+                            path_object.parent.name == "micr") and subject_path.startswith('sub')):
                         force_index.append(str(Path(*path_object.parent.parts[subject_path_index:])))
                     # CT-scan
                     if (path_object.name.endswith(ext_ct) and path_object.name.split('.')[0].endswith(suffix_ct) and


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
There was a significant change in the folder structure of the BIDS microscopy BEP following the community review.
The datatype "microscopy" is now abbreviated to "micr" (equivalent of "anat" in MRI).

This PR adds “micr” in addition to “microscopy” in the "force-index" feature of the ivadomed bids_dataframe function.
Temporarily with this PR, both "micr" and "microscopy" will be indexed. Therefore, the indexation of new datasets with "micr" and "old" datasets with "microscopy" will still work.

After the BEP is merged in BIDS, I plan to switch to "micr" only, for which I will have to updated all our microscopy datasets and ivadomed testing data.

## Linked issues
There are not related issue.
