### PR TITLE
Update publish_package.yml

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -7,12 +7,6 @@ on:
   # publish from the Releases page:
   release:
     types: [published]
-  # publish from the Actions page:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version (e.g. 2.0.3)'
-        required: true
 
 jobs:
   deploy:
@@ -20,12 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: '3.6'
+      uses: actions/setup-python@v3
         
     - name: Install dependencies
       run: |
@@ -34,15 +26,15 @@ jobs:
         
     - name: Build
       run: |
-          python -m build --wheel --sdist
+          python -m build
           
     - name: Publish to Github
       uses: softprops/action-gh-release@v1
       with:
         files: 'dist/*'
         fail_on_unmatched_files: true
-        tag_name: ${{ github.event.inputs.version }} # in the workflow_dispatch case, make a new tag from the given input; in the published release case, this will be empty and will fall back to updating that release.
-        
+        prerelease: ${{ contains(github.ref, 'rc') || contains(github.ref, 'dev') }}
+    
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:


### PR DESCRIPTION
I've used this script in some of my own projects, and this reintegrates some of the improvements I've made as I've used it in practice:

- bump dependencies
- drop building on python 3.6 (the package is version agnostic, so this is just confusing)
- drop the workflow_dispatch because it's glitchy in some cases; use the Releases page instead to create a release
- add prerelease tagging (using a tag with an 'rc' suffix would mark it as pre-release on PyPI, this makes it also so on the releases page on GitHub)