### PR TITLE
Drop redundant pre-commit checks

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,12 +10,8 @@ on:
 jobs:
 
   pre-commit-checks:
-    strategy:
-      matrix:
-        os: [ "macos-latest", "windows-latest", "ubuntu-18.04", "ubuntu-20.04",  "macos-10.15"]
-        python-version: [3.6, 3.7, 3.8]
         
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
 
       - name: Checkout repo


### PR DESCRIPTION


<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

There's no need to run the pre-commit checks on all platforms.

The checks themselves only take a couple of seconds, but waiting for VMs to be allocated and all of ivadomed to be installed in each can take a very long time:

[![Screenshot 2022-06-01 at 16-02-56 Actions · ivadomed_ivadomed](https://user-images.githubusercontent.com/987487/171491664-3a6cd7ae-041a-49a2-89c1-69f8b326cf5c.png)](https://github.com/ivadomed/ivadomed/actions/runs/2423871404)

[![Screenshot 2022-06-01 at 16-03-58 Actions · ivadomed_ivadomed](https://user-images.githubusercontent.com/987487/171491751-5943f633-576f-462d-a8f1-b61a63de2442.png)
](https://github.com/ivadomed/ivadomed/actions/runs/2423927382)

This is waste:

![Screenshot 2022-06-01 at 16-04-55 unify installation (attempt #2) · ivadomed_ivadomed@6c21c89](https://user-images.githubusercontent.com/987487/171491876-efea2b34-c02c-4d4c-9ecd-1dc529aa42da.png)


And also, waiting on pre-commit checks on one PR blocks other PRs from using CI, because Github only gives a limited VM budget.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
