### PR TITLE
fix: update link to contribution guidelines

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,8 +1,22 @@
 Contributing to ivadomed
 ========================
 
+General Guidelines
+++++++++++++++++++
+
 Thank you for your interest in contributing to ivadomed! This project uses the following pages to guide new contributions:
 
-  * The `ivadomed GitHub repository <https://github.com/ivadomed/ivadomed>`_ is where the source code for the project is maintained, and where new contributions are submitted to.
-  * The `NeuroPoly Contributing Guidelines <https://intranet.neuro.polymtl.ca/software-development/contributing>`_ provide instructions for development workflows, such as reporting issues or submitting pull requests.
-  * The `ivadomed Developer Wiki <https://github.com/ivadomed/ivadomed/wiki>`_ acts as a knowledge base for documenting internal design decisions specific to the ivadomed codebase. It also contains step-by-step walkthroughs for common ivadomed maintainer tasks.
+  * The `ivadomed GitHub repository <https://github.com/ivadomed/ivadomed>`_
+    is where the source code for the project is maintained, and where new
+    contributions are submitted to. We welcome any type of contribution
+    and recommend setting up ``ivadomed`` by following the Contributor
+    or Developer installation as instructed below before proceeding
+    towards any contribution.
+
+  * The `NeuroPoly Contributing Guidelines <https://intranet.neuro.polymtl.ca/geek-tips/contributing.html>`_ 
+    provide instructions for development workflows, such as reporting issues or submitting pull requests.
+
+  * The `ivadomed Developer Wiki <https://github.com/ivadomed/ivadomed/wiki>`_
+    acts as a knowledge base for documenting internal design decisions specific
+    to the ivadomed codebase. It also contains step-by-step walkthroughs for
+    common ivadomed maintainer tasks.


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
The link to contribution guidelines, earlier broken, now points to the appropriate page.

## Linked issues