### PR TITLE
Segment with ONNX or PT model based on CPU/GPU availability

### DIFF
--- a/ivadomed/inference.py
+++ b/ivadomed/inference.py
@@ -50,7 +50,7 @@ def get_preds(context: dict, fname_model: str, model_params: dict, gpu_id: int, 
 
     Args:
         context (dict): configuration dict.
-        fname_model (str): name of file containing model (without .pt or .onnx extension).
+        fname_model (str): name of file containing model.
         model_params (dict): dictionary containing model parameters.
         gpu_id (int): Number representing gpu number if available. Currently does NOT support multiple GPU segmentation.
         batch (dict): dictionary containing input, gt and metadata
@@ -60,16 +60,6 @@ def get_preds(context: dict, fname_model: str, model_params: dict, gpu_id: int, 
     """
     # Define device
     cuda_available, device = imed_utils.define_device(gpu_id)
-
-    # Assign '.onnx' or '.pt' model based on availability and device
-    # On GPU, '.pt' model is prioritized whereas '.onnx' model is prioritized on CPU.
-    if Path(fname_model + '.onnx').is_file():
-        if cuda_available and Path(fname_model + '.pt').is_file():
-            fname_model = fname_model + '.pt'
-        else:
-            fname_model = fname_model + '.onnx'
-    else:
-        fname_model = fname_model + '.pt'
 
     with torch.no_grad():
 

--- a/ivadomed/inference.py
+++ b/ivadomed/inference.py
@@ -50,7 +50,7 @@ def get_preds(context: dict, fname_model: str, model_params: dict, gpu_id: int, 
 
     Args:
         context (dict): configuration dict.
-        fname_model (str): name of file containing model.
+        fname_model (str): name of file containing model (without .pt or .onnx extension).
         model_params (dict): dictionary containing model parameters.
         gpu_id (int): Number representing gpu number if available. Currently does NOT support multiple GPU segmentation.
         batch (dict): dictionary containing input, gt and metadata
@@ -60,6 +60,16 @@ def get_preds(context: dict, fname_model: str, model_params: dict, gpu_id: int, 
     """
     # Define device
     cuda_available, device = imed_utils.define_device(gpu_id)
+
+    # Assign '.onnx' or '.pt' model based on availability and device
+    # On GPU, '.pt' model is prioritized whereas '.onnx' model is prioritized on CPU.
+    if Path(fname_model + '.onnx').is_file():
+        if cuda_available and Path(fname_model + '.pt').is_file():
+            fname_model = fname_model + '.pt'
+        else:
+            fname_model = fname_model + '.onnx'
+    else:
+        fname_model = fname_model + '.pt'
 
     with torch.no_grad():
 

--- a/ivadomed/models.py
+++ b/ivadomed/models.py
@@ -1486,27 +1486,29 @@ def set_model_for_retrain(model_path, retrain_fraction, map_location, reset=True
 def get_model_filenames(folder_model):
     """Get trained model filenames from its folder path.
 
-    This function checks if the folder_model exists and get trained model (.pt or .onnx) and its configuration file
-    (.json) from it.
-    Note: if the model exists as .onnx, then this function returns its onnx path instead of the .pt version.
+    This function checks if the folder_model exists and get trained model path (without .pt or .onnx extension)
+    and its configuration file (.json) from it.
 
     Args:
         folder_name (str): Path of the model folder.
 
     Returns:
-        str, str: Paths of the model (.onnx) and its configuration file (.json).
+        str, str: Paths of the model (without .pt or .onnx extension) and its configuration file (.json).
     """
     if Path(folder_model).is_dir():
         prefix_model = Path(folder_model).name
-        # Check if model and model metadata exist. Verify if ONNX model exists, if not try to find .pt model
-        fname_model = Path(folder_model, prefix_model + '.onnx')
-        if not fname_model.is_file():
-            fname_model = Path(folder_model, prefix_model + '.pt')
-            if not fname_model.exists():
-                raise FileNotFoundError(fname_model)
+        fname_model = Path(folder_model, prefix_model)
+
+        # Check if at least one of '.pt' or '.onnx' model exists
+        if not Path(str(fname_model) + '.onnx').is_file() and not Path(str(fname_model) + '.pt').is_file():
+            raise FileNotFoundError(f"Model files not found in model folder: "
+                                    f"'{str(fname_model) + '.onnx'}' or '{str(fname_model) + '.pt'}'")
+
         fname_model_metadata = Path(folder_model, prefix_model + '.json')
         if not fname_model_metadata.is_file():
-            raise FileNotFoundError(fname_model)
+            raise FileNotFoundError(f"Model config file not found in model folder: '{str(fname_model_metadata)}'")
+
     else:
         raise FileNotFoundError(folder_model)
+
     return str(fname_model), str(fname_model_metadata)

--- a/ivadomed/models.py
+++ b/ivadomed/models.py
@@ -1495,7 +1495,6 @@ def get_model_filenames(folder_model):
         str, str: Paths of the model (.pt or .onnx) and its configuration file (.json).
     """
     if Path(folder_model).is_dir():
-
         prefix_model = Path(folder_model).name
         fname_model_onnx = Path(folder_model, prefix_model + '.onnx')
         fname_model_pt = Path(folder_model, prefix_model + '.pt')
@@ -1517,7 +1516,6 @@ def get_model_filenames(folder_model):
         fname_model_metadata = Path(folder_model, prefix_model + '.json')
         if not fname_model_metadata.is_file():
             raise FileNotFoundError(f"Model config file not found in model folder: '{str(fname_model_metadata)}'")
-
     else:
         raise FileNotFoundError(folder_model)
 

--- a/ivadomed/training.py
+++ b/ivadomed/training.py
@@ -331,8 +331,8 @@ def train(model_params, dataset_train, dataset_val, training_params, path_output
                                            model_params[ModelParamsKW.FOLDER_NAME] + ".onnx")
             imed_utils.save_onnx_model(model, input_samples, str(best_model_path))
             logger.info(f"Model saved as '.onnx': {best_model_path}")
-        except:
-            logger.warning(f"Failed to save the model as '.onnx'")
+        except Exception as e:
+            logger.warning(f"Failed to save the model as '.onnx': {e}")
 
         # Save best model as PT in the model directory
         best_model_path = Path(path_output, model_params[ModelParamsKW.FOLDER_NAME],

--- a/ivadomed/training.py
+++ b/ivadomed/training.py
@@ -328,7 +328,7 @@ def train(model_params, dataset_train, dataset_val, training_params, path_output
         try:
             # Convert best model to ONNX and save it in model directory
             best_model_path = Path(path_output, model_params[ModelParamsKW.FOLDER_NAME],
-                                           model_params[ModelParamsKW.FOLDER_NAME] + ".onnx")
+                                   model_params[ModelParamsKW.FOLDER_NAME] + ".onnx")
             imed_utils.save_onnx_model(model, input_samples, str(best_model_path))
             logger.info(f"Model saved as '.onnx': {best_model_path}")
         except Exception as e:

--- a/ivadomed/training.py
+++ b/ivadomed/training.py
@@ -336,7 +336,7 @@ def train(model_params, dataset_train, dataset_val, training_params, path_output
 
         # Save best model as PT in the model directory
         best_model_path = Path(path_output, model_params[ModelParamsKW.FOLDER_NAME],
-                                       model_params[ModelParamsKW.FOLDER_NAME] + ".pt")
+                               model_params[ModelParamsKW.FOLDER_NAME] + ".pt")
         torch.save(model, best_model_path)
         logger.info(f"Model saved as '.pt': {best_model_path}")
 

--- a/ivadomed/training.py
+++ b/ivadomed/training.py
@@ -330,12 +330,15 @@ def train(model_params, dataset_train, dataset_val, training_params, path_output
             best_model_path = Path(path_output, model_params[ModelParamsKW.FOLDER_NAME],
                                            model_params[ModelParamsKW.FOLDER_NAME] + ".onnx")
             imed_utils.save_onnx_model(model, input_samples, str(best_model_path))
+            logger.info(f"Model saved as '.onnx': {best_model_path}")
         except:
-            # Save best model in model directory
-            best_model_path = Path(path_output, model_params[ModelParamsKW.FOLDER_NAME],
-                                           model_params[ModelParamsKW.FOLDER_NAME] + ".pt")
-            torch.save(model, best_model_path)
-            logger.warning(f"Failed to save the model as '.onnx', saved it as '.pt': {best_model_path}")
+            logger.warning(f"Failed to save the model as '.onnx'")
+
+        # Save best model as PT in the model directory
+        best_model_path = Path(path_output, model_params[ModelParamsKW.FOLDER_NAME],
+                                       model_params[ModelParamsKW.FOLDER_NAME] + ".pt")
+        torch.save(model, best_model_path)
+        logger.info(f"Model saved as '.pt': {best_model_path}")
 
     # Save GIFs
     gif_folder = Path(path_output, "gifs")


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

This PR fixes #961 and adds 2 features:
1) After training, both the ONNX and PT versions of the model are saved under the model folder. Up until now, when conversion to ONNX was possible, only the ONNX version was saved, otherwise, only the PT version.
2) When running `segment_volume` (through the `--segment` command or API), the version of the model used (ONNX or PT) is based on its availability and on GPU availability. Hence, when GPU is available, PT is used (if available) otherwise ONNX is used. And vice-versa for CPU using ONNX in priority.

Details of the motivation are explained in #961.
In addition for ADS, we chose to package our model repo with both the ONNX and PT version, ex: [SEM model](https://github.com/axondeepseg/default-SEM-model/tree/main/model_seg_rat_axon-myelin_sem).
This PR will allow the segmentation to be done more efficiently on large microscopy images by choosing the ONNX version (optimize for CPU) or the PT version (optimized for GPU) depending on the device.

Tagging @joshuacwnewton because the `segment_volume` API is also used by SCT.

## Linked issues
Fixes #961 
