### PR TITLE
Use setuptools_scm

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -26,7 +26,7 @@ jobs:
         
     - name: Build
       run: |
-          python -m build --wheel --sdist
+          python -m build
           
     - name: Publish to Github
       uses: softprops/action-gh-release@v1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-include ivadomed/config/*.json
-include ivadomed/version.txt

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -522,7 +522,7 @@ def run_command(context, n_gif=0, thr_increment=None, resume_training=False):
 def create_dataset_and_ivadomed_version_log(context):
     path_data = context.get(ConfigKW.LOADER_PARAMETERS).get(LoaderParamsKW.PATH_DATA)
 
-    ivadomed_version = imed_utils._version_string()
+    ivadomed_version = imed_utils.__version__
     datasets_version = []
 
     if isinstance(path_data, str):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+importlib_metadata; python_version<'3.8'
 # workarounds for pip 20.0.2's buggy dependency resolver
 # which doesn't account for cross-package constraints: https://pip.pypa.io/en/stable/user_guide/#changes-to-the-pip-dependency-resolver-in-20-3-2020
 # matplotlib pulls in the latest pyparsing, nibabel pulls in the latest packaging, and the two latests are in conflict.

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,6 @@ this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
-# Get Release version
-path_version = path.join(this_directory, 'ivadomed', 'version.txt')
-with open(path_version) as f:
-    version = f.read().strip()
-
 extra_requirements = {
     'docs': [
         # pin sphinx to match what RTD uses:
@@ -52,7 +47,6 @@ extra_requirements['dev'] = [
 
 setup(
     name='ivadomed',
-    version=version,
     description='Feature conditioning for IVADO medical imaging project.',
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -64,6 +58,8 @@ setup(
         'Intended Audience :: Developers',
         'Programming Language :: Python :: 3',
     ],
+    setup_requires=['setuptools_scm'],
+    use_scm_version=True, # read version from git tags
     python_requires='>=3.7,<3.10',
     packages=find_packages(exclude=['docs', 'tests']),
     include_package_data=True,


### PR DESCRIPTION

<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

setuptools_scm is the PyPA-blessed way to integrate git with pip.

Replaces version.txt with the most recent git tag, and MANIFEST.in with
git's contents.  This makes it much less likely to accidentally publish
a broken build, and less work to do a release.

Drops _git_info() and its subroutines. This changes the version string's
format used in dev mode (pip install -e). It previously was

```
{install_type}-{ivadomed_branch}-{ivadomed_commit}
```

Now it's (roughly)

```
{tag+1}.dev{N}+g{commit}[.d{date}]
```

which is https://peps.python.org/pep-0440/#version-scheme approved.

e.g. right now the most recent tag is v2.9.5, 9 commits back before the
current ec136672i, so setuptools_scm generates "2.9.6.dev9+gec136672".
If the branch is edited with uncommited changes, it is marked "dirty"
with "2.9.6.dev9+gec136672.d20220602"; this is a feature the previous
format couldn't tell us. Losing the branch name is too bad but we can
probably live without it for the benefit of conforming to standards.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

The fragileness of MANIFEST.in showed up while trying to release 2.9.6: https://github.com/ivadomed/ivadomed/runs/6711207528?check_suite_focus=true#step:6:169. The immediate problem there was broken build introduced by https://github.com/ivadomed/ivadomed/pull/1131#issuecomment-1145207416, which was reverted in https://github.com/ivadomed/ivadomed/pull/1144, but setuptools_scm is a much stronger long term solution.