### PR TITLE
Remove deprecated torch and dev installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,6 @@ cd ivadomed
 pip install -e .
 ```
 
-### Install from source
-
-Make sure to install Torch1.8 following commands [here](https://pytorch.org/get-started/previous-versions/#v180) as pip is not able to auto infer GPU/CPU support on your behalf.
-Again, the more comprehensive installation instruction is available [there](https://ivadomed.org/installation.html).
 
 ## Contributors
 <p float="left">

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -131,46 +131,6 @@ Step 2: Install ``ivadomed``
                 pip install -e .
 
 
-Step 3: Install ``torch`` and ``torchvision`` with CPU or GPU Support
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-    .. tabs::
-
-        .. group-tab:: PyPI Installation
-
-            .. tabs::
-
-                .. tab:: Nvidia GPU Support
-
-                    ``ivadomed`` requires CUDA11 to execute properly. If you have a nvidia GPU, try to look up its Cuda Compute Score `here <https://developer.nvidia.com/cuda-gpus>`__, which needs to be > 3.5 to support CUDA11. Then, make sure to upgrade to nvidia driver to be at least v450+ or newer.
-
-                    You can use ``nvidia-smi`` in both Linux and Windows to check for driver CUDA Version listed at the top right of the output console. On Linux, simply type in ``nvidia-smi`` in any console to see the output. On windows, you will need to locate the `nvidia-smi.exe` tool by following the instructions on `this page <https://stackoverflow.com/a/57100016>`__.
-
-                    If you have a compatible NVIDIA GPU that supports CUDA11, and you have a recent enough driver installed, then run the following command:
-
-                    .. code::
-
-                       pip install torch==1.8.1+cu111 torchvision==0.9.1+cu111 --find-links https://download.pytorch.org/whl/torch_stable.html
-
-                .. tab:: CPU Support
-
-                    If you plan to run ``ivadomed`` on CPU only, install PyTorch per instructions provided below for your specific operating system:
-
-                    .. tabs::
-
-                        .. tab:: Windows/Linux
-
-                            .. code::
-
-                               pip install torch==1.8.0+cpu torchvision==0.9.0+cpu --find-links https://download.pytorch.org/whl/torch_stable.html
-
-                        .. tab:: Mac
-
-                            .. code::
-
-                               pip install torch==1.8.0 torchvision==0.9.0 --find-links https://download.pytorch.org/whl/torch_stable.html
-
-
         .. group-tab:: Repo Installation (Advanced or Developer)
 
             Run this only if you have already downloaded/cloned the repo with access to the ``requirement_gpu.txt`` file, then run the following command while at the repository root level:

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -130,28 +130,3 @@ Step 2: Install ``ivadomed``
 
                 pip install -e .
 
-
-        .. group-tab:: Repo Installation (Advanced or Developer)
-
-            Run this only if you have already downloaded/cloned the repo with access to the ``requirement_gpu.txt`` file, then run the following command while at the repository root level:
-
-            .. code::
-
-               pip install -r requirements_gpu.txt
-
-
-
-
-Developer-only Installation Steps
-+++++++++++++++++++++++++++++++++
-
-    The additional steps below are only necessary for contributors to the ``ivadomed`` project.
-
-    The ``pre-commit`` package is used to enforce a size limit on committed files. The ``requirements_dev.txt`` also contain additional dependencies related to documentation building and testing.
-
-    After you've installed ``ivadomed``, install the ``pre-commit`` hooks by running:
-
-    .. code::
-
-        pip install -r requirements_dev.txt
-        pre-commit install


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

It seems recently you've changed from a manual Torch and Torch vision installation procedure, to including them in your requirements.txt file. However, the documentation in the Readme and the detailed RTD instructions continued to ask the users to install it manually. In particular, for the Mac installtion on RTD, I encountered an error because a file it was telling me to use does not exist anymore:

```
ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'requirements_gpu.txt'
```

I've removed three instances I could find in the documentation.

You've also removed the dev requirements file, and so I removed that section in RTD as well.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
