### PR TITLE
fix: metric flag while vizualizing

### DIFF
--- a/ivadomed/scripts/visualize_and_compare_testing_models.py
+++ b/ivadomed/scripts/visualize_and_compare_testing_models.py
@@ -49,7 +49,8 @@ def onclick(event, df):
     #          If that's the case, all will be displayed
     clicked_index = event.ind
 
-    fig = plt.gca()
+    ax = plt.gca()
+
     # clicking outside the plot area produces a coordinate of None, so we filter those out.
     if None not in clicked_index:
         output_folders = df["EvaluationModel"].unique()
@@ -57,9 +58,9 @@ def onclick(event, df):
 
         # Remove the previously displayed subject(s)
         # This also takes care of the case where more than one subjects are displayed
-        while len(fig.texts) > nfolders + np.math.factorial(nfolders) / (
+        while len(ax.texts) > nfolders + np.math.factorial(nfolders) / (
                 np.math.factorial(2) * np.math.factorial(nfolders - 2)):
-            fig.texts.pop()
+            ax.texts.pop()
 
         # This is a hack to find the index of the Violinplot - There should be another way to get this from the
         # figure object
@@ -69,15 +70,14 @@ def onclick(event, df):
         selected_output_folder = df[df["EvaluationModel"] == output_folders[i_output_folder]]
 
         for iSubject in range(0, len(clicked_index.tolist())):
-            frame = plt.text(event.mouseevent.xdata, -0.08 - 0.08 * iSubject + event.mouseevent.ydata,
+            frame = plt.text(event.mouseevent.xdata, -0.004 + event.mouseevent.ydata,
                              selected_output_folder["subject"][clicked_index[iSubject]], size=10,
                              ha="center", va="center",
                              bbox=dict(facecolor='red', alpha=0.5)
                              )
             # To show the artist
             matplotlib.artist.Artist.set_visible(frame, True)
-
-        plt.show()
+        plt.gcf().canvas.draw()
 
 
 def visualize_and_compare_models(ofolders, metric="dice_class0", metadata=None):
@@ -185,8 +185,11 @@ def visualize_and_compare_models(ofolders, metric="dice_class0", metadata=None):
         # Display the mean performance on top of every violinplot
         for i in range(len(ofolders)):
             # This will be used to plot the mean value on top of each individual violinplot
+
             temp = df[metric][df['EvaluationModel'] == Path(ofolders[i]).resolve().name]
-            plt.text(i, df[metric].max() + 0.07, str(round((100 * temp.mean())) / 100), ha='center', va='top',
+            
+            # mean values superimposed on the top of each violin plot: df[metric].max() + 0.07
+            plt.gca().text(i, 0.99, str(round(temp.mean(),2)), ha='center', va='top',
                      color='r', picker=True)
 
         if len(ofolders) > 1 and len(ofolders) < 5:

--- a/ivadomed/scripts/visualize_and_compare_testing_models.py
+++ b/ivadomed/scripts/visualize_and_compare_testing_models.py
@@ -35,7 +35,7 @@ def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("--ofolders", required=True, nargs="*", dest="ofolders",
                         help="List of log folders from different models.")
-    parser.add_argument("--metric", default='dice_class0', nargs=1, type=str, dest="metric",
+    parser.add_argument("--metric", default='dice_class0', nargs='?', type=str, dest="metric",
                         help="Metric from evaluation_3Dmetrics.csv to base the plots on.")
     parser.add_argument("--metadata", required=False, nargs=2, type=str, dest="metadata",
                         help="Selection based on metadata from participants.tsv:"
@@ -118,9 +118,11 @@ def visualize_and_compare_models(ofolders, metric="dice_class0", metadata=None):
     # access CLI options
     logger.debug(f"ofolders: {ofolders}")
     logger.debug(f"metric: {metric}")
-    if metadata is None:
-        metadata = []
+
     if metadata:
+        logger.debug(f"metadata: {metadata}")
+    else:
+        metadata = []
         logger.debug(f"metadata: {metadata}")
 
     # Do a quick check that all the required files are present
@@ -161,7 +163,7 @@ def visualize_and_compare_models(ofolders, metric="dice_class0", metadata=None):
 
             folders = [Path(folder).resolve().name] * len(scores)
             subject_id = result["image_id"]
-            combined = np.column_stack((folders, scores.astype(np.object, folders), subject_id)).T
+            combined = np.column_stack((folders, scores.astype(object, folders), subject_id)).T
             singleFolderDF = pd.DataFrame(combined, columnNames).T
             df = df.append(singleFolderDF, ignore_index=True)
 
@@ -184,7 +186,7 @@ def visualize_and_compare_models(ofolders, metric="dice_class0", metadata=None):
         for i in range(len(ofolders)):
             # This will be used to plot the mean value on top of each individual violinplot
             temp = df[metric][df['EvaluationModel'] == Path(ofolders[i]).resolve().name]
-            plt.text(i, df[metric].max() + 0.07, str((100 * temp.mean()).round() / 100), ha='center', va='top',
+            plt.text(i, df[metric].max() + 0.07, str(round((100 * temp.mean())) / 100), ha='center', va='top',
                      color='r', picker=True)
 
         if len(ofolders) > 1 and len(ofolders) < 5:

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -444,7 +444,7 @@ def similarity_score(a: str, b: str) -> float:
 def init_ivadomed():
     """Initialize the ivadomed for typical terminal usage."""
     # Display ivadomed version
-    logger.info('\nivadomed ({})\n'.format(__version__))
+    logger.info(f'ivadomed ({__version__})')
 
 
 def print_stats(arr):


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR resolves the bug while using the `--metric` flag in the `visualize_and_compare_testing_models.py` script. Furthermore, the datapoints within each violinplot are made fixed to be interactive as they earlier usesd to be. Although, the visualization works completely fine but fails in case of using a Jupyter Notebook or a Google Colab Notebook.

## Linked issues
partially resolves #1138 
