### PR TITLE
fix: adapt the filenames of the predictions in pred_masks as per target_suffix

### DIFF
--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -98,7 +98,7 @@ def check_multiple_raters(is_train, loader_params):
         if not is_train:
             logger.error(
                 "Please provide only one annotation per class in 'target_suffix' when not training a model.\n")
-            exit()
+            sys.exit()
 
 
 def film_normalize_data(context, model_params, ds_train, ds_valid, path_output):

--- a/ivadomed/testing.py
+++ b/ivadomed/testing.py
@@ -223,7 +223,7 @@ def run_inference(test_loader, model, model_params, testing_params, ofolder, cud
                     # save the completely processed file as a NifTI file
                     if ofolder:
                         fname_pred = str(Path(ofolder, Path(fname_ref).name))
-                        fname_pred = fname_pred.rsplit("_", 1)[0] + '_pred.nii.gz'
+                        fname_pred = fname_pred.split(testing_params['target_suffix'][0])[0] + '_pred.nii.gz'
                         # If Uncertainty running, then we save each simulation result
                         if testing_params['uncertainty']['applied']:
                             fname_pred = fname_pred.split('.nii.gz')[0] + '_' + str(i_monte_carlo).zfill(2) + '.nii.gz'

--- a/testing/unit_tests/test_main.py
+++ b/testing/unit_tests/test_main.py
@@ -1,0 +1,14 @@
+import pytest
+
+from ivadomed.main import check_multiple_raters
+
+@pytest.mark.parametrize(
+    'is_train, loader_params', [
+       (False, {"target_suffix":
+           [["_seg-axon-manual1", "_seg-axon-manual2"],
+            ["_seg-myelin-manual1", "_seg-myelin-manual2"]]
+           }) 
+])
+def test_check_multiple_raters(is_train, loader_params):
+    with pytest.raises(SystemExit):
+        check_multiple_raters(is_train, loader_params)

--- a/testing/unit_tests/test_testing.py
+++ b/testing/unit_tests/test_testing.py
@@ -211,5 +211,98 @@ def test_inference_2d_microscopy(download_data_testing_test_files, transforms_di
     assert len([x for x in __output_dir__.iterdir() if x.name.endswith(".png")]) == 2*len(test_lst)
 
 
+@pytest.mark.parametrize('transforms_dict', [{
+        "CenterCrop": {
+                "size": [128, 128]
+            },
+        "NormalizeInstance": {"applied_to": ["im"]}
+    }])
+@pytest.mark.parametrize('test_lst',
+    [['sub-rat3_ses-01_sample-data9_SEM.png', 'sub-rat3_ses-02_sample-data10_SEM.png']])
+@pytest.mark.parametrize('target_lst', [["_seg-axon_manual", "_seg-myelin_manual"]])
+@pytest.mark.parametrize('roi_params', [{"suffix": None, "slice_filter_roi": None}])
+@pytest.mark.parametrize('testing_params', [{
+    "binarize_maxpooling": {},
+    "uncertainty": {
+        "applied": False,
+        "epistemic": False,
+        "aleatoric": False,
+        "n_it": 0
+    }}])
+def test_inference_2d_microscopy_target_suffix(download_data_testing_test_files, transforms_dict, test_lst, target_lst, roi_params,
+        testing_params):
+    """
+    This test checks if the filenames of the predictions in the pred_masks conform to the target_suffix and
+    are independent of _. As a result, _seg-axon-manual or _seg-axon_manual should yield same outputs
+    (c.f: https://github.com/ivadomed/ivadomed/issues/1135)
+    """
+    cuda_available, device = imed_utils.define_device(GPU_ID)
+
+    model_params = {"name": "Unet", "is_2d": True, "out_channel": 3}
+    loader_params = {
+        "transforms_params": transforms_dict,
+        "data_list": test_lst,
+        "dataset_type": "testing",
+        "requires_undo": True,
+        "contrast_params": {"contrast_lst": ['SEM'], "balance": {}},
+        "path_data": [str(Path(__data_testing_dir__, "microscopy_png"))],
+        "bids_config": f"{path_repo_root}/ivadomed/config/config_bids.json",
+        "target_suffix": target_lst,
+        "extensions": [".png"],
+        "roi_params": roi_params,
+        "slice_filter_params": {"filter_empty_mask": False, "filter_empty_input": True},
+        "patch_filter_params": {"filter_empty_mask": False, "filter_empty_input": False},
+        "slice_axis": SLICE_AXIS,
+        "multichannel": False
+    }
+    loader_params.update({"model_params": model_params})
+
+    # restructuring the dataset 
+    gt_path = f'{loader_params["path_data"][0]}/derivatives/labels/'
+    for file_path in Path(gt_path).rglob('*.png'):
+      src_filename = file_path.resolve()
+      dst_filename = '_'.join(str(src_filename).rsplit('-', 1))
+      src_filename.rename(Path(dst_filename))
+
+    # bids_df = BidsDataframe(loader_params, __tmp_dir__, derivatives=True)
+    bids_df = BidsDataframe(loader_params, '/content/', derivatives=True)
+
+    ds_test = imed_loader.load_dataset(bids_df, **loader_params)
+    test_loader = DataLoader(ds_test, batch_size=BATCH_SIZE,
+                             shuffle=False, pin_memory=True,
+                             collate_fn=imed_loader_utils.imed_collate,
+                             num_workers=0)
+
+    # Undo transform
+    val_undo_transform = imed_transforms.UndoCompose(imed_transforms.Compose(transforms_dict))
+
+    # Update testing_params
+    testing_params.update({
+        "slice_axis": loader_params["slice_axis"],
+        "target_suffix": loader_params["target_suffix"],
+        "undo_transforms": val_undo_transform
+    })
+
+    # Model
+    model = imed_models.Unet(out_channel=model_params['out_channel'])
+
+    if cuda_available:
+        model.cuda()
+    model.eval()
+
+    if not __output_dir__.is_dir():
+        __output_dir__.mkdir(parents=True, exist_ok=True)
+
+    preds_npy, gt_npy = imed_testing.run_inference(test_loader=test_loader,
+                                                   model=model,
+                                                   model_params=model_params,
+                                                   testing_params=testing_params,
+                                                   ofolder=str(__output_dir__),
+                                                   cuda_available=cuda_available)
+
+    for x in __output_dir__.iterdir():
+      if x.name.endswith('_pred.nii.gz'):
+        assert x.name.rsplit('_', 1)[0].endswith(loader_params['contrast_params']['contrast_lst'][-1])
+
 def teardown_function():
     remove_tmp_dir()

--- a/testing/unit_tests/test_testing.py
+++ b/testing/unit_tests/test_testing.py
@@ -229,7 +229,7 @@ def test_inference_2d_microscopy(download_data_testing_test_files, transforms_di
         "aleatoric": False,
         "n_it": 0
     }}])
-def test_inference_2d_microscopy_target_suffix(download_data_testing_test_files, transforms_dict, test_lst, target_lst, roi_params,
+def test_inference_target_suffix(download_data_testing_test_files, transforms_dict, test_lst, target_lst, roi_params,
         testing_params):
     """
     This test checks if the filename(s) of the prediction(s) saved as NifTI file(s) in the pred_masks

--- a/testing/unit_tests/test_testing.py
+++ b/testing/unit_tests/test_testing.py
@@ -232,8 +232,9 @@ def test_inference_2d_microscopy(download_data_testing_test_files, transforms_di
 def test_inference_2d_microscopy_target_suffix(download_data_testing_test_files, transforms_dict, test_lst, target_lst, roi_params,
         testing_params):
     """
-    This test checks if the filenames of the predictions in the pred_masks conform to the target_suffix and
-    are independent of _. As a result, _seg-axon-manual or _seg-axon_manual should yield same outputs
+    This test checks if the filename(s) of the prediction(s) saved as NifTI file(s) in the pred_masks
+    dir conform to the target_suffix or not. Thus, independent of underscore(s) in the target_suffix. As a result,
+    _seg-axon-manual or _seg-axon_manual should yield the same filename(s).
     (c.f: https://github.com/ivadomed/ivadomed/issues/1135)
     """
     cuda_available, device = imed_utils.define_device(GPU_ID)
@@ -301,7 +302,9 @@ def test_inference_2d_microscopy_target_suffix(download_data_testing_test_files,
 
     for x in __output_dir__.iterdir():
       if x.name.endswith('_pred.nii.gz'):
-        assert x.name.rsplit('_', 1)[0].endswith(loader_params['contrast_params']['contrast_lst'][-1])
+        assert x.name.rsplit('_', 1)[0].endswith(loader_params['contrast_params']['contrast_lst'][-1]), ( 
+            'Incompatible filename(s) of the prediction(s) saved as NifTI file(s)!'
+        )
 
 def teardown_function():
     remove_tmp_dir()

--- a/testing/unit_tests/test_testing.py
+++ b/testing/unit_tests/test_testing.py
@@ -264,8 +264,7 @@ def test_inference_2d_microscopy_target_suffix(download_data_testing_test_files,
       dst_filename = '_'.join(str(src_filename).rsplit('-', 1))
       src_filename.rename(Path(dst_filename))
 
-    # bids_df = BidsDataframe(loader_params, __tmp_dir__, derivatives=True)
-    bids_df = BidsDataframe(loader_params, '/content/', derivatives=True)
+    bids_df = BidsDataframe(loader_params, __tmp_dir__, derivatives=True)
 
     ds_test = imed_loader.load_dataset(bids_df, **loader_params)
     test_loader = DataLoader(ds_test, batch_size=BATCH_SIZE,


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR updates how the filenames of the predictions in pred_masks dir are saved. It is now adapted according to the `target_suffix` as opposed to earlier being dependent on underscores. As a result, either of the syntax, `_seg-axon-manual` or `_seg-axon_manual` should yield the same results.

## Testing 
To test this PR, replace the current changed line (226) with https://github.com/ivadomed/ivadomed/blob/f063485b083fc5503e1a1ee4ae0d7e947131603f/ivadomed/testing.py#L226
and run

```
pytest /content/ivadomed/testing/unit_tests/test_testing.py
```
you'd find the one of the tests to fail.

There were qualms about the proposed changed, whether it would work in the case of multiple raters. Currently, the `--test` command doesn't support multiple raters and raises an error if there are multiple annotations available for the ground truth:

<details>
<summary>ivadomed --test -c config_microscopy.json</summary>

```
2022-06-21 08:10:05.439 | INFO     | ivadomed.utils:init_ivadomed:454 - 
ivadomed (git-kk/adapt_to_target_suffix-74794da2f53b9868648b081a8a0a12a484dba3d9*)

2022-06-21 08:10:05.441 | INFO     | ivadomed.utils:get_path_output:405 - CLI flag --path-output not used to specify output directory. Will check config file for directory...
2022-06-21 08:10:05.442 | INFO     | ivadomed.utils:get_path_data:418 - CLI flag --path-data not used to specify BIDS data directory. Will check config file for directory...
2022-06-21 08:10:05.442 | INFO     | ivadomed.main:set_output_path:207 - Output path already exists: log_microscopy_sem
2022-06-21 08:10:05.546 | INFO     | ivadomed.utils:define_device:160 - Cuda is not available.
2022-06-21 08:10:05.547 | INFO     | ivadomed.utils:define_device:161 - Working on cpu.
2022-06-21 08:10:05.547 | INFO     | ivadomed.utils:display_selected_model_spec:176 - Selected architecture: Unet, with the following parameters:
2022-06-21 08:10:05.547 | INFO     | ivadomed.utils:display_selected_model_spec:179 - 	dropout_rate: 0.2
2022-06-21 08:10:05.547 | INFO     | ivadomed.utils:display_selected_model_spec:179 - 	bn_momentum: 0.1
2022-06-21 08:10:05.548 | INFO     | ivadomed.utils:display_selected_model_spec:179 - 	depth: 4
2022-06-21 08:10:05.548 | INFO     | ivadomed.utils:display_selected_model_spec:179 - 	is_2d: True
2022-06-21 08:10:05.548 | INFO     | ivadomed.utils:display_selected_model_spec:179 - 	final_activation: sigmoid
2022-06-21 08:10:05.548 | INFO     | ivadomed.utils:display_selected_model_spec:179 - 	length_2D: [256, 256]
2022-06-21 08:10:05.548 | INFO     | ivadomed.utils:display_selected_model_spec:179 - 	stride_2D: [244, 244]
2022-06-21 08:10:05.548 | INFO     | ivadomed.utils:display_selected_model_spec:179 - 	folder_name: model_seg_rat_axon-myelin_sem
2022-06-21 08:10:05.548 | INFO     | ivadomed.utils:display_selected_model_spec:179 - 	in_channel: 1
2022-06-21 08:10:05.548 | INFO     | ivadomed.utils:display_selected_model_spec:179 - 	out_channel: 3
2022-06-21 08:10:06.284 | INFO     | ivadomed.loader.bids_dataframe:save:322 - Dataframe has been saved in log_microscopy_sem/bids_dataframe.csv.
2022-06-21 08:10:06.292 | WARNING  | ivadomed.loader.utils:split_dataset:106 - After splitting: train, validation and test fractions are respectively 0.6, 0.3 and 0.1 of sample_id.
2022-06-21 08:10:06.319 | INFO     | ivadomed.utils:display_selected_transfoms:189 - Selected transformations for the ['testing'] dataset:
2022-06-21 08:10:06.319 | INFO     | ivadomed.utils:display_selected_transfoms:191 - 	Resample: {'hspace': 0.0001, 'wspace': 0.0001}
2022-06-21 08:10:06.319 | INFO     | ivadomed.utils:display_selected_transfoms:191 - 	NormalizeInstance: {'applied_to': ['im']}
2022-06-21 08:10:06.319 | INFO     | ivadomed.main:check_multiple_raters:96 - Annotations from multiple raters will be used during model training, one annotation from one rater randomly selected at each iteration.

2022-06-21 08:10:06.319 | ERROR    | ivadomed.main:check_multiple_raters:100 - Please provide only one annotation per class in 'target_suffix' when not training a model.
```

</details>

Hence, rules out the possibility to verify multiple raters as of now. But, it would be good to review this whenever the `--test` command is extended to include a multiple rater scenario. To document and ensure we don't miss the above scenario while extending it, I have added a test that would fail as soon as there is any change in the current `check_multiple_raters()` behaviour for `--test`.

## Linked issues
Resolves #1135
