### PR TITLE
Fix loading when names of multiple target_suffix overlap

### DIFF
--- a/ivadomed/loader/bids_dataframe.py
+++ b/ivadomed/loader/bids_dataframe.py
@@ -115,8 +115,11 @@ class BidsDataframe:
             # Drop rows with json, tsv and LICENSE files in case no extensions are provided in config file for filtering
             df_next = df_next[~df_next['filename'].str.endswith(tuple(['.json', '.tsv', 'LICENSE']))]
 
-            # Update dataframe with subject files of chosen contrasts
-            # and with derivative files of chosen target_suffix
+            # The following command updates the dataframe by doing 2 things:
+            # 1. Keep only subject files of chosen contrasts (for files that are not in the 'derivatives' folder)
+            #    (ex: '<dataset_path>/sub-XX/anat/sub-XX_T1w.nii.gz' with contrast_lst:["T1w"])
+            # 2. Keep only derivatives files of chosen target_suffix (for files that are in the 'derivatives' folder)
+            #    (ex: '<dataset_path>/derivatives/labels/sub-XX/anat/sub-XX_T1w_seg-manual.nii.gz' with target_suffix:["_seg-manual"])
             df_next = df_next[(~df_next['path'].str.contains('derivatives')
                                & df_next['suffix'].str.contains('|'.join(self.contrast_lst)))
                                | (df_next['path'].str.contains('derivatives')

--- a/ivadomed/loader/bids_dataframe.py
+++ b/ivadomed/loader/bids_dataframe.py
@@ -119,8 +119,8 @@ class BidsDataframe:
             # and with derivative files of chosen target_suffix
             df_next = df_next[(~df_next['path'].str.contains('derivatives')
                                & df_next['suffix'].str.contains('|'.join(self.contrast_lst)))
-                              | (df_next['path'].str.contains('derivatives')
-                                 & df_next['filename'].str.contains('|'.join(self.target_suffix)))]
+                               | (df_next['path'].str.contains('derivatives')
+                               & (df_next['filename'].str.split('.').apply(lambda x: x[0])).str.endswith(tuple(self.target_suffix)))]
 
             # Update dataframe with files of chosen extensions
             df_next = df_next[df_next['filename'].str.endswith(tuple(self.extensions))]


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR attempts to fix issue #1055 where the derivatives were index with "contains" in the filename that could pick-up multiple targets in certain case.

I replaced "contains" by "endswith" which will prevent the 2 problems we have encountered so far when the target_suffix names overlap which are:
- `_lesion-manual` and `_lesion-manual2` files were used with target_suffix `_lesion-manual` ([ref comment](https://github.com/ivadomed/ivadomed/issues/1055#issue-1114505527))
- `_seg-axon` and `_seg-axonmyelin` files were used with target_suffix `_seg-axon` ([ref comment](https://github.com/ivadomed/ivadomed/issues/1055#issuecomment-1064226989))


## Discussion points:

**EDIT: I'll leave the discussion points here for future reference. However, as commented below, the "endswith" approach is sufficient for now and further improvements of pairing visibility of image and grounds-truths for the users will be done separately (see #1102).**
1. Some cases may not be covered because "endswith" is still not an exact match.
ex: `manual` could be used to match `lesion-manual` ([ref comment](https://github.com/ivadomed/ivadomed/issues/1055#issuecomment-1023904525))
2. I was unable to enforce an exact match because I don't know where to split the filename to get the beginning of the `target_suffix`. My original idea was to split after the `modality_suffix` (columns `suffix` in the dataframe), but unfortunately the `modality_suffix` are not indexed by pybids for derivatives files.
3. We could split at the last underscore but that implies that the `target_suffix` in the filenames must not have underscore in them except for the leading underscore.
4. In addition, an exact match implies that the underscore must always be included in the `target_suffix` in the config file.

## Linked issues
Fixes #1055
