### PR TITLE
MONAI Models Integration

### DIFF
--- a/ivadomed/keywords.py
+++ b/ivadomed/keywords.py
@@ -7,6 +7,8 @@ class ConfigKW:
     TRAINING_PARAMETERS: str = "training_parameters"
     MODEL_NAME: str = "model_name"
     MODIFIED_3D_UNET: str = "Modified3DUNet"
+    MONAI_UNET: str = "MONAIUNet"
+    UNETR: str = "UNETR"
     DEBUGGING: str = "debugging"
     FILMED_UNET: str = "FiLMedUnet"
     DEFAULT_MODEL: str = "default_model"

--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -21,3 +21,4 @@ tensorboard>=1.15.0
 tqdm>=4.30
 scipy
 torchio>=0.18.68
+monai>=0.8.0


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

As per [this comment](https://github.com/ivadomed/ivadomed/issues/211#issuecomment-1080964112), this PR explores interoperability between ivadomed and MONAI by adapting MONAI's `BasicUNet()` and `UNETR()` models to ivadomed. Specifically, the additions are:
* `monai` requirement added to the `requirements_common.txt` and model keywords added to `keywords.py`
*  `ivadomed_params_to_monai_params()` helper function to facilitate the mapping of ivadomed params to MONAI params in `models.py`
* Two model classes `MONAIUNet()` and `UNETR()` IN `models.py`

The `MONAIUNet()` model, for example, can now be used for training & testing by including the following in the config file:
```json
    "default_model": {
        "name": "MONAIUNet",
        "dropout_rate": 0.3,
        "features": [8, 16, 32, 32, 16, 8],
        "is_2d": false,
        "final_activation": "sigmoid",
        "length_3D": [128, 64, 32],
        "stride_3D": [128, 64, 32],
        "attention": false
    },
```

### TODO
* Benchmark MONAI models against ivadomed models using the [model_seg_ms_mp2rage](https://github.com/ivadomed/model_seg_ms_mp2rage) project.
* Implement `"attention": true` case as this is not covered in MONAI's `BasicUNet`; there is `AttentionUnet()` for this purpose in MONAI.
* Further generalize & beautify the implementation.
* Update documentation once/if we decide to merge this PR.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Resolves #211. 
