### PR TITLE
Resolve imageio v2->v3 imread deprecation warnings

### DIFF
--- a/ivadomed/loader/segmentation_pair.py
+++ b/ivadomed/loader/segmentation_pair.py
@@ -311,9 +311,9 @@ class SegmentationPair(object):
         # For '.png', '.tif', '.tiff', '.jpg' and 'jpeg' extentions
         # Read image as 8 bit grayscale in numpy array (behavior TBD in ivadomed for RGB, RBGA or higher bit depth)
         if "tif" in extension:
-            img = np.expand_dims(imageio.imread(filename, format='tiff-pil'), axis=-1).astype(np.uint8)
+            img = np.expand_dims(imageio.v2.imread(filename, format='tiff-pil'), axis=-1).astype(np.uint8)
             if len(img.shape) > 3:
-                img = np.expand_dims(imageio.imread(filename, format='tiff-pil', as_gray=True), axis=-1).astype(np.uint8)
+                img = np.expand_dims(imageio.v2.imread(filename, format='tiff-pil', as_gray=True), axis=-1).astype(np.uint8)
         else:
             img = np.expand_dims(imageio.v2.imread(filename, as_gray=True), axis=-1).astype(np.uint8)
 

--- a/ivadomed/loader/segmentation_pair.py
+++ b/ivadomed/loader/segmentation_pair.py
@@ -315,7 +315,7 @@ class SegmentationPair(object):
             if len(img.shape) > 3:
                 img = np.expand_dims(imageio.imread(filename, format='tiff-pil', as_gray=True), axis=-1).astype(np.uint8)
         else:
-            img = np.expand_dims(imageio.imread(filename, as_gray=True), axis=-1).astype(np.uint8)
+            img = np.expand_dims(imageio.v2.imread(filename, as_gray=True), axis=-1).astype(np.uint8)
 
         # Binarize ground-truth values (0-255) to 0 and 1 in uint8 with threshold 0.5
         if is_gt:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@
 pyparsing<3,>=2.0.2
 csv-diff>=1.0
 loguru~=0.5
+imageio~=2.19
 joblib~=1.0
 matplotlib>=3.3.0
 nibabel~=3.2


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

The IVADOMED test suite run is throwing warning about the deprecation of imageio's imread behaviour when it changes from version 2 to version 3:

<img width="883" alt="Screen Shot 2022-07-11 at 1 37 08 PM" src="https://user-images.githubusercontent.com/1421029/178314617-0d428dcb-119a-4b11-845c-9dd93e756083.png">

Because imageio is only implicitely installed in the current [requirements file](https://github.com/ivadomed/ivadomed/blob/e22b2e340261d48dc137a9a9c72ad627440073eb/requirements.txt) through other of the installed packages, but [explicitely used](https://github.com/mathieuboudreau/ivadomed/blob/87cf24db983f89d231b86d39cedd5f558b9b9819/ivadomed/loader/segmentation_pair.py#L2) in at least one file (the one throwing the warnings), this makes it such that whenever imageio releases version 3.0, the IVADOMED behaviour might break. Note that the dependency(ies) that install imagio don't appear have a cap on the version, since the most up-to-date version is installed during installation.

In this PR I suggest that the recommended deprecation solution is applied (`imageio.imread` -> `imageio.v2.imread`).

Doing so resolves 89 of the 90 warnings for me:

<img width="883" alt="Screen Shot 2022-07-11 at 1 36 40 PM" src="https://user-images.githubusercontent.com/1421029/178315488-e50d5e80-31f2-4ba2-afd4-359d44e914ae.png">

The other alternative would be to add imageio as a dependency and fix it to version ~2.x, but I just chose this one as it was suggested by the imageio devs.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
