### PR TITLE
Implemented denoising filter in preprocessing

### DIFF
--- a/docs/source/configuration_file.rst
+++ b/docs/source/configuration_file.rst
@@ -1771,6 +1771,37 @@ Transformations applied during data augmentation. Transformations are sorted in 
         }
     }
 
+.. jsonschema::
+
+    {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": "Denoise",
+        "type": "dict",
+        "$$description": [
+            "Denoise an image using non-local means adaptive denoising from P. Coupe et al."
+        ],
+        "options": {
+            "patch_radius": {
+                "type": "int"
+            },
+            "block_radius": {
+                "type": "int"
+            }
+        }
+    }
+
+.. code-block:: JSON
+
+    {
+        "transformation": {
+            "Denoise": {
+                "patch_radius": 1,
+                "block_radius": 5,
+                "applied_to": ["im"]
+            }
+        }
+    }
+
 .. _Uncertainty:
 
 Uncertainty

--- a/ivadomed/keywords.py
+++ b/ivadomed/keywords.py
@@ -73,6 +73,7 @@ class TransformationKW:
     ROICROP = "ROICrop"
     CENTERCROP = "CenterCrop"
     RESAMPLE = "Resample"
+    DENOISE = "Denoise"
 
 
 @dataclass

--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -21,3 +21,4 @@ tensorboard>=1.15.0
 tqdm>=4.30
 scipy
 torchio>=0.18.68
+dipy


### PR DESCRIPTION
## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR 
* implements a denoising filter via `dipy.denoise.nlmeans` just like how it is [implemented in SCT](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/f5aa4ce78077e44511f7e5fc923e8c2eda438ae8/spinalcordtoolbox/math.py#L278)
* imports `dipy` and adds a `dipy` dependency to `requirements_common.txt`
* adds the `DENOISE` keyword in `ivadomed/keywords.py`
* updates the docs accordingly

To test this PR using this branch, you can add
```json
"Denoise": {
     "patch_radius": 1,
     "block_radius": 5,
     "applied_to": ["im"]
},
```
to the config file given in [one-class segmentation with 2D U-Net tutorial](https://ivadomed.org/tutorials/one_class_segmentation_2d_unet.html)  or to the config file for your preferred task.

Optionally in reviewing of this PR, it would be great to consider that denoising is already [implemented in SCT](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/f5aa4ce78077e44511f7e5fc923e8c2eda438ae8/spinalcordtoolbox/math.py#L278) and question whether this current implementation in ivadomed can be simplified (e.g. directly calling SCT perhaps?)

More information and motivation for this feature can found at https://github.com/ivadomed/model_seg_ms_mp2rage/issues/46.

## Linked issues

Resolves #1072 
