### PR TITLE
Don't declare pillow dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ matplotlib>=3.3.0
 nibabel~=3.2
 onnxruntime==1.7.0
 pandas~=1.1
-pillow>=7.0.0
 pybids>=0.14.0
 scikit-learn>=0.20.3
 scikit-image~=0.17


### PR DESCRIPTION

<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

Pillow (or PIL) is a dependency of imageio, not ivadomed: it's only used in one place in our code, and that, just a test.

By dropping it, we can let imageio choose the version it needs without raising the spectre of version conflicts.


## Linked issues

Should help avoid the confusion raised in https://github.com/ivadomed/ivadomed/pull/1181#issuecomment-1199851199