### PR TITLE
Fix loading of TIF 16bits grayscale files

### DIFF
--- a/ivadomed/loader/segmentation_pair.py
+++ b/ivadomed/loader/segmentation_pair.py
@@ -311,7 +311,9 @@ class SegmentationPair(object):
         # For '.png', '.tif', '.tiff', '.jpg' and 'jpeg' extentions
         # Read image as 8 bit grayscale in numpy array (behavior TBD in ivadomed for RGB, RBGA or higher bit depth)
         if "tif" in extension:
-            img = np.expand_dims(imageio.imread(filename, format='tiff-pil', as_gray=True), axis=-1).astype(np.uint8)
+            img = np.expand_dims(imageio.imread(filename, format='tiff-pil'), axis=-1).astype(np.uint8)
+            if len(img.shape) > 3:
+                img = np.expand_dims(imageio.imread(filename, format='tiff-pil', as_gray=True), axis=-1).astype(np.uint8)
         else:
             img = np.expand_dims(imageio.imread(filename, as_gray=True), axis=-1).astype(np.uint8)
 

--- a/ivadomed/scripts/download_data.py
+++ b/ivadomed/scripts/download_data.py
@@ -23,7 +23,7 @@ DICT_URL = {
             `Spine Generic <https://github.com/spine-generic/data-multi-subject>`_.
             Used for Tutorial and example in Ivadomed."""},
     "data_testing": {
-        "url": ["https://github.com/ivadomed/data-testing/archive/r20220221.zip"],
+        "url": ["https://github.com/ivadomed/data-testing/archive/r20220328.zip"],
         "description": "Data Used for integration/unit test in Ivadomed."},
     "t2_tumor": {
         "url": ["https://github.com/ivadomed/t2_tumor/archive/r20200621.zip"],

--- a/testing/unit_tests/test_loader.py
+++ b/testing/unit_tests/test_loader.py
@@ -378,9 +378,7 @@ def test_microscopy_pixelsize(download_data_testing_test_files, loader_parameter
     "dropout_rate": 0.3,
     "bn_momentum": 0.1,
     "final_activation": "sigmoid",
-    "depth": 3,
-    "length_2D": [256, 256],
-    "stride_2D": [256, 256]
+    "depth": 3
     }])
 def test_read_png_tif(download_data_testing_test_files, loader_parameters, model_parameters):
     """
@@ -396,13 +394,12 @@ def test_read_png_tif(download_data_testing_test_files, loader_parameters, model
     filename_pairs = [(file_lst, None, None, metadata if isinstance(metadata, list) else [metadata])]
     slice_axis = imed_utils.AXIS_DCT[loader_parameters[LoaderParamsKW.SLICE_AXIS]]
     ds = imed_loader_mri2dseg.MRI2DSegmentationDataset(filename_pairs,
-                                                       length=model_parameters[ModelParamsKW.LENGTH_2D],
-                                                       stride=model_parameters[ModelParamsKW.STRIDE_2D],
                                                        slice_axis=slice_axis,
                                                        cache=True,
                                                        transform=[None, None],
                                                        slice_filter_fn=None)
     ds.load_filenames()
+
 
 def teardown_function():
     remove_tmp_dir()

--- a/testing/unit_tests/test_loader.py
+++ b/testing/unit_tests/test_loader.py
@@ -11,7 +11,7 @@ from ivadomed import utils as imed_utils
 from ivadomed.loader import utils as imed_loader_utils
 from ivadomed.loader import loader as imed_loader
 from ivadomed.loader import mri2d_segmentation_dataset as imed_loader_mri2dseg
-from ivadomed.keywords import LoaderParamsKW, MetadataKW, ModelParamsKW
+from ivadomed.keywords import LoaderParamsKW, MetadataKW, ModelParamsKW, TransformationKW
 from pathlib import Path
 logger = logging.getLogger(__name__)
 
@@ -39,8 +39,8 @@ def test_bids_df_microscopy_png(download_data_testing_test_files, loader_paramet
     bids_df = BidsDataframe(loader_parameters, __tmp_dir__, derivatives=True)
     df_test = bids_df.df.drop(columns=['path'])
     df_test = df_test.sort_values(by=['filename']).reset_index(drop=True)
-    csv_ref = Path(loader_parameters["path_data"][0], "df_ref.csv")
-    csv_test = Path(loader_parameters["path_data"][0], "df_test.csv")
+    csv_ref = Path(loader_parameters[LoaderParamsKW.PATH_DATA][0], "df_ref.csv")
+    csv_test = Path(loader_parameters[LoaderParamsKW.PATH_DATA][0], "df_test.csv")
     df_test.to_csv(csv_test, index=False)
     diff = csv_diff.compare(csv_diff.load_csv(open(csv_ref)), csv_diff.load_csv(open(csv_test)))
     assert diff == {'added': [], 'removed': [], 'changed': [], 'columns_added': [], 'columns_removed': []}
@@ -64,8 +64,8 @@ def test_bids_df_anat(download_data_testing_test_files, loader_parameters):
     bids_df = BidsDataframe(loader_parameters, __tmp_dir__, derivatives=True)
     df_test = bids_df.df.drop(columns=['path'])
     df_test = df_test.sort_values(by=['filename']).reset_index(drop=True)
-    csv_ref = Path(loader_parameters["path_data"][0], "df_ref.csv")
-    csv_test = Path(loader_parameters["path_data"][0], "df_test.csv")
+    csv_ref = Path(loader_parameters[LoaderParamsKW.PATH_DATA][0], "df_ref.csv")
+    csv_test = Path(loader_parameters[LoaderParamsKW.PATH_DATA][0], "df_test.csv")
     df_test.to_csv(csv_test, index=False)
     diff = csv_diff.compare(csv_diff.load_csv(open(csv_ref)), csv_diff.load_csv(open(csv_test)))
     assert diff == {'added': [], 'removed': [], 'changed': [],
@@ -88,8 +88,8 @@ def test_bids_df_multi(download_data_testing_test_files, loader_parameters):
     bids_df = BidsDataframe(loader_parameters, __tmp_dir__, derivatives=True)
     df_test = bids_df.df.drop(columns=['path'])
     df_test = df_test.sort_values(by=['filename']).reset_index(drop=True)
-    csv_ref = Path(loader_parameters["path_data"][0], "df_ref_multi.csv")
-    csv_test = Path(loader_parameters["path_data"][0], "df_test_multi.csv")
+    csv_ref = Path(loader_parameters[LoaderParamsKW.PATH_DATA][0], "df_ref_multi.csv")
+    csv_test = Path(loader_parameters[LoaderParamsKW.PATH_DATA][0], "df_test_multi.csv")
     df_test.to_csv(csv_test, index=False)
     diff = csv_diff.compare(csv_diff.load_csv(open(csv_ref)), csv_diff.load_csv(open(csv_test)))
     assert diff == {'added': [], 'removed': [], 'changed': [],
@@ -113,8 +113,8 @@ def test_bids_df_ctscan(download_data_testing_test_files, loader_parameters):
     bids_df = BidsDataframe(loader_parameters, __tmp_dir__, derivatives=True)
     df_test = bids_df.df.drop(columns=['path'])
     df_test = df_test.sort_values(by=['filename']).reset_index(drop=True)
-    csv_ref = Path(loader_parameters["path_data"][0], "df_ref.csv")
-    csv_test = Path(loader_parameters["path_data"][0], "df_test.csv")
+    csv_ref = Path(loader_parameters[LoaderParamsKW.PATH_DATA][0], "df_ref.csv")
+    csv_test = Path(loader_parameters[LoaderParamsKW.PATH_DATA][0], "df_test.csv")
     df_test.to_csv(csv_test, index=False)
     diff = csv_diff.compare(csv_diff.load_csv(open(csv_ref)), csv_diff.load_csv(open(csv_test)))
     assert diff == {'added': [], 'removed': [], 'changed': [], 'columns_added': [], 'columns_removed': []}
@@ -168,7 +168,7 @@ def test_load_dataset_2d_png(download_data_testing_test_files,
     Test to make sure load_dataset runs with 2D PNG files, writes corresponding NIfTI files,
     and binarizes ground-truth values to 0 and 1.
     """
-    loader_parameters.update({"model_params": model_parameters})
+    loader_parameters.update({LoaderParamsKW.MODEL_PARAMS: model_parameters})
     bids_df = BidsDataframe(loader_parameters, __tmp_dir__, derivatives=True)
     data_lst = ['sub-rat3_ses-01_sample-data9_SEM.png']
     ds = imed_loader.load_dataset(bids_df,
@@ -217,7 +217,7 @@ def test_2d_patches_and_resampling(download_data_testing_test_files,
     Test that 2d patching is done properly.
     Test that microscopy pixelsize and resampling are applied on the right dimensions.
     """
-    loader_parameters.update({"model_params": model_parameters})
+    loader_parameters.update({LoaderParamsKW.MODEL_PARAMS: model_parameters})
     bids_df = BidsDataframe(loader_parameters, __tmp_dir__, derivatives=True)
     data_lst = ['sub-rat3_ses-01_sample-data9_SEM.png']
     ds = imed_loader.load_dataset(bids_df,
@@ -255,7 +255,7 @@ def test_get_target_filename_list(loader_parameters, model_parameters, transform
     """
     Test that all target_suffix are considered for target filename when list
     """
-    loader_parameters.update({"model_params": model_parameters})
+    loader_parameters.update({LoaderParamsKW.MODEL_PARAMS: model_parameters})
     bids_df = BidsDataframe(loader_parameters, __tmp_dir__, derivatives=True)
     data_lst = ['sub-rat3_ses-01_sample-data9_SEM.png']
     test_ds = imed_loader.load_dataset(bids_df,
@@ -264,7 +264,7 @@ def test_get_target_filename_list(loader_parameters, model_parameters, transform
                                                                   'dataset_type': 'training'}})
     target_filename = test_ds.filename_pairs[0][1]
     
-    assert len(target_filename) == len(loader_parameters["target_suffix"])
+    assert len(target_filename) == len(loader_parameters[LoaderParamsKW.TARGET_SUFFIX])
 
 
 @pytest.mark.parametrize('loader_parameters', [{
@@ -292,7 +292,7 @@ def test_get_target_filename_list_multiple_raters(loader_parameters, model_param
     """
     Test that all target_suffix are considered for target filename when list
     """
-    loader_parameters.update({"model_params": model_parameters})
+    loader_parameters.update({LoaderParamsKW.MODEL_PARAMS: model_parameters})
     bids_df = BidsDataframe(loader_parameters, __tmp_dir__, derivatives=True)
     data_lst = ['sub-rat3_ses-01_sample-data9_SEM.png']
     test_ds = imed_loader.load_dataset(bids_df,
@@ -301,9 +301,9 @@ def test_get_target_filename_list_multiple_raters(loader_parameters, model_param
                                                                   'dataset_type': 'training'}})
     target_filename = test_ds.filename_pairs[0][1]
 
-    assert len(target_filename) == len(loader_parameters["target_suffix"])
-    assert len(target_filename[0]) == len(loader_parameters["target_suffix"][0])
-    assert len(target_filename[1]) == len(loader_parameters["target_suffix"][1])
+    assert len(target_filename) == len(loader_parameters[LoaderParamsKW.TARGET_SUFFIX])
+    assert len(target_filename[0]) == len(loader_parameters[LoaderParamsKW.TARGET_SUFFIX][0])
+    assert len(target_filename[1]) == len(loader_parameters[LoaderParamsKW.TARGET_SUFFIX][1])
 
 
 @pytest.mark.parametrize('loader_parameters', [{
@@ -330,12 +330,12 @@ def test_microscopy_pixelsize(download_data_testing_test_files, loader_parameter
     Test that PixelSize and PixelSizeUnits microscopy metadata
     are handled properly for PixelSizeUnits: "mm", "um" and "nm"
     """
-    loader_parameters.update({"model_params": model_parameters})
+    loader_parameters.update({LoaderParamsKW.MODEL_PARAMS: model_parameters})
     bids_df = BidsDataframe(loader_parameters, __tmp_dir__, derivatives=True)
 
     # PixelSizeUnits: "mm"
     data_lst = ['sub-rat2_sample-data5_SEM.png']
-    transform_parameters = {"Resample": {"wspace": 0.000093, "hspace": 0.000093}}
+    transform_parameters = {TransformationKW.RESAMPLE: {"wspace": 0.000093, "hspace": 0.000093}}
     ds = imed_loader.load_dataset(bids_df,
                                   **{**loader_parameters, **{'data_list': data_lst,
                                                              'transforms_params': transform_parameters,
@@ -344,7 +344,7 @@ def test_microscopy_pixelsize(download_data_testing_test_files, loader_parameter
 
     # PixelSizeUnits: "um"
     data_lst = ['sub-rat3_ses-02_sample-data11_run-1_SEM.png']
-    transform_parameters = {"Resample": {"wspace": 0.0001, "hspace": 0.0001}}
+    transform_parameters = {TransformationKW.RESAMPLE: {"wspace": 0.0001, "hspace": 0.0001}}
     ds = imed_loader.load_dataset(bids_df,
                                   **{**loader_parameters, **{'data_list': data_lst,
                                                              'transforms_params': transform_parameters,
@@ -353,7 +353,7 @@ def test_microscopy_pixelsize(download_data_testing_test_files, loader_parameter
 
     # PixelSizeUnits: "nm"
     data_lst = ['sub-rat3_ses-02_sample-data10_SEM.png']
-    transform_parameters = {"Resample": {"wspace": 0.0001, "hspace": 0.0001}}
+    transform_parameters = {TransformationKW.RESAMPLE: {"wspace": 0.0001, "hspace": 0.0001}}
     ds = imed_loader.load_dataset(bids_df,
                                   **{**loader_parameters, **{'data_list': data_lst,
                                                              'transforms_params': transform_parameters,


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR fixes issue #1105 where TIF 16bits grayscale gave an error while loading:
- It includes a new test to make sure every combination of PNG/TIF, 8/16 bits, Grayscale/RGB/RGBA files are loaded properly.
- It requires a new set of testing images being integrated in data-testing in PR https://github.com/ivadomed/data-testing/pull/18.
- PR https://github.com/ivadomed/data-testing/pull/18 needs to be approved, merged and a new release of data-testing done to update the link for download [here](https://github.com/ivadomed/ivadomed/blob/6e1e87b4251a1e8985901194a821fb638d9242cb/ivadomed/scripts/download_data.py#L26) before merging the current PR.
- I updated some keywords in the code of the test_loader.py file as well.

## Linked issues
Fixes #1105 
