### PR TITLE
Rename prediction filenames: add class index and compat. for multi-rater

### DIFF
--- a/docs/source/tutorials/two_class_microscopy_seg_2d_unet.rst
+++ b/docs/source/tutorials/two_class_microscopy_seg_2d_unet.rst
@@ -299,7 +299,8 @@ For more details on the evaluation metrics, see :mod:`ivadomed.metrics`.
    [1 rows x 26 columns]
 
 The test image segmentations are stored in ``<PATH_TO_OUT_DIR>/pred_masks/`` in PNG format and have the same name as
-the input image with the suffix ``<target_suffix>_pred.png``.
+the input image with the suffix ``<class-index>_pred.png``. In our case: ``sub-rat3_sample-data9_SEM_class-0_pred.png`` and
+``sub-rat3_sample-data9_SEM_class-1_pred.png`` for axons and myelin respectively (in the same order as ``target_suffix``).
 A temporary NIfTI files containing the predictions for both classes with the suffix ``_pred.nii.gz`` will also be
 present.
 

--- a/ivadomed/evaluation.py
+++ b/ivadomed/evaluation.py
@@ -98,8 +98,10 @@ def evaluate(bids_df, path_output, target_suffix, eval_params):
         # For Microscopy PNG/TIF files (TODO: implement OMETIFF behavior)
         if "nii" not in extension:
             painted_list = imed_inference.split_classes(nib_painted)
+            # Reformat target list to include class index and be compatible with multiple raters
+            target_list = ["_class-%d" % i for i in range(len(target_suffix))]
             imed_inference.pred_to_png(painted_list,
-                                       target_suffix,
+                                       target_list,
                                        str(path_preds.joinpath(subj_acq)),
                                        suffix="_painted")
 

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -294,6 +294,9 @@ def run_segment_command(context, model_params):
             if not pred_path.exists():
                 pred_path.mkdir(parents=True)
 
+            # Reformat target list to include class index and be compatible with multiple raters
+            target_list = ["_class-%d" % i for i in range(len(target_list))]
+
             for pred, target in zip(pred_list, target_list):
                 filename = subject.split('.')[0] + target + "_pred" + ".nii.gz"
                 nib.save(pred, Path(pred_path, filename))

--- a/ivadomed/testing.py
+++ b/ivadomed/testing.py
@@ -259,8 +259,10 @@ def run_inference(test_loader, model, model_params, testing_params, ofolder, cud
                     extension = imed_loader_utils.get_file_extension(fname_ref)
                     if "nii" not in extension and fname_pred:
                         output_list = imed_inference.split_classes(output_nii)
+                        # Reformat target list to include class index and be compatible with multiple raters
+                        target_list = ["_class-%d" % i for i in range(len(testing_params['target_suffix']))]
                         imed_inference.pred_to_png(output_list,
-                                                   testing_params['target_suffix'],
+                                                   target_list,
                                                    fname_pred.split("_pred.nii.gz")[0])
 
                     # re-init pred_stack_lst and last_slice_bool


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

There are two issues this PR aims to address:
* As mentioned in #816, currently running `--segment` with random sampling of multiple raters gives `TypeError: can only concatenate str (not "list") to str` at the following lines:  https://github.com/ivadomed/ivadomed/blob/d1b9e118f491d9e5e88523f8d0f0cae65b26ecca/ivadomed/main.py#L297-L299
This is because with random sampling of multiple raters we have a `target_suffix` specified like `[[<suffix1>, <suffix2>]]` (i.e. list of lists) as explained in #546. Therefore, in each loop the `target` variable shown above is a `list`. 

* As mentioned in #1006, the current naming of the prediction files can be confusing as the `target_suffix` includes the word "manual" as per our [naming convention](https://github.com/ivadomed/ivadomed/wiki/repositories#derivatives) whereas the prediction files are generated automatically by the segmentation model.

### Implementation

The fix employed in this PR is a one liner and implements [@mariehbourget's suggestion](https://github.com/ivadomed/ivadomed/issues/1006#issuecomment-1009211678). It reformats the `target_list` variable such that each item (whether a string as in the usual case or a list of strings in the multiple raters case) in the list is converted to the string `"class-<INDEX>"`. Notice that this also fixes the multiple raters problem.

### Results

Following the steps mentioned at https://github.com/ivadomed/model_seg_ms_mp2rage/pull/11 for lesion segmentation, I get the following error (as mentioned in https://github.com/ivadomed/model_seg_ms_mp2rage/issues/27):

<details><summary>Terminal output</summary>

```console
(um_main) uzmac@romane:~/model_seg_ms_mp2rage$ ivadomed --segment -c config/seg_lesion.json
2022-01-14 07:17:38.127 | INFO     | ivadomed.utils:init_ivadomed:408 -
ivadomed (git-master-9092196db826773205ad25047fc291e853f9fc52)

2022-01-14 07:17:38.129 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:17:38.129 | INFO     | ivadomed.config_manager:deep_dict_compare:44 -     log_file: log
2022-01-14 07:17:38.129 | INFO     | ivadomed.config_manager:deep_dict_compare:44 -     loader_parameters: is_input_dropout: False
2022-01-14 07:17:38.129 | INFO     | ivadomed.config_manager:deep_dict_compare:44 -     split_dataset: split_method: participant_id
2022-01-14 07:17:38.129 | INFO     | ivadomed.config_manager:deep_dict_compare:44 -     split_dataset: data_testing: {'data_type': None, 'data_value': []}
2022-01-14 07:17:38.129 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:17:38.129 | INFO     | ivadomed.utils:get_path_output:371 - CLI flag --path-output not used to specify output directory. Will check config file for directory...
2022-01-14 07:17:38.129 | INFO     | ivadomed.utils:get_path_data:383 - CLI flag --path-data not used to specify BIDS data directory. Will check config file for directory...
2022-01-14 07:17:38.129 | INFO     | ivadomed.main:set_output_path:207 - Output path already exists: seg_lesion_output
2022-01-14 07:17:38.305 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:17:38.306 | INFO     | ivadomed.utils:display_selected_model_spec:145 - Selected architecture: Modified3DUNet, with the following parameters:
2022-01-14 07:17:38.306 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   dropout_rate: 0.3
2022-01-14 07:17:38.306 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   bn_momentum: 0.1
2022-01-14 07:17:38.306 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   depth: 4
2022-01-14 07:17:38.306 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   is_2d: False
2022-01-14 07:17:38.306 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   final_activation: sigmoid
2022-01-14 07:17:38.306 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   folder_name: seg_lesion_model
2022-01-14 07:17:38.306 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   applied: True
2022-01-14 07:17:38.307 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   length_3D: [128, 64, 32]
2022-01-14 07:17:38.307 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   stride_3D: [128, 64, 32]
2022-01-14 07:17:38.307 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   attention: False
2022-01-14 07:17:38.307 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   n_filters: 8
2022-01-14 07:17:38.307 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   in_channel: 1
2022-01-14 07:17:38.307 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   out_channel: 1
2022-01-14 07:17:38.631 | INFO     | ivadomed.loader.bids_dataframe:save:289 - Dataframe has been saved in seg_lesion_output/bids_dataframe.csv.
2022-01-14 07:17:38.633 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:17:38.633 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:17:38.633 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:17:38.645 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:17:41.826 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:17:41.827 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:17:41.856 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:17:42.025 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
Traceback (most recent call last):
  File "/home/GRAMES.POLYMTL.CA/uzmac/.local/bin/ivadomed", line 11, in <module>
    load_entry_point('ivadomed', 'console_scripts', 'ivadomed')()
  File "/home/GRAMES.POLYMTL.CA/uzmac/ivadomed/ivadomed/main.py", line 589, in run_main
    run_command(context=context,
  File "/home/GRAMES.POLYMTL.CA/uzmac/ivadomed/ivadomed/main.py", line 362, in run_command
    run_segment_command(context, model_params)
  File "/home/GRAMES.POLYMTL.CA/uzmac/ivadomed/ivadomed/main.py", line 298, in run_segment_command
    filename = subject.split('.')[0] + target + "_pred" + ".nii.gz"
TypeError: can only concatenate str (not "list") to str                                                     
```

</details>

After `git checkout um/rename_prediction_filenames` in ivadomed, the `--segment` for lesion segmentation works successfully:

<details><summary>Terminal output</summary>

```console
(um_main) uzmac@romane:~/model_seg_ms_mp2rage$ ivadomed --segment -c config/seg_lesion.json
2022-01-14 07:18:10.221 | INFO     | ivadomed.utils:init_ivadomed:408 -
ivadomed (git-master-9092196db826773205ad25047fc291e853f9fc52*)

2022-01-14 07:18:10.223 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:10.223 | INFO     | ivadomed.config_manager:deep_dict_compare:44 -     log_file: log
2022-01-14 07:18:10.223 | INFO     | ivadomed.config_manager:deep_dict_compare:44 -     loader_parameters: is_input_dropout: False
2022-01-14 07:18:10.223 | INFO     | ivadomed.config_manager:deep_dict_compare:44 -     split_dataset: split_method: participant_id
2022-01-14 07:18:10.223 | INFO     | ivadomed.config_manager:deep_dict_compare:44 -     split_dataset: data_testing: {'data_type': None, 'data_value': []}
2022-01-14 07:18:10.223 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:10.223 | INFO     | ivadomed.utils:get_path_output:371 - CLI flag --path-output not used to specify output directory. Will check config file for directory...
2022-01-14 07:18:10.224 | INFO     | ivadomed.utils:get_path_data:383 - CLI flag --path-data not used to specify BIDS data directory. Will check config file for directory...
2022-01-14 07:18:10.224 | INFO     | ivadomed.main:set_output_path:207 - Output path already exists: seg_lesion_output
2022-01-14 07:18:10.404 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:10.405 | INFO     | ivadomed.utils:display_selected_model_spec:145 - Selected architecture: Modified3DUNet, with the following parameters:
2022-01-14 07:18:10.405 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   dropout_rate: 0.3
2022-01-14 07:18:10.405 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   bn_momentum: 0.1
2022-01-14 07:18:10.405 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   depth: 4
2022-01-14 07:18:10.405 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   is_2d: False
2022-01-14 07:18:10.405 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   final_activation: sigmoid
2022-01-14 07:18:10.405 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   folder_name: seg_lesion_model
2022-01-14 07:18:10.406 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   applied: True
2022-01-14 07:18:10.406 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   length_3D: [128, 64, 32]
2022-01-14 07:18:10.406 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   stride_3D: [128, 64, 32]
2022-01-14 07:18:10.406 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   attention: False
2022-01-14 07:18:10.406 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   n_filters: 8
2022-01-14 07:18:10.406 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   in_channel: 1
2022-01-14 07:18:10.406 | INFO     | ivadomed.utils:display_selected_model_spec:148 -   out_channel: 1
2022-01-14 07:18:10.762 | INFO     | ivadomed.loader.bids_dataframe:save:289 - Dataframe has been saved in seg_lesion_output/bids_dataframe.csv.
2022-01-14 07:18:10.764 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:10.764 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:10.764 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:10.776 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:13.678 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:13.679 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:13.679 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:13.830 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:13.841 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:13.841 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:13.841 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:13.854 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:13.856 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:13.856 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:13.856 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:13.997 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:14.014 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:14.014 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:14.015 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:14.031 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:14.033 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:14.034 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:14.034 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:14.212 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:14.227 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:14.228 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:14.228 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:14.242 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:14.244 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:14.244 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:14.244 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:14.444 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:14.482 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:14.482 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:14.482 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:14.523 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:14.525 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:14.526 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:14.526 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:14.687 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:14.708 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:14.708 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:14.708 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:14.726 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:14.730 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:14.730 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:14.730 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:14.887 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:14.905 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:14.907 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:14.908 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:14.935 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:14.942 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:14.942 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:14.942 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:15.144 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:15.158 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:15.158 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:15.158 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:15.177 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:15.178 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:15.179 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:15.179 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:15.320 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:15.340 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:15.341 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:15.341 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:15.356 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:15.357 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:15.358 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:15.358 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:15.540 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:15.553 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:15.553 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:15.553 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:15.569 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:15.570 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:15.570 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:15.570 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:15.719 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:15.730 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:15.731 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:15.731 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:15.746 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:15.747 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:15.747 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:15.747 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:15.889 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:15.904 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:15.905 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:15.905 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:15.928 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:15.930 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:15.930 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:15.930 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:16.075 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:16.089 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:16.089 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:16.089 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:16.103 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:16.107 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:16.107 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:16.107 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:16.258 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:16.276 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:16.276 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:16.276 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:16.288 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:16.289 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:16.289 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:16.290 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:16.436 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:16.449 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:16.450 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:16.450 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:16.462 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:16.463 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:16.464 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:16.464 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:16.613 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:16.628 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:16.629 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:16.629 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:16.651 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:16.652 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:16.653 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:16.653 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:16.812 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:16.840 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:16.841 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:16.841 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:16.864 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:16.866 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:16.866 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:16.866 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:17.019 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:17.051 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:17.051 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:17.051 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:17.078 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:17.084 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:17.085 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:17.085 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:17.318 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:17.338 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:17.338 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:17.339 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:17.354 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:17.356 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:17.356 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:17.356 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:17.496 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:17.513 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:17.513 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:17.514 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:17.528 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:17.530 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:17.530 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:17.530 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:17.701 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:17.716 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:17.717 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:17.718 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:17.765 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:17.780 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:17.780 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:17.780 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:17.946 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:17.966 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:17.966 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:17.966 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:17.981 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:17.982 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:17.983 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:17.983 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:18.140 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:18.158 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:18.159 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:18.159 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:18.179 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:18.184 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:18.184 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:18.185 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:18.363 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:18.379 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:18.379 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:18.379 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:18.394 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:18.396 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:18.396 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:18.396 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:18.551 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:18.567 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:18.567 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:18.567 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:18.585 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:18.586 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:18.586 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:18.586 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:18.750 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:18.768 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:18.768 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:18.769 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:18.780 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:18.781 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:18.782 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:18.782 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:18.931 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:18.947 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:18.947 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:18.947 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:18.958 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:18.960 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:18.960 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:18.960 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:19.108 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:19.123 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:19.123 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:19.124 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:19.136 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:19.138 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:19.138 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:19.138 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:19.287 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:19.298 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:19.298 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:19.299 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:19.310 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:19.311 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:19.311 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:19.311 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:19.462 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
2022-01-14 07:18:19.482 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-01-14 07:18:19.482 | INFO     | ivadomed.config_manager:_display_differing_keys:155 -

2022-01-14 07:18:19.483 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
2022-01-14 07:18:19.501 | INFO     | ivadomed.inference:segment_volume:435 - Loaded 1 sagittal volumes of shape [128, 64, 32].
2022-01-14 07:18:19.518 | INFO     | ivadomed.utils:define_device:135 - Using GPU ID 0
2022-01-14 07:18:19.519 | DEBUG    | ivadomed.inference:get_preds:88 - Likely ONNX model detected at: seg_lesion_output/seg_lesion_model/seg_lesion_model.onnx
2022-01-14 07:18:19.519 | DEBUG    | ivadomed.inference:get_preds:89 - Conduct ONNX model inference...
2022-01-14 07:18:19.706 | DEBUG    | ivadomed.inference:get_preds:92 - Sending predictions to CPU
```

</details>

And here are the segmented files as a result:

<details><summary>Terminal output</summary>

```console
(um_main) uzmac@romane:~/model_seg_ms_mp2rage$ ls seg_lesion_output/pred_masks/
sub-P001_UNIT1_class-0_pred.nii.gz  sub-P011_UNIT1_class-0_pred.nii.gz  sub-P021_UNIT1_class-0_pred.nii.gz  sub-P029_UNIT1_class-0_pred.nii.gz
sub-P002_UNIT1_class-0_pred.nii.gz  sub-P012_UNIT1_class-0_pred.nii.gz  sub-P022_UNIT1_class-0_pred.nii.gz  sub-P030_UNIT1_class-0_pred.nii.gz
sub-P003_UNIT1_class-0_pred.nii.gz  sub-P013_UNIT1_class-0_pred.nii.gz  sub-P023_UNIT1_class-0_pred.nii.gz  sub-P031_UNIT1_class-0_pred.nii.gz
sub-P004_UNIT1_class-0_pred.nii.gz  sub-P014_UNIT1_class-0_pred.nii.gz  sub-P024_UNIT1_class-0_pred.nii.gz  sub-P033_UNIT1_class-0_pred.nii.gz
sub-P005_UNIT1_class-0_pred.nii.gz  sub-P015_UNIT1_class-0_pred.nii.gz  sub-P025_UNIT1_class-0_pred.nii.gz  sub-P034_UNIT1_class-0_pred.nii.gz
sub-P006_UNIT1_class-0_pred.nii.gz  sub-P016_UNIT1_class-0_pred.nii.gz  sub-P026_UNIT1_class-0_pred.nii.gz  sub-P035_UNIT1_class-0_pred.nii.gz
sub-P007_UNIT1_class-0_pred.nii.gz  sub-P017_UNIT1_class-0_pred.nii.gz  sub-P027_UNIT1_class-0_pred.nii.gz
sub-P010_UNIT1_class-0_pred.nii.gz  sub-P019_UNIT1_class-0_pred.nii.gz  sub-P028_UNIT1_class-0_pred.nii.gz
```

</details>

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Resolves #816, Resolves #1006.
