### PR TITLE
Random patch sampling

### DIFF
--- a/ivadomed/keywords.py
+++ b/ivadomed/keywords.py
@@ -72,6 +72,7 @@ class TrainingParamsKW:
 class TransformationKW:
     ROICROP = "ROICrop"
     CENTERCROP = "CenterCrop"
+    RANDOMCROP = "RandomCrop"
     RESAMPLE = "Resample"
 
 

--- a/ivadomed/transforms.py
+++ b/ivadomed/transforms.py
@@ -505,6 +505,28 @@ class ROICrop(Crop):
         return super().__call__(sample, metadata)
 
 
+class RandomCrop(Crop):
+    """Make a random crop of a specified size."""
+
+    @multichannel_capable
+    @multichannel_capable  # for multiple raters during training/preprocessing
+    @two_dim_compatible
+    def __call__(self, sample, metadata=None):
+        # Only modify metadata if random crop is not specified on sample beforehand
+        if self.__class__.__name__ not in metadata[MetadataKW.CROP_PARAMS]:
+            # Crop parameters
+            th, tw, td = self.size
+            h, w, d = sample.shape
+            fh = int(np.random.uniform(*sorted((0, h - th))))
+            fw = int(np.random.uniform(*sorted((0, w - tw))))
+            fd = int(np.random.uniform(*sorted((0, d - td))))
+            params = (fh, fw, fd, h, w, d)
+            metadata[MetadataKW.CROP_PARAMS][self.__class__.__name__] = params
+
+        # Call base method
+        return super().__call__(sample, metadata)
+
+
 class DilateGT(ImedTransform):
     """Randomly dilate a ground-truth tensor.
 


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR explores random / uniform patch sampling [as implemented in `torchio`](https://torchio.readthedocs.io/_modules/torchio/data/sampler/uniform.html#UniformSampler) as an alternative to (i) center-cropping and (ii) using length and stride parameters in `ivadomed` to traverse the image in a rigid way. Random sampling of patches involves randomly choosing a starting pixel `(x, y, z)` for the cropping every time the transformation is invoked. 

This PR (to-be updated as we progress)
* adds the `RANDOMCROP` keyword in `ivadomed/keywords.py` for the random crop transformation
* implements random crop transformation for images and GTs through a `RandomCrop()` class in `ivadomed/transforms.py`

The goal of using this transformation is to diversify the training and preliminary results are provided below on `data_axondeepseg_sem`, our publicly available dataset consisting of 10 microscopy samples of rat spinal cord as mentioned in the [microscopy tutorial](https://ivadomed.org/tutorials/two_class_microscopy_seg_2d_unet.html). We compare different random crop scenarios to the [original config file provided in the tutorial](https://github.com/ivadomed/ivadomed/blob/master/ivadomed/config/config_microscopy.json).

| Training Config | Multi-class Test Dice Score | Seconds per Epoch | Environment and GPU |
| --------------  | --------------------------- | -------------------- | ---------------------- |
| Original config file | 0.8511 | ~25 secs | romane, RTX A6000 |
| Random cropping, n=8  | 0.8490 | ~5 secs | romane, RTX A6000 |
| Random cropping, n=16  | **0.8549** | ~10 secs | romane, RTX A6000 |
| Random cropping, n=32  | 0.8536 | ~20 secs | romane, RTX A6000 |

As we can see, the random cropping strategy matches and even exceeds the performance for the original config file with significantly faster training runtimes (note that the inference runtime stays the same). All of these configs were tested using the original config file (i.e. with `ivadomed --test`) which performs standard traversal across images with a length of `256` and a stride of `244` in both axes.

To replicate the results shown above, I also had to implement the functionality to draw a specified number of samples per subject (shown as n in the table above) so that we can **randomly crop multiple images from the same subject**. This not only further diversifies each training epoch, but also ensures fair comparison to standard traversal strategy which sees the entire subject image in each pass. For now, an hack I found was to change

https://github.com/ivadomed/ivadomed/blob/76b36a0a0f7141feb2d5b00b33e4c3a06865fc2c/ivadomed/loader/mri2d_segmentation_dataset.py#L128-L129

to

```python
else:
    for _ in range(NUM_SAMPLES_PER_SUBJECT):
        self.indexes.append(item)
```

However, of course this only works for the current 2D segmentation task and we have to generalize it to all use cases.

To-do:
- [ ] Implement num samples per subject functionality (i.e. draw multiple samples to enhance diversification) in a dataset- and task-agnostic way
- [ ] Test random cropping in other datasets than microscopy to assess its effectiveness
- [ ] Update documentation about random cropping
- [ ] Find a way to use a single config file where training dataset uses random cropping and validation and test datasets use standard traversal through the length and stride params

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Resolves #1018.
