### PR TITLE
Fix TSV metadata indexation and remove unused lines from bids_dataframe based on split_method

### DIFF
--- a/docs/source/configuration_file.rst
+++ b/docs/source/configuration_file.rst
@@ -644,9 +644,9 @@ Split Dataset
         "$schema": "http://json-schema.org/draft-04/schema#",
         "title": "split_method",
         "$$description": [
-            "Metadata contained in a BIDS tabular file on which the files are shuffled, then split\n",
-            "between train/validation/test, according to ``train_fraction`` and ``test_fraction``.\n",
-            "For example, ``participant_id`` from the ``participants.tsv`` file will shuffle all participants,\n",
+            "Metadata contained in a BIDS tabular (TSV) file or a BIDS sidecar JSON file on which the files are shuffled\n",
+            "then split between train/validation/test, according to ``train_fraction`` and ``test_fraction``.\n",
+            "For examples, ``participant_id`` from the ``participants.tsv`` file will shuffle all participants\n",
             "then split between train/validation/test sets."
         ],
         "type": "string"

--- a/docs/source/configuration_file.rst
+++ b/docs/source/configuration_file.rst
@@ -646,7 +646,7 @@ Split Dataset
         "$$description": [
             "Metadata contained in a BIDS tabular (TSV) file or a BIDS sidecar JSON file on which the files are shuffled\n",
             "then split between train/validation/test, according to ``train_fraction`` and ``test_fraction``.\n",
-            "For examples, ``participant_id`` from the ``participants.tsv`` file will shuffle all participants\n",
+            "For examples, ``participant_id`` will shuffle all participants from the ``participants.tsv`` file\n",
             "then split between train/validation/test sets."
         ],
         "type": "string"

--- a/ivadomed/loader/bids_dataframe.py
+++ b/ivadomed/loader/bids_dataframe.py
@@ -154,11 +154,15 @@ class BidsDataframe:
         columns.remove('path')
         self.df = self.df[~(self.df.astype(str).duplicated(subset=columns, keep='first'))]
 
-        # Remove subject files without the "split_method" metadata if specified
-        # Keep all derivatives
+        # Remove subject files without the "split_method" metadata if specified and keep all derivatives
         if self.split_method:
-            files_remove = (self.df[(~self.df['path'].str.contains('derivatives')
-                               & self.df[self.split_method].isnull())]['filename']).tolist()
+            files_remove = (self.df[(
+                                # Path does not contain derivative string (i.e. we only target subject raw data files)
+                                ~self.df['path'].str.contains('derivatives')
+                                # and split method metadata is null (i.e. the subject must have the split_method metadata or will be excluded)
+                                & self.df[self.split_method].isnull())]
+                                # Get these filesnames and convert to list.
+                                ['filename']).tolist()
             if files_remove:
                 logger.warning("The files {} don't have the '{}' metadata used as split_method. Skipping files."
                                .format(files_remove, self.split_method))

--- a/ivadomed/loader/bids_dataframe.py
+++ b/ivadomed/loader/bids_dataframe.py
@@ -31,7 +31,7 @@ class BidsDataframe:
         df (pd.DataFrame): Dataframe containing dataset information
     """
 
-    def __init__(self, loader_params, path_output, derivatives, split_method=None):
+    def __init__(self, loader_params: dict, path_output: str, derivatives: bool, split_method: str = None):
 
         # paths_data from loader parameters
         self.paths_data = loader_params['path_data']
@@ -184,10 +184,16 @@ class BidsDataframe:
         # Drop columns with all null values
         self.df.dropna(axis=1, inplace=True, how='all')
 
-    def add_tsv_metadata(self, df, path_data, layout):
+    def add_tsv_metadata(self, df: pd.DataFrame, path_data: str, layout: pybids.BIDSLayout):
         """Add tsv files metadata to dataframe.
+
         Args:
-            layout (BIDSLayout): pybids BIDSLayout of the indexed files of the path_data
+            df (pd.DataFrame): Dataframe containing dataset information
+            path_data (str): Path to the BIDS dataset
+            layout (pybids.BIDSLayout): pybids BIDSLayout of the indexed files of the path_data
+
+        Returns:
+            pd.DataFrame: Dataframe containing datasets information
         """
 
         # Drop columns with all null values before loading TSV metadata
@@ -285,8 +291,9 @@ class BidsDataframe:
         """
         return self.df[self.df['path'].str.contains('derivatives')]['filename'].tolist()
 
-    def get_derivatives(self, subject_fname, deriv_fnames):
+    def get_derivatives(self, subject_fname: str, deriv_fnames: list):
         """Return list of available derivative filenames for a subject filename.
+
         Args:
             subject_fname (str): Subject filename.
             deriv_fnames (list of str): List of derivative filenames.
@@ -297,8 +304,9 @@ class BidsDataframe:
         prefix_fname = subject_fname.split('.')[0]
         return [d for d in deriv_fnames if prefix_fname in d]
 
-    def save(self, path):
+    def save(self, path: str):
         """Save the dataframe into a csv file.
+
         Args:
             path (str): Path to csv file.
         """
@@ -308,8 +316,11 @@ class BidsDataframe:
         except FileNotFoundError:
             logger.error("Wrong path, bids_dataframe.csv could not be saved in {}.".format(path))
 
-    def write_derivatives_dataset_description(self, path_data):
+    def write_derivatives_dataset_description(self, path_data: str):
         """Writes default dataset_description.json file if not found in path_data/derivatives folder
+
+        Args:
+            path_data (str): Path to the BIDS dataset.
         """
         path_data = Path(path_data).absolute()
 

--- a/ivadomed/loader/bids_dataframe.py
+++ b/ivadomed/loader/bids_dataframe.py
@@ -166,6 +166,7 @@ class BidsDataframe:
             if files_remove:
                 logger.warning(f"The following files don't have the '{self.split_method}' metadata indicated as the "
                                f"split_method in the configuration JSON file. Skipping these files: {files_remove}")
+                # Removing from dataframe all filenames which contain any of the file from files_remove field.
                 self.df = self.df[~self.df['filename'].str.contains('|'.join(files_remove))]
 
         # If indexing of derivatives is true

--- a/ivadomed/loader/bids_dataframe.py
+++ b/ivadomed/loader/bids_dataframe.py
@@ -133,7 +133,7 @@ class BidsDataframe:
 
             # Warning if no subject files are found in path_data
             if df_next[~df_next['path'].str.contains('derivatives')].empty:
-                logger.warning("No subject files were found in '{}' dataset. Skipping dataset.".format(path_data))
+                logger.warning(f"No subject files were found in '{path_data}' dataset. Skipping dataset.")
             else:
                 # Add tsv files metadata to dataframe
                 df_next = self.add_tsv_metadata(df_next, path_data, layout)
@@ -164,8 +164,8 @@ class BidsDataframe:
                                 # Get these filesnames and convert to list.
                                 ['filename']).tolist()
             if files_remove:
-                logger.warning("The files {} don't have the '{}' metadata used as split_method. Skipping files."
-                               .format(files_remove, self.split_method))
+                logger.warning(f"The following files don't have the '{self.split_method}' metadata indicated as the "
+                               f"split_method in the configuration JSON file. Skipping these files: {files_remove}")
                 self.df = self.df[~self.df['filename'].str.contains('|'.join(files_remove))]
 
         # If indexing of derivatives is true
@@ -266,16 +266,15 @@ class BidsDataframe:
                         has_deriv.append(subject_fname)
                         deriv.extend(available)
                     else:
-                        logger.warning("Missing roi_suffix {} for {}. Skipping file."
-                                       .format(self.roi_suffix, subject_fname))
+                        logger.warning(f"Missing roi_suffix {self.roi_suffix} for {subject_fname}. Skipping file.")
                 else:
                     has_deriv.append(subject_fname)
                     deriv.extend(available)
                 for target in self.target_suffix:
                     if target not in str(available) and target != self.roi_suffix:
-                        logger.warning("Missing target_suffix {} for {}".format(target, subject_fname))
+                        logger.warning(f"Missing target_suffix {target} for {subject_fname}")
             else:
-                logger.warning("Missing derivatives for {}. Skipping file.".format(subject_fname))
+                logger.warning(f"Missing derivatives for {subject_fname}. Skipping file.")
 
         return has_deriv, deriv
 
@@ -316,9 +315,9 @@ class BidsDataframe:
         """
         try:
             self.df.to_csv(path, index=False)
-            logger.info("Dataframe has been saved in {}.".format(path))
+            logger.info(f"Dataframe has been saved in {path}.")
         except FileNotFoundError:
-            logger.error("Wrong path, bids_dataframe.csv could not be saved in {}.".format(path))
+            logger.error(f"Wrong path, bids_dataframe.csv could not be saved in {path}.")
 
     def write_derivatives_dataset_description(self, path_data: str):
         """Writes default dataset_description.json file if not found in path_data/derivatives folder

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -21,7 +21,7 @@ from ivadomed import inference as imed_inference
 from ivadomed.loader import utils as imed_loader_utils, loader as imed_loader, film as imed_film
 from ivadomed.keywords import ConfigKW, ModelParamsKW, LoaderParamsKW, ContrastParamsKW, BalanceSamplesKW, \
     TrainingParamsKW, ObjectDetectionParamsKW, UncertaintyKW, PostprocessingKW, BinarizeProdictionKW, MetricsKW, \
-    MetadataKW, OptionKW
+    MetadataKW, OptionKW, SplitDatasetKW
 from loguru import logger
 from pathlib import Path
 
@@ -226,10 +226,12 @@ def update_film_model_params(context, ds_test, model_params, path_output):
 def run_segment_command(context, model_params):
     # BIDSDataframe of all image files
     # Indexing of derivatives is False for command segment
+    # split_method is unused for command segment
     bids_df = BidsDataframe(
         context.get(ConfigKW.LOADER_PARAMETERS),
         context.get(ConfigKW.PATH_OUTPUT),
-        derivatives=False
+        derivatives=False,
+        split_method=None
     )
 
     # Append subjects filenames into a list
@@ -371,8 +373,10 @@ def run_command(context, n_gif=0, thr_increment=None, resume_training=False):
         return
 
     # BIDSDataframe of all image files
-    # Indexing of derivatives is True for command train and test
-    bids_df = BidsDataframe(loader_params, path_output, derivatives=True)
+    # Indexing of derivatives is True for commands train and test
+    # split_method is used for removing unused subject files in bids_df for commands train and test
+    bids_df = BidsDataframe(loader_params, path_output, derivatives=True,
+        split_method=context.get(ConfigKW.SPLIT_DATASET).get(SplitDatasetKW.SPLIT_METHOD))
 
     # Get subject filenames lists. "segment" command uses all participants of data path, hence no need to split
     train_lst, valid_lst, test_lst = imed_loader_utils.get_subdatasets_subject_files_list(context[ConfigKW.SPLIT_DATASET],


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR is in complement to PR #1103 after feedback from a user in #1096 for training with microscopy data.

What is done:
1. Fix bug in TSV metadata indexation in `bids_dataframe`:

    -  Previously, the `participant_id` and `sample_id` were assigned to each file based on `subject` and `sample` columns, and then used to merge the TSV metadata. However, `participant_id` and `sample_id` are attributes from the TSV files and should not be pre-assigned.
    - In theory, all `subjects` should have a `participant_id` row in `participants.tsv`, same for `samples` and `sample_id` from `samples.tsv`. However, in practice, it is not always the case and the BIDS-validator doesn't check for this.
    - This was problematic because we often use `participant_id` to split the dataset (see [split_method](https://ivadomed.org/configuration_file.html#split-method)), but we were not taking potential discrepancies between `subjects` and `participant_id` into account.
    - The fix doesn't take retrocompatibility into account as it was more a bug then a feature.
2.  Remove unused files in the `bids_dataframe` based on the `split_method` for training and testing.

    - Related in part to point 1, `split_method` accepts ANY metadata present in the dataframe to make the split. Files that don't have a value in this metadata column won't be used, but they were still present in the `bids_dataframe.csv` file.
    - They are now removed from the dataframe and give a warning that the file is skipped in the terminal, similar to the warning used when derivatives are missing for a subject.
    - This does not apply with the command "segment" as all the files are segmented regardless of `split_method`.

3. Minor related clarification to documentation.

## Linked issues
Related to #1096 
