### PR TITLE
Update pred_to_png prediction filenames for ADS integration

### DIFF
--- a/ivadomed/evaluation.py
+++ b/ivadomed/evaluation.py
@@ -103,7 +103,7 @@ def evaluate(bids_df, path_output, target_suffix, eval_params):
             imed_inference.pred_to_png(painted_list,
                                        target_list,
                                        str(path_preds.joinpath(subj_acq)),
-                                       suffix="_painted")
+                                       suffix="_pred_painted.png")
 
         # SAVE RESULTS FOR THIS PRED
         results_pred['image_id'] = subj_acq

--- a/ivadomed/inference.py
+++ b/ivadomed/inference.py
@@ -220,10 +220,10 @@ def pred_to_png(pred_list: list, target_list: list, subj_path: str, suffix: str 
         target_list (list of str): list of target suffixes.
         subj_path (str): Path of the subject filename in output folder without extension
             (e.g. "path_output/pred_masks/sub-01_sample-01_SEM").
-        suffix (str): additional suffix to append to the filename.
+        suffix (str): additional suffix to append to the filename (e.g. "_pred.png")
     """
     for pred, target in zip(pred_list, target_list):
-        filename = subj_path + target + "_pred" + suffix + ".png"
+        filename = subj_path + target + suffix
         data = pred.get_fdata()
         imageio.imwrite(filename, data, format='png')
 

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -306,7 +306,8 @@ def run_segment_command(context, model_params):
             if "nii" not in extension:
                 imed_inference.pred_to_png(pred_list,
                                            target_list,
-                                           str(Path(pred_path, subject)).replace(extension, ''))
+                                           str(Path(pred_path, subject)).replace(extension, ''),
+                                           suffix="_pred.png")
 
 
 def run_command(context, n_gif=0, thr_increment=None, resume_training=False):

--- a/ivadomed/testing.py
+++ b/ivadomed/testing.py
@@ -263,7 +263,8 @@ def run_inference(test_loader, model, model_params, testing_params, ofolder, cud
                         target_list = ["_class-%d" % i for i in range(len(testing_params['target_suffix']))]
                         imed_inference.pred_to_png(output_list,
                                                    target_list,
-                                                   fname_pred.split("_pred.nii.gz")[0])
+                                                   fname_pred.split("_pred.nii.gz")[0],
+                                                   suffix="_pred.png")
 
                     # re-init pred_stack_lst and last_slice_bool
                     pred_tmp_lst, z_tmp_lst = [], []


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR address an issue with prediction filenames found when integrating ivadomed in ADS in https://github.com/neuropoly/axondeepseg/pull/587#issuecomment-1018705068.
It refactored the `pred_to_png` function to remove hardcoded strings in the filename (namely the `_pred` and `.png` part of the filename) that were interfering with the naming convention used in ADS.
`pred` and `.png` are now passed to the already existing "suffix" argument of `pred_to_png`, the behavior in ivadomed is unchanged.

@mathieuboudreau, the PR is a draft for now, would you be able to test it from this branch in ADS v4?
I also removed the hardcoded ".png" so you should be able to pass our `target_lst` directly without removing the `.png` on ADS side. Let me know if that works as intended, thanks!

## Linked issues
Related to https://github.com/neuropoly/axondeepseg/pull/587