### PR TITLE
Minor correction to unsupported file extension error message

### DIFF
--- a/ivadomed/loader/segmentation_pair.py
+++ b/ivadomed/loader/segmentation_pair.py
@@ -281,7 +281,7 @@ class SegmentationPair(object):
         extension = imed_loader_utils.get_file_extension(filename)
         # TODO: remove "ome" from condition when implementing OMETIFF support (#739)
         if (not extension) or ("ome" in extension):
-            raise RuntimeError(f"The input file extension '{extension}' of '{Path(filename).stem}' is not "
+            raise RuntimeError(f"The input file extension '{extension}' of '{Path(filename).name}' is not "
                                f"supported. ivadomed supports the following "
                                f"file extensions: '.nii', '.nii.gz', '.png', '.tif', '.tiff', '.jpg' and '.jpeg'.")
 


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
Very small PR to improve the error message when a file extension is not supported, especially for double extensions.

We previously used `.stem` to output the name of the faulty file **without extension** in the terminal.

This work great with single extension:
- With `filename = image.png` : `filename.stem` outputs `image`

But not with double extensions:
- With `filename = image.ome.tif` : `filename.stem` outputs `image.ome`

This PR now uses `.name` instead of `.stem` and outputs the full filename **with extension** in the terminal, so:

- With `filename = image.png` : `filename.stem` outputs `image.png`
- With `filename = image.ome.tif` : `filename.name` outputs `image.ome.tif`

## Linked issues
No related issues in ivadomed.
It was raised in ADS PR[629](https://github.com/axondeepseg/axondeepseg/pull/629#discussion_r914926683) where we use the same code to check file extensions.
