### PR TITLE
Refactor missing print statements to be using logger

### DIFF
--- a/testing/unit_tests/test_patch_filter.py
+++ b/testing/unit_tests/test_patch_filter.py
@@ -3,6 +3,7 @@ import pytest
 import numpy as np
 import torch.backends.cudnn as cudnn
 from torch.utils.data import DataLoader
+from loguru import logger
 
 from ivadomed.loader.bids_dataframe import BidsDataframe
 from ivadomed import utils as imed_utils
@@ -29,7 +30,7 @@ def _cmpt_slice(ds_loader):
                 cmpt_label[1] += 1
             else:
                 cmpt_label[0] += 1
-    print(cmpt_label)
+    logger.debug(cmpt_label)
     return cmpt_label[0], cmpt_label[1]
 
 
@@ -66,13 +67,13 @@ def test_patch_filter(download_data_testing_test_files, transforms_dict, train_l
     bids_df = BidsDataframe(loader_params, __tmp_dir__, derivatives=True)
     ds = imed_loader.load_dataset(bids_df, **loader_params)
 
-    print('\tNumber of loaded patches: {}'.format(len(ds)))
+    logger.info(f"\tNumber of loaded patches: {len(ds)}")
 
     loader = DataLoader(ds, batch_size=BATCH_SIZE,
                         shuffle=True, pin_memory=True,
                         collate_fn=imed_loader_utils.imed_collate,
                         num_workers=0)
-    print('\tNumber of Neg/Pos patches in GT.')
+    logger.info("\tNumber of Neg/Pos patches in GT.")
     cmpt_neg, cmpt_pos = _cmpt_slice(loader)
     if patch_filter_params["filter_empty_mask"]:
         if dataset_type == "testing":


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
A minor PR that aims to replace all of the `print` from PR #980 to be using `logger`.
## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
