### PR TITLE
Use headless ("Agg") matplotlib backend in CI

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -19,6 +19,11 @@ env:
   # (TravisCI quietly defined this on all their platforms, but we have to give it manually on GithubCI.)
   DEBIAN_FRONTEND: 'noninteractive'
   HDF5_USE_FILE_LOCKING: 'FALSE'
+  # Skip to the headless matplotlib renderer, which is less
+  # bug-prone in the constrained environment of CI
+  # Tip from a matplotlib dev: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3388#issuecomment-846091012
+  # Ref: https://matplotlib.org/stable/users/explain/backends.html
+  MPLBACKEND: 'Agg'
 
 jobs:
   ultra_matrix_test:

--- a/ivadomed/scripts/visualize_and_compare_testing_models.py
+++ b/ivadomed/scripts/visualize_and_compare_testing_models.py
@@ -9,6 +9,7 @@
 ###########################################################################################################
 
 import matplotlib
+from matplotlib import pyplot as plt
 import pandas as pd
 import numpy as np
 import itertools

--- a/ivadomed/scripts/visualize_and_compare_testing_models.py
+++ b/ivadomed/scripts/visualize_and_compare_testing_models.py
@@ -21,21 +21,7 @@ import argparse
 
 matplotlib.rcParams['toolbar'] = 'None'  # Remove buttons
 
-gui_env = ['TKAgg', 'GTKAgg', 'Qt4Agg', 'WXAgg']
-selected_gui_env = []
-for gui in gui_env:
-    try:
-        matplotlib.use(gui)
-        from matplotlib import pyplot as plt
-
-        selected_gui_env = gui
-        break
-    except:
-        continue
-# If none works
-if selected_gui_env == []:
-    from matplotlib import pyplot as plt
-
+if matplotlib.get_backend() == "agg":
     logger.warning("No backend can be used - Visualization will fail")
 else:
     logger.info(f"Using: {matplotlib.get_backend()}  gui")

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -222,7 +222,6 @@ def plot_transformed_sample(before, after, list_title=None, fname_out="", cmap="
     if fname_out:
         plt.savefig(fname_out)
     else:
-        matplotlib.use('TkAgg')
         plt.show()
 
 


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

Force Agg matplotlib backend to avoid problems in CI. CI should be headless anyway, there's no need to try the other six backends.

## Linked issues

Fixes #1132, which is the most recent symptom, but it's not the only tricky thing that can come up when mixing and matching rendering backends and headless test machines.
