### PR TITLE
Fixes `--segment` with multiple raters s.t. first element is used for target

### DIFF
--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -295,6 +295,10 @@ def run_segment_command(context, model_params):
                 pred_path.mkdir(parents=True)
 
             for pred, target in zip(pred_list, target_list):
+                # Set the target to first element if the target is a list (e.g. multi-rater setting)
+                if isinstance(target, list):
+                    target = target[0]
+
                 filename = subject.split('.')[0] + target + "_pred" + ".nii.gz"
                 nib.save(pred, Path(pred_path, filename))
 


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

As mentioned in #816, currently running `--segment` with random sampling of multiple raters gives `TypeError: can only concatenate str (not "list") to str` at the following lines:

https://github.com/ivadomed/ivadomed/blob/d1b9e118f491d9e5e88523f8d0f0cae65b26ecca/ivadomed/main.py#L297-L299

This is because with random sampling of multiple raters we have a `target_suffix` specified like `[[<suffix1>, <suffix2>]]` (i.e. list of lists) as explained in #546. Therefore, in each loop the `target` variable shown above is a `list`. 

### Implementation

The fix I employed in this PR is very simple: check if `target` is a list and set `target` to the first element if that's the case (i.e. `<suffix1>` from the example above).

### Results

Following the steps mentioned at https://github.com/ivadomed/model_seg_ms_mp2rage/pull/11 for lesion segmentation, I get the following error (as mentioned in https://github.com/ivadomed/model_seg_ms_mp2rage/issues/27):

<details><summary>Terminal output</summary>

```console
(um_main) uzmac@romane:~/model_seg_ms_mp2rage$ ivadomed --segment -c config/seg_lesion.json                                                                          
2021-12-22 15:24:10.563 | INFO     | ivadomed.utils:init_ivadomed:408 -                                                                                              
ivadomed (git-HEAD-d1b9e118f491d9e5e88523f8d0f0cae65b26ecca*)                                                                                                        
                                                                                                                                                                     
2021-12-22 15:24:10.564 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file                       
2021-12-22 15:24:10.564 | INFO     | ivadomed.config_manager:deep_dict_compare:44 -     log_file: log                                                                
2021-12-22 15:24:10.565 | INFO     | ivadomed.config_manager:deep_dict_compare:44 -     loader_parameters: is_input_dropout: False                                   
2021-12-22 15:24:10.565 | INFO     | ivadomed.config_manager:deep_dict_compare:44 -     split_dataset: split_method: participant_id                                  
2021-12-22 15:24:10.565 | INFO     | ivadomed.config_manager:deep_dict_compare:44 -     split_dataset: data_testing: {'data_type': None, 'data_value': []}           
2021-12-22 15:24:10.565 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -                                                                           
                                                                                                                                                                     
2021-12-22 15:24:10.565 | INFO     | ivadomed.utils:get_path_output:371 - CLI flag --path-output not used to specify output directory. Will check config file for dir
ectory...                                                                                                                                                            
2021-12-22 15:24:10.565 | INFO     | ivadomed.utils:get_path_data:383 - CLI flag --path-data not used to specify BIDS data directory. Will check config file for dire
ctory...                                                                                                                                                             
2021-12-22 15:24:10.565 | INFO     | ivadomed.main:set_output_path:207 - Output path already exists: seg_lesion_output                                               
2021-12-22 15:24:10.759 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0                                                                               
2021-12-22 15:24:10.760 | INFO     | ivadomed.utils:display_selected_model_spec:145 - Selected architecture: Modified3DUNet, with the following parameters:          
2021-12-22 15:24:10.760 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   dropout_rate: 0.3                                                            
2021-12-22 15:24:10.760 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   bn_momentum: 0.1                                                             
2021-12-22 15:24:10.760 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   depth: 4                                                                     
2021-12-22 15:24:10.760 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   is_2d: False                                                                 
2021-12-22 15:24:10.760 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   final_activation: sigmoid                                                    
2021-12-22 15:24:10.761 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   folder_name: seg_lesion_model                                                
2021-12-22 15:24:10.761 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   applied: True                                                                
2021-12-22 15:24:10.761 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   length_3D: [32, 64, 128]
2021-12-22 15:24:10.761 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   stride_3D: [32, 64, 128]
2021-12-22 15:24:10.761 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   attention: False
2021-12-22 15:24:10.761 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   n_filters: 8
2021-12-22 15:24:10.761 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   in_channel: 1
2021-12-22 15:24:10.761 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   out_channel: 1
2021-12-22 15:24:11.225 | INFO     | ivadomed.loader.bids_dataframe:save:289 - Dataframe has been saved in seg_lesion_output/bids_dataframe.csv.
2021-12-22 15:24:11.227 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:24:11.227 | INFO     | ivadomed.config_manager:_display_differing_keys:155 - 

2021-12-22 15:24:11.227 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:24:11.239 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:24:14.206 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:24:14.209 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:24:14.209 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference... 
2021-12-22 15:24:14.359 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
target_list:  [['_lesion-manual', '_lesion-manual2']]
target:  ['_lesion-manual', '_lesion-manual2']
Traceback (most recent call last):
  File "/home/GRAMES.POLYMTL.CA/uzmac/.local/bin/ivadomed", line 11, in <module>
    load_entry_point('ivadomed', 'console_scripts', 'ivadomed')()
  File "/home/GRAMES.POLYMTL.CA/uzmac/ivadomed/ivadomed/main.py", line 591, in run_main
    run_command(context=context,
  File "/home/GRAMES.POLYMTL.CA/uzmac/ivadomed/ivadomed/main.py", line 364, in run_command
    run_segment_command(context, model_params)
  File "/home/GRAMES.POLYMTL.CA/uzmac/ivadomed/ivadomed/main.py", line 300, in run_segment_command
    filename = subject.split('.')[0] + target + "_pred" + ".nii.gz"
TypeError: can only concatenate str (not "list") to str
```

</details>

After `git checkout um/segment_with_multiple_raters` in ivadomed, the `--segment` for lesion segmentation works successfully:

<details><summary>Terminal output</summary>

```console

(um_main) uzmac@romane:~/model_seg_ms_mp2rage$ ivadomed --segment -c config/seg_lesion.json
2021-12-22 15:27:43.963 | INFO     | ivadomed.utils:init_ivadomed:408 -
ivadomed (git-HEAD-d1b9e118f491d9e5e88523f8d0f0cae65b26ecca*)

2021-12-22 15:27:43.965 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:43.965 | INFO     | ivadomed.config_manager:deep_dict_compare:44 -     log_file: log
2021-12-22 15:27:43.965 | INFO     | ivadomed.config_manager:deep_dict_compare:44 -     loader_parameters: is_input_dropout: False
2021-12-22 15:27:43.965 | INFO     | ivadomed.config_manager:deep_dict_compare:44 -     split_dataset: split_method: participant_id
2021-12-22 15:27:43.965 | INFO     | ivadomed.config_manager:deep_dict_compare:44 -     split_dataset: data_testing: {'data_type': None, 'data_value': []}
2021-12-22 15:27:43.965 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:43.965 | INFO     | ivadomed.utils:get_path_output:371 - CLI flag --path-output not used to specify output directory. Will check config file for directory...
2021-12-22 15:27:43.965 | INFO     | ivadomed.utils:get_path_data:383 - CLI flag --path-data not used to specify BIDS data directory. Will check config file for directory...
2021-12-22 15:27:43.965 | INFO     | ivadomed.main:set_output_path:207 - Output path already exists: seg_lesion_output
2021-12-22 15:27:44.125 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:44.126 | INFO     | ivadomed.utils:display_selected_model_spec:145 - Selected architecture: Modified3DUNet, with the following parameters:
2021-12-22 15:27:44.126 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   dropout_rate: 0.3
2021-12-22 15:27:44.126 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   bn_momentum: 0.1
2021-12-22 15:27:44.126 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   depth: 4
2021-12-22 15:27:44.126 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   is_2d: False
2021-12-22 15:27:44.126 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   final_activation: sigmoid
2021-12-22 15:27:44.126 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   folder_name: seg_lesion_model
2021-12-22 15:27:44.126 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   applied: True
2021-12-22 15:27:44.126 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   length_3D: [32, 64, 128]
2021-12-22 15:27:44.126 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   stride_3D: [32, 64, 128]
2021-12-22 15:27:44.126 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   attention: False
2021-12-22 15:27:44.126 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   n_filters: 8
2021-12-22 15:27:44.127 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   in_channel: 1
2021-12-22 15:27:44.127 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   out_channel: 1
2021-12-22 15:27:44.589 | INFO     | ivadomed.loader.bids_dataframe:save:289 - Dataframe has been saved in seg_lesion_output/bids_dataframe.csv.
2021-12-22 15:27:44.591 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:44.591 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:44.591 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:44.603 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:47.383 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:47.385 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:47.386 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:47.551 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:47.569 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:47.569 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:47.569 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:47.583 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:47.584 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:47.584 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:47.584 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:47.729 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:47.748 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:47.748 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:47.749 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:47.761 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:47.762 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:47.763 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:47.763 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:47.888 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:47.901 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:47.902 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:47.902 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:47.916 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:47.918 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:47.918 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:47.918 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:48.037 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:48.049 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:48.050 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:48.050 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:48.074 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:48.075 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:48.075 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:48.075 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:48.189 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:48.206 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:48.206 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:48.206 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:48.228 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:48.235 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:48.235 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:48.235 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:48.414 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:48.428 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:48.428 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:48.428 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:48.444 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:48.446 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:48.446 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:48.446 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:48.591 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:48.608 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:48.608 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:48.609 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:48.627 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:48.629 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:48.629 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:48.629 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:48.779 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:48.797 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:48.797 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:48.797 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:48.812 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:48.813 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:48.813 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:48.814 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:48.946 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:48.961 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:48.961 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:48.961 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:48.977 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:48.978 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:48.978 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:48.979 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:49.119 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:49.139 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:49.139 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:49.139 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:49.153 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:49.155 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:49.155 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:49.155 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:49.298 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:49.313 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:49.313 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:49.313 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:49.330 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:49.331 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:49.332 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:49.332 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:49.469 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:49.486 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:49.486 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:49.486 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:49.500 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:49.501 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:49.501 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:49.502 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:49.673 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:49.704 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:49.706 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:49.707 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:49.719 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:49.721 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:49.721 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:49.721 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:49.848 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:49.859 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:49.859 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:49.859 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:49.872 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:49.874 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:49.874 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:49.874 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:50.001 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:50.011 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:50.011 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:50.011 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:50.031 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:50.033 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:50.033 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:50.033 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:50.167 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:50.182 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:50.182 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:50.183 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:50.195 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:50.196 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:50.196 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:50.197 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:50.325 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:50.335 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:50.336 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:50.336 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:50.352 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:50.353 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:50.354 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:50.354 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:50.484 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:50.497 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:50.497 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:50.498 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:50.513 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:50.515 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:50.515 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:50.515 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:50.642 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:50.655 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:50.655 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:50.655 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:50.670 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:50.671 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:50.671 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:50.672 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:50.799 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:50.811 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:50.811 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:50.811 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:50.830 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:50.831 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:50.831 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:50.832 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:50.992 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:51.017 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:51.017 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:51.017 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:51.044 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:51.045 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:51.045 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:51.046 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:51.178 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:51.194 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:51.194 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:51.194 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:51.207 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:51.209 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:51.209 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:51.209 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:51.345 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:51.356 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:51.357 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:51.357 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:51.372 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:51.374 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:51.374 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:51.374 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:51.525 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:51.542 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:51.543 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:51.543 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:51.560 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:51.561 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:51.561 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:51.561 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:51.696 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:51.708 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:51.708 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:51.708 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:51.720 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:51.721 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:51.721 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:51.722 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:51.849 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:51.859 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:51.860 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:51.860 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:51.872 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:51.873 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:51.873 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:51.873 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:52.001 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:52.012 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:52.012 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:52.013 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:52.024 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:52.026 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:52.026 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:52.026 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:52.157 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:52.168 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:52.168 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:52.168 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:52.179 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:52.180 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:52.180 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:52.181 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:52.337 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2021-12-22 15:27:52.364 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2021-12-22 15:27:52.364 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2021-12-22 15:27:52.364 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2021-12-22 15:27:52.382 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 axial volumes of shape [32, 64, 128].
2021-12-22 15:27:52.395 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2021-12-22 15:27:52.395 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2021-12-22 15:27:52.395 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2021-12-22 15:27:52.540 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
```

</details>

And here are the segmented files as a result:

<details><summary>Terminal output</summary>

```console
(um_main) uzmac@romane:~/model_seg_ms_mp2rage$ ls seg_lesion_output/pred_masks/
sub-P001_UNIT1_lesion-manual_pred.nii.gz  sub-P013_UNIT1_lesion-manual_pred.nii.gz  sub-P025_UNIT1_lesion-manual_pred.nii.gz
sub-P002_UNIT1_lesion-manual_pred.nii.gz  sub-P014_UNIT1_lesion-manual_pred.nii.gz  sub-P026_UNIT1_lesion-manual_pred.nii.gz
sub-P003_UNIT1_lesion-manual_pred.nii.gz  sub-P015_UNIT1_lesion-manual_pred.nii.gz  sub-P027_UNIT1_lesion-manual_pred.nii.gz
sub-P004_UNIT1_lesion-manual_pred.nii.gz  sub-P016_UNIT1_lesion-manual_pred.nii.gz  sub-P028_UNIT1_lesion-manual_pred.nii.gz
sub-P005_UNIT1_lesion-manual_pred.nii.gz  sub-P017_UNIT1_lesion-manual_pred.nii.gz  sub-P029_UNIT1_lesion-manual_pred.nii.gz
sub-P006_UNIT1_lesion-manual_pred.nii.gz  sub-P019_UNIT1_lesion-manual_pred.nii.gz  sub-P030_UNIT1_lesion-manual_pred.nii.gz
sub-P007_UNIT1_lesion-manual_pred.nii.gz  sub-P021_UNIT1_lesion-manual_pred.nii.gz  sub-P031_UNIT1_lesion-manual_pred.nii.gz
sub-P010_UNIT1_lesion-manual_pred.nii.gz  sub-P022_UNIT1_lesion-manual_pred.nii.gz  sub-P033_UNIT1_lesion-manual_pred.nii.gz
sub-P011_UNIT1_lesion-manual_pred.nii.gz  sub-P023_UNIT1_lesion-manual_pred.nii.gz  sub-P034_UNIT1_lesion-manual_pred.nii.gz
sub-P012_UNIT1_lesion-manual_pred.nii.gz  sub-P024_UNIT1_lesion-manual_pred.nii.gz  sub-P035_UNIT1_lesion-manual_pred.nii.gz
```

</details>

As mentioned https://github.com/ivadomed/model_seg_ms_mp2rage/issues/27

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Resolves #816.
