### PR TITLE
Aea/input dropout params

### DIFF
--- a/ivadomed/config/config.json
+++ b/ivadomed/config/config.json
@@ -28,7 +28,9 @@
         },
         "slice_axis": "axial",
         "multichannel": false,
-        "soft_gt": false
+        "soft_gt": false,
+        "is_input_dropout": false,
+        "input_dropout_params": [0.5, 0.5, 0.5]
     },
     "split_dataset": {
         "fname_split": null,

--- a/ivadomed/config/config_default.json
+++ b/ivadomed/config/config_default.json
@@ -30,7 +30,8 @@
         "slice_axis": "axial",
         "multichannel": false,
         "soft_gt": false,
-        "is_input_dropout": false
+        "is_input_dropout": false,
+        "input_dropout_params": [0.5, 0.5, 0.5]
     },
     "split_dataset": {
         "fname_split": null,

--- a/ivadomed/keywords.py
+++ b/ivadomed/keywords.py
@@ -41,6 +41,7 @@ class LoaderParamsKW:
     MODEL_PARAMS = "model_params"
     SLICE_AXIS = "slice_axis"
     IS_INPUT_DROPOUT = "is_input_dropout"
+    INPUT_DROPOUT_PARAMS = "input_dropout_params"
     SLICE_FILTER_PARAMS = "slice_filter_params"
 
 

--- a/ivadomed/loader/bids3d_dataset.py
+++ b/ivadomed/loader/bids3d_dataset.py
@@ -22,12 +22,13 @@ class Bids3DDataset(MRI3DSubVolumeSegmentationDataset):
             contrast is processed individually (ie different sample / tensor).
         object_detection_params (dict): Object dection parameters.
         is_input_dropout (bool): Return input with missing modalities.
+        input_dropout_params (list): Dropout parameters.
     """
 
     def __init__(self, bids_df, subject_file_lst, target_suffix, model_params, contrast_params, slice_axis=2,
                  cache=True, transform=None, metadata_choice=False, roi_params=None,
                  multichannel=False, object_detection_params=None, task="segmentation", soft_gt=False,
-                 is_input_dropout=False):
+                 is_input_dropout=False, input_dropout_params=[0.5, 0.5, 0.5]):
         dataset = BidsDataset(bids_df=bids_df,
                               subject_file_lst=subject_file_lst,
                               target_suffix=target_suffix,
@@ -39,9 +40,10 @@ class Bids3DDataset(MRI3DSubVolumeSegmentationDataset):
                               transform=transform,
                               multichannel=multichannel,
                               object_detection_params=object_detection_params,
-                              is_input_dropout=is_input_dropout)
+                              is_input_dropout=is_input_dropout
+                              input_dropout_params=input_dropout_params)
 
         super().__init__(dataset.filename_pairs, length=model_params[ModelParamsKW.LENGTH_3D],
                          stride=model_params[ModelParamsKW.STRIDE_3D],
                          transform=transform, slice_axis=slice_axis, task=task, soft_gt=soft_gt,
-                         is_input_dropout=is_input_dropout)
+                         is_input_dropout=is_input_dropout, input_dropout_params=input_dropout_params)

--- a/ivadomed/loader/bids_dataset.py
+++ b/ivadomed/loader/bids_dataset.py
@@ -32,6 +32,7 @@ class BidsDataset(MRI2DSegmentationDataset):
         soft_gt (bool): If True, ground truths are not binarized before being fed to the network. Otherwise, ground
         truths are thresholded (0.5) after the data augmentation operations.
         is_input_dropout (bool): Return input with missing modalities.
+        input_dropout_params (list): Dropout parameters
 
     Attributes:
         filename_pairs (list): A list of tuples in the format (input filename list containing all modalities,ground \
@@ -46,7 +47,7 @@ class BidsDataset(MRI2DSegmentationDataset):
     def __init__(self, bids_df, subject_file_lst, target_suffix, contrast_params, model_params, slice_axis=2,
                  cache=True, transform=None, metadata_choice=False, slice_filter_fn=None, roi_params=None,
                  multichannel=False, object_detection_params=None, task="segmentation", soft_gt=False,
-                 is_input_dropout=False):
+                 is_input_dropout=False, input_dropout_params=[0.5, 0.5, 0.5]):
 
         self.roi_params = roi_params if roi_params is not None else \
             {ROIParamsKW.SUFFIX: None, ROIParamsKW.SLICE_FILTER_ROI: None}
@@ -128,7 +129,7 @@ class BidsDataset(MRI2DSegmentationDataset):
         stride = model_params[ModelParamsKW.STRIDE_2D] if ModelParamsKW.STRIDE_2D in model_params else []
 
         super().__init__(self.filename_pairs, length, stride, slice_axis, cache, transform, slice_filter_fn, task, self.roi_params,
-                         self.soft_gt, is_input_dropout)
+                         self.soft_gt, is_input_dropout, input_dropout_params)
 
     def get_target_filename(self, target_suffix, target_filename, derivative):
         for idx, suffix_list in enumerate(target_suffix):

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -12,7 +12,7 @@ def load_dataset(bids_df, data_list, transforms_params, model_params, target_suf
                  contrast_params, slice_filter_params, slice_axis, multichannel,
                  dataset_type="training", requires_undo=False, metadata_type=None,
                  object_detection_params=None, soft_gt=False, device=None,
-                 cuda_available=None, is_input_dropout=False, **kwargs):
+                 cuda_available=None, is_input_dropout=False, input_dropout_params=[0.5, 0.5, 0.5], **kwargs):
     """Get loader appropriate loader according to model type. Available loaders are Bids3DDataset for 3D data,
     BidsDataset for 2D data and HDF5Dataset for HeMIS.
 
@@ -37,6 +37,7 @@ def load_dataset(bids_df, data_list, transforms_params, model_params, target_suf
         soft_gt (bool): If True, ground truths are not binarized before being fed to the network. Otherwise, ground
         truths are thresholded (0.5) after the data augmentation operations.
         is_input_dropout (bool): Return input with missing modalities.
+        input_dropout_params (list): Dropout parameters.
 
     Returns:
         BidsDataset
@@ -66,7 +67,8 @@ def load_dataset(bids_df, data_list, transforms_params, model_params, target_suf
                                 model_params=model_params,
                                 object_detection_params=object_detection_params,
                                 soft_gt=soft_gt,
-                                is_input_dropout=is_input_dropout)
+                                is_input_dropout=is_input_dropout,
+                                input_dropout_params=input_dropout_params)
 
     # elif model_params[ModelParamsKW.NAME] == ConfigKW.HEMIS_UNET:
     #     dataset = imed_adaptative.HDF5Dataset(bids_df=bids_df,
@@ -102,7 +104,8 @@ def load_dataset(bids_df, data_list, transforms_params, model_params, target_suf
                               soft_gt=soft_gt,
                               object_detection_params=object_detection_params,
                               task=task,
-                              is_input_dropout=is_input_dropout)
+                              is_input_dropout=is_input_dropout,
+                              input_dropout_params=input_dropout_params)
         dataset.load_filenames()
 
     if model_params[ModelParamsKW.NAME] == ConfigKW.MODIFIED_3D_UNET:

--- a/ivadomed/loader/mri2d_segmentation_dataset.py
+++ b/ivadomed/loader/mri2d_segmentation_dataset.py
@@ -32,6 +32,7 @@ class MRI2DSegmentationDataset(Dataset):
         soft_gt (bool): If True, ground truths are not binarized before being fed to the network. Otherwise, ground
         truths are thresholded (0.5) after the data augmentation operations.
         is_input_dropout (bool): Return input with missing modalities.
+        input_dropout_params (list): Dropout parameters.
 
     Attributes:
         indexes (list): List of indices corresponding to each slice or patch in the dataset.
@@ -57,11 +58,12 @@ class MRI2DSegmentationDataset(Dataset):
         roi_thr (int): If the ROI mask contains less than this number of non-zero voxels, the slice will be discarded
             from the dataset.
         is_input_dropout (bool): Return input with missing modalities.
+        input_dropout_params (list): Dropout parameters.
 
     """
 
     def __init__(self, filename_pairs, length=None, stride=None, slice_axis=2, cache=True, transform=None,
-                 slice_filter_fn=None, task="segmentation", roi_params=None, soft_gt=False, is_input_dropout=False):
+                 slice_filter_fn=None, task="segmentation", roi_params=None, soft_gt=False, is_input_dropout=False, input_dropout_params=[0.5, 0.5, 0.5]):
         if length is None:
             length = []
         if stride is None:
@@ -85,6 +87,7 @@ class MRI2DSegmentationDataset(Dataset):
         self.has_bounding_box = True
         self.task = task
         self.is_input_dropout = is_input_dropout
+        self.input_dropout_params = input_dropout_params
 
 
     def load_filenames(self):
@@ -259,6 +262,6 @@ class MRI2DSegmentationDataset(Dataset):
 
         # Input-level dropout to train with missing modalities
         if self.is_input_dropout:
-            data_dict = dropout_input(data_dict)
+            data_dict = dropout_input(data_dict, self.input_dropout_params)
 
         return data_dict

--- a/ivadomed/loader/mri3d_subvolume_segmentation_dataset.py
+++ b/ivadomed/loader/mri3d_subvolume_segmentation_dataset.py
@@ -31,10 +31,11 @@ class MRI3DSubVolumeSegmentationDataset(Dataset):
         soft_gt (bool): If True, ground truths are not binarized before being fed to the network. Otherwise, ground
         truths are thresholded (0.5) after the data augmentation operations.
         is_input_dropout (bool): Return input with missing modalities.
+        input_dropout_params (list): Dropout parameters.
     """
 
     def __init__(self, filename_pairs, transform=None, length=(64, 64, 64), stride=(0, 0, 0), slice_axis=0,
-                 task="segmentation", soft_gt=False, is_input_dropout=False):
+                 task="segmentation", soft_gt=False, is_input_dropout=False, input_dropout_params=[0.5, 0.5, 0.5]):
         self.filename_pairs = filename_pairs
         self.handlers = []
         self.indexes = []
@@ -46,6 +47,7 @@ class MRI3DSubVolumeSegmentationDataset(Dataset):
         self.task = task
         self.soft_gt = soft_gt
         self.is_input_dropout = is_input_dropout
+        self.input_dropout_params = input_dropout_params
 
         self._load_filenames()
         self._prepare_indices()
@@ -173,7 +175,7 @@ class MRI3DSubVolumeSegmentationDataset(Dataset):
 
         # Input-level dropout to train with missing modalities
         if self.is_input_dropout:
-            subvolumes = dropout_input(subvolumes)
+            subvolumes = dropout_input(subvolumes, self.input_dropout_params)
 
         if stack_gt is not None:
             for _ in range(len(stack_gt)):

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -426,12 +426,13 @@ def update_filename_to_nifti(filename):
     return filename
 
 
-def dropout_input(seg_pair):
+def dropout_input(seg_pair, drop_param):
     """Applies input-level dropout: zero to all channels minus one will be randomly set to zeros. This function verifies
     if some channels are already empty. Always at least one input channel will be kept.
 
     Args:
         seg_pair (dict): Batch containing torch tensors (input and gt) and metadata.
+        drop_param (list): [p1, p2, p3], T1w, T2w and T2star have respectively p1, p2 and p3 chances to be dropped.
 
     Return:
         seg_pair (dict): Batch containing torch tensors (input and gt) and metadata with channel(s) dropped.
@@ -439,10 +440,31 @@ def dropout_input(seg_pair):
     n_channels = seg_pair['input'].size(0)
     # Verify if the input is multichannel
     if n_channels > 1:
+
         # Verify if some channels are already empty
         n_unique_values = [len(torch.unique(input_data)) > 1 for input_data in seg_pair['input']]
         idx_empty = np.where(np.invert(n_unique_values))[0]
 
+
+        # select n_dropped channels to be dropped between 0 and (n_channels - 1) (keep at least one input)
+        # taking into consideration the empty channels, so making sure: n_available_channel - (n_dropped_channels + n_empty_channels) >= 1
+        n_dropped = n_channels
+        while n_dropped > (n_channels - 1):
+
+            # choose some channels to drop, 1 means drop, 0 means keep
+            to_drop = [1 if ( (random.random()<drop_param[i]) or (i in idx_empty) ) else 0 for i in range(len(drop_param))]
+
+            # calculate the total number of channels chosen to be dropped
+            n_dropped = sum(to_drop)
+
+        # indexes of the channels to be dropped
+        idx_dropped = [i for i in range(len(to_drop)) if (to_drop[i]==1)]
+
+        # drop these channels
+        seg_pair['input'][idx_dropped] = torch.zeros_like(seg_pair['input'][idx_dropped])
+
+        
+        """
         # Select how many channels will be dropped between 0 and n_channels - 1 (keep at least one input)
         n_dropped = random.randint(0, n_channels - 1)
 
@@ -460,7 +482,7 @@ def dropout_input(seg_pair):
             idx_dropped = idx_empty
 
         seg_pair['input'][idx_dropped] = torch.zeros_like(seg_pair['input'][idx_dropped])
-
+        """
     else:
         logger.warning("\n Impossible to apply input-level dropout since input is not multi-channel.")
 


### PR DESCRIPTION
## Description
This PR implements the input-level dropout controlling parameters. When input-level dropout is enabled and the parameters [p1, p2, p3] (with p in [0, 1]) are passed, T1w, T2w and T2star have respectively p1, p2, and p3 chance to be dropped. If a channel is already empty due to an actual missing modality, it will be considered by the function as a having the parameter p=1.

To apply the input-level dropout and use the parameters [0.5, 0.5, 0.5], one can edit the config file as follow:
```
"loader_parameters": {
    "is_input_dropout": true,
    "input_dropout_params": [0.5, 0.5, 0.5]
}
```

## Linked issues
Following PR #705 Input-level dropout feature
and issue #730 about adding a parameter that controls the frequency of this dropping.

## PR contents

- [x] Modify dropout_input function to add dropping parameters
- [x] Adapt all relevant files (mri2d_segmentation_dataset, mri3d_subvolume_segmentation_dataset, bids_dataset, bids3d_dataset, keywords, loader, config_default)