### PR TITLE
Implementation of Random Blur Augmentation

### DIFF
--- a/docs/source/configuration_file.rst
+++ b/docs/source/configuration_file.rst
@@ -1696,6 +1696,39 @@ Available Transformations:
         }
     }
 
+.. jsonschema::
+
+    {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": "RandomBlur",
+        "type": "dict",
+        "$$description": [
+            "Applies a random blur to the image."
+        ],
+        "options": {
+            "sigma_range": {
+                "type": "(float, float)",
+                "description": "Standard deviation range for the gaussian filter."
+            },
+            "p": {
+                "type": "float"
+            }
+        }
+    }
+
+.. code-block:: JSON
+
+    {
+        "transformation": {
+            "RandomBlur": {
+                "sigma_range": [0.0, 2.0],
+                "p": 0.5,
+                "applied_to": ["im"],
+                "dataset_type": ["training"]
+            }
+        }
+    }
+
 .. _Uncertainty:
 
 Uncertainty

--- a/ivadomed/keywords.py
+++ b/ivadomed/keywords.py
@@ -182,6 +182,7 @@ class MetadataKW:
     GAUSSIAN_NOISE = "gaussian_noise"
     GAMMA = "gamma"
     BIAS_FIELD = "bias_field"
+    BLUR = "blur"
     DATA_SHAPE = "data_shape"
     SLICE_INDEX = "slice_index"
     MISSING_MOD = "missing_mod"

--- a/ivadomed/transforms.py
+++ b/ivadomed/transforms.py
@@ -1062,7 +1062,7 @@ class RandomBiasField(ImedTransform):
         Args:
             coefficients (float): Maximum magnitude of polynomial coefficients
             order: Order of the basis polynomial functions
-            p (float): Probability of performing the gamma contrast
+            p (float): Probability of applying the bias field
         """
 
     def __init__(self, coefficients, order, p=0.5):

--- a/ivadomed/transforms.py
+++ b/ivadomed/transforms.py
@@ -1101,6 +1101,44 @@ class RandomBiasField(ImedTransform):
             return sample, metadata
 
 
+class RandomBlur(ImedTransform):
+    """Applies a random blur to the image
+
+        Args:
+            sigma_range (tuple of floats): Standard deviation range for the gaussian filter
+            p (float): Probability of performing blur
+        """
+
+    def __init__(self, sigma_range, p=0.5):
+        self.sigma_range = sigma_range
+        self.p = p
+
+    @multichannel_capable
+    @two_dim_compatible
+    def __call__(self, sample, metadata=None):
+        if np.random.random() < self.p:
+            # Get params
+            sigma = np.random.uniform(self.sigma_range[0], self.sigma_range[1])
+
+            # Save params
+            metadata[MetadataKW.BLUR] = [sigma]
+
+        else:
+            metadata[MetadataKW.BLUR] = [None]
+
+        if any(metadata[MetadataKW.BLUR]):
+            # Apply random blur
+            data_out = gaussian_filter(sample, sigma)
+
+            # Keep data type
+            data_out = data_out.astype(sample.dtype)
+
+            return data_out, metadata
+
+        else:
+            return sample, metadata
+
+
 def get_subdatasets_transforms(transform_params):
     """Get transformation parameters for each subdataset: training, validation and testing.
 


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
This PR
* adds the `blur` keyword in `ivadomed/keywords.py` for the random blur augmentation
* implements random blur augmentation for images through a `RandomBlur()` class which utilizes the `scipy.ndimage.filters.gaussian_filter()` function in `ivadomed/transforms.py`
* updates the docs accordingly
* fixes a minor type in the docstring of `RandomBiasField()` in `ivadomed/transforms.py` (missed in #1033)

## Augmentation Visualization

Given below are visualizations (generated with `ivadomed_visualize_transforms`) of the result of random blur with standard deviations of 0.5, 1.0, 1.5, and 2.0 (before on left and after on right):

<img src="https://user-images.githubusercontent.com/33473983/147370798-9df6f49d-05f3-425f-838b-f6a2132ff128.png" height="200" />
<img src="https://user-images.githubusercontent.com/33473983/147370801-6bf4d7ed-f23f-4c73-b4cd-5d1f2314eb7a.png" height="200" />
<img src="https://user-images.githubusercontent.com/33473983/147370802-87eb2c0f-bd8f-4dfa-a496-1f140e185fcb.png" height="200" />
<img src="https://user-images.githubusercontent.com/33473983/147370803-7b9534c9-0527-40ad-b6eb-934d559acfb3.png" height="200" />

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Resolves #1017.
