### PR TITLE
Fix 3D training with data augmentation

### DIFF
--- a/ivadomed/keywords.py
+++ b/ivadomed/keywords.py
@@ -83,6 +83,7 @@ class TransformationKW:
     ROICROP: str = "ROICrop"
     CENTERCROP: str = "CenterCrop"
     RESAMPLE: str = "Resample"
+    RANDOM_AFFINE: str = "RandomAffine"
 
 
 @dataclass
@@ -123,6 +124,7 @@ class ModelParamsKW:
     DEPTH: str = "depth"
     MISSING_PROBABILITY: str = "missing_probability"
     MISSING_PROBABILITY_GROWTH: str = "missing_probability_growth"
+    N_FILTERS: str = "n_filters"
 
 
 @dataclass

--- a/ivadomed/loader/mri3d_subvolume_segmentation_dataset.py
+++ b/ivadomed/loader/mri3d_subvolume_segmentation_dataset.py
@@ -226,14 +226,14 @@ class MRI3DSubVolumeSegmentationDataset(Dataset):
             stack_gt = []
 
         # Run transforms on image slices
-        stack_input, metadata_input = self.transform(sample=stack_input,
+        stack_input, metadata_input = self.transform(sample=list(stack_input),
                                                      metadata=metadata_input,
                                                      data_type="im")
         # Update metadata_gt with metadata_input
         metadata_gt = imed_loader_utils.update_metadata(metadata_input, metadata_gt)
 
         # Run transforms on gt slices
-        stack_gt, metadata_gt = self.transform(sample=stack_gt,
+        stack_gt, metadata_gt = self.transform(sample=list(stack_gt),
                                                metadata=metadata_gt,
                                                data_type="gt")
         # Make sure stack_gt is binarized

--- a/testing/functional_tests/test_training_3d.py
+++ b/testing/functional_tests/test_training_3d.py
@@ -1,0 +1,246 @@
+import json
+import logging
+import os
+import pytest
+from pytest_console_scripts import script_runner
+from pathlib import Path
+from testing.functional_tests.t_utils import __tmp_dir__, create_tmp_dir, __data_testing_dir__, \
+    download_functional_test_files
+from testing.common_testing_util import remove_tmp_dir
+from ivadomed import config_manager as imed_config_manager
+from ivadomed.keywords import ConfigKW, ModelParamsKW, LoaderParamsKW, ContrastParamsKW, TransformationKW
+
+
+logger = logging.getLogger(__name__)
+
+
+def setup_function():
+    create_tmp_dir()
+
+
+@pytest.mark.script_launch_mode('subprocess')
+def test_training_3d_1class_single_channel_with_data_augmentation(download_functional_test_files, script_runner):
+
+    # Load automate training config as context
+    file_config = os.path.join(__data_testing_dir__, 'automate_training_config.json')
+    context = imed_config_manager.ConfigurationManager(file_config).get_config()
+
+    # Modify key-value pairs in context for given test
+    # Set-up 3D model params
+    context[ConfigKW.DEFAULT_MODEL][ModelParamsKW.IS_2D] = False
+    context[ConfigKW.MODIFIED_3D_UNET] = {
+        ModelParamsKW.APPLIED: True,
+        ModelParamsKW.LENGTH_3D: [32, 32, 16],
+        ModelParamsKW.STRIDE_3D: [32, 32, 16],
+        ModelParamsKW.N_FILTERS: 4
+    }
+    # Set target_suffix (1 class)
+    context[ConfigKW.LOADER_PARAMETERS][LoaderParamsKW.TARGET_SUFFIX] = ["_lesion-manual"]
+    # Set contrasts or interest (2 single channels)
+    context[ConfigKW.LOADER_PARAMETERS][LoaderParamsKW.CONTRAST_PARAMS][ContrastParamsKW.TRAINING_VALIDATION] = ["T1w", "T2w"]
+    context[ConfigKW.LOADER_PARAMETERS][LoaderParamsKW.CONTRAST_PARAMS][ContrastParamsKW.TESTING] = ["T1w", "T2w"]
+    context[ConfigKW.LOADER_PARAMETERS][LoaderParamsKW.MULTICHANNEL] = False
+    # Set 3D preprocessing and data augmentation
+    context[ConfigKW.TRANSFORMATION][TransformationKW.RESAMPLE] = {
+        "wspace": 0.75,
+        "hspace": 0.75,
+        "dspace": 0.75
+    }
+    context[ConfigKW.TRANSFORMATION][TransformationKW.CENTERCROP] = {
+        "size": [32, 32, 16],
+    }
+    context[ConfigKW.TRANSFORMATION][TransformationKW.RANDOM_AFFINE] = {
+        "degrees": 10,
+        "scale": [0.03, 0.03, 0.03],
+        "translate": [0.8, 0.8, 0.8],
+        "applied_to": ["im", "gt"],
+        "dataset_type": ["training"]
+    }
+
+    # Write temporary config file for given test
+    file_config_updated = os.path.join(__tmp_dir__, "data_functional_testing", "config_3d_training.json")
+    with Path(file_config_updated).open(mode='w') as fp:
+        json.dump(context, fp, indent=4)
+
+    # Set output directory
+    __output_dir__ = Path(__tmp_dir__, 'results')
+
+    # Run ivadomed
+    ret = script_runner.run('ivadomed', '-c', f'{file_config_updated}',
+                            '--path-data', f'{__data_testing_dir__}',
+                            '--path-output', f'{__output_dir__}')
+    logger.debug(f"{ret.stdout}")
+    logger.debug(f"{ret.stderr}")
+    assert ret.success
+
+
+@pytest.mark.script_launch_mode('subprocess')
+def test_training_3d_2class_single_channel_with_data_augmentation(download_functional_test_files, script_runner):
+
+    # Load automate training config as context
+    file_config = os.path.join(__data_testing_dir__, 'automate_training_config.json')
+    context = imed_config_manager.ConfigurationManager(file_config).get_config()
+
+    # Modify key-value pairs in context for given test
+    # Set-up 3D model params
+    context[ConfigKW.DEFAULT_MODEL][ModelParamsKW.IS_2D] = False
+    context[ConfigKW.MODIFIED_3D_UNET] = {
+        ModelParamsKW.APPLIED: True,
+        ModelParamsKW.LENGTH_3D: [32, 32, 16],
+        ModelParamsKW.STRIDE_3D: [32, 32, 16],
+        ModelParamsKW.N_FILTERS: 4
+    }
+    # Set target_suffix (2-class)
+    context[ConfigKW.LOADER_PARAMETERS][LoaderParamsKW.TARGET_SUFFIX] = ["_lesion-manual", "_seg-manual"]
+    # Set contrasts or interest (2 single channels)
+    context[ConfigKW.LOADER_PARAMETERS][LoaderParamsKW.CONTRAST_PARAMS][ContrastParamsKW.TRAINING_VALIDATION] = ["T1w", "T2w"]
+    context[ConfigKW.LOADER_PARAMETERS][LoaderParamsKW.CONTRAST_PARAMS][ContrastParamsKW.TESTING] = ["T1w", "T2w"]
+    context[ConfigKW.LOADER_PARAMETERS][LoaderParamsKW.MULTICHANNEL] = False
+    # Set 3D preprocessing and data augmentation
+    context[ConfigKW.TRANSFORMATION][TransformationKW.RESAMPLE] = {
+        "wspace": 0.75,
+        "hspace": 0.75,
+        "dspace": 0.75
+    }
+    context[ConfigKW.TRANSFORMATION][TransformationKW.CENTERCROP] = {
+        "size": [32, 32, 16],
+    }
+    context[ConfigKW.TRANSFORMATION][TransformationKW.RANDOM_AFFINE] = {
+        "degrees": 10,
+        "scale": [0.03, 0.03, 0.03],
+        "translate": [0.8, 0.8, 0.8],
+        "applied_to": ["im", "gt"],
+        "dataset_type": ["training"]
+    }
+
+    # Write temporary config file for given test
+    file_config_updated = os.path.join(__tmp_dir__, "data_functional_testing", "config_3d_training.json")
+    with Path(file_config_updated).open(mode='w') as fp:
+        json.dump(context, fp, indent=4)
+
+    # Set output directory
+    __output_dir__ = Path(__tmp_dir__, 'results')
+
+    # Run ivadomed
+    ret = script_runner.run('ivadomed', '-c', f'{file_config_updated}',
+                            '--path-data', f'{__data_testing_dir__}',
+                            '--path-output', f'{__output_dir__}')
+    logger.debug(f"{ret.stdout}")
+    logger.debug(f"{ret.stderr}")
+    assert ret.success
+
+
+@pytest.mark.script_launch_mode('subprocess')
+def test_training_3d_1class_multi_channel_with_data_augmentation(download_functional_test_files, script_runner):
+
+    # Load automate training config as context
+    file_config = os.path.join(__data_testing_dir__, 'automate_training_config.json')
+    context = imed_config_manager.ConfigurationManager(file_config).get_config()
+
+    # Modify key-value pairs in context for given test
+    # Set-up 3D model params
+    context[ConfigKW.DEFAULT_MODEL][ModelParamsKW.IS_2D] = False
+    context[ConfigKW.MODIFIED_3D_UNET] = {
+        ModelParamsKW.APPLIED: True,
+        ModelParamsKW.LENGTH_3D: [32, 32, 16],
+        ModelParamsKW.STRIDE_3D: [32, 32, 16],
+        ModelParamsKW.N_FILTERS: 4
+    }
+    # Set target_suffix (1-class)
+    context[ConfigKW.LOADER_PARAMETERS][LoaderParamsKW.TARGET_SUFFIX] = ["_lesion-manual"]
+    # Set contrasts or interest (1 multi-channel)
+    context[ConfigKW.LOADER_PARAMETERS][LoaderParamsKW.CONTRAST_PARAMS][ContrastParamsKW.TRAINING_VALIDATION] = ["T1w", "T2w"]
+    context[ConfigKW.LOADER_PARAMETERS][LoaderParamsKW.CONTRAST_PARAMS][ContrastParamsKW.TESTING] = ["T1w", "T2w"]
+    context[ConfigKW.LOADER_PARAMETERS][LoaderParamsKW.MULTICHANNEL] = True
+    # Set 3D preprocessing and data augmentation
+    context[ConfigKW.TRANSFORMATION][TransformationKW.RESAMPLE] = {
+        "wspace": 0.75,
+        "hspace": 0.75,
+        "dspace": 0.75
+    }
+    context[ConfigKW.TRANSFORMATION][TransformationKW.CENTERCROP] = {
+        "size": [32, 32, 16],
+    }
+    context[ConfigKW.TRANSFORMATION][TransformationKW.RANDOM_AFFINE] = {
+        "degrees": 10,
+        "scale": [0.03, 0.03, 0.03],
+        "translate": [0.8, 0.8, 0.8],
+        "applied_to": ["im", "gt"],
+        "dataset_type": ["training"]
+    }
+
+    # Write temporary config file for given test
+    file_config_updated = os.path.join(__tmp_dir__, "data_functional_testing", "config_3d_training.json")
+    with Path(file_config_updated).open(mode='w') as fp:
+        json.dump(context, fp, indent=4)
+
+    # Set output directory
+    __output_dir__ = Path(__tmp_dir__, 'results')
+
+    # Run ivadomed
+    ret = script_runner.run('ivadomed', '-c', f'{file_config_updated}',
+                            '--path-data', f'{__data_testing_dir__}',
+                            '--path-output', f'{__output_dir__}')
+    logger.debug(f"{ret.stdout}")
+    logger.debug(f"{ret.stderr}")
+    assert ret.success
+
+
+@pytest.mark.script_launch_mode('subprocess')
+def test_training_3d_1class_multirater_with_data_augmentation(download_functional_test_files, script_runner):
+
+    # Load automate training config as context
+    file_config = os.path.join(__data_testing_dir__, 'automate_training_config.json')
+    context = imed_config_manager.ConfigurationManager(file_config).get_config()
+
+    # Modify key-value pairs in context for given test
+    # Set-up 3D model params
+    context[ConfigKW.DEFAULT_MODEL][ModelParamsKW.IS_2D] = False
+    context[ConfigKW.MODIFIED_3D_UNET] = {
+        ModelParamsKW.APPLIED: True,
+        ModelParamsKW.LENGTH_3D: [32, 32, 16],
+        ModelParamsKW.STRIDE_3D: [32, 32, 16],
+        ModelParamsKW.N_FILTERS: 4
+    }
+    # Set target_suffix (1-class, multirater)
+    context[ConfigKW.LOADER_PARAMETERS][LoaderParamsKW.TARGET_SUFFIX] = [["_lesion-manual", "_seg-manual"]]
+    # Set contrasts or interest (2 single channels)
+    context[ConfigKW.LOADER_PARAMETERS][LoaderParamsKW.CONTRAST_PARAMS][ContrastParamsKW.TRAINING_VALIDATION] = ["T1w", "T2w"]
+    context[ConfigKW.LOADER_PARAMETERS][LoaderParamsKW.CONTRAST_PARAMS][ContrastParamsKW.TESTING] = ["T1w", "T2w"]
+    context[ConfigKW.LOADER_PARAMETERS][LoaderParamsKW.MULTICHANNEL] = False
+    # Set 3D preprocessing and data augmentation
+    context[ConfigKW.TRANSFORMATION][TransformationKW.RESAMPLE] = {
+        "wspace": 0.75,
+        "hspace": 0.75,
+        "dspace": 0.75
+    }
+    context[ConfigKW.TRANSFORMATION][TransformationKW.CENTERCROP] = {
+        "size": [32, 32, 16],
+    }
+    context[ConfigKW.TRANSFORMATION][TransformationKW.RANDOM_AFFINE] = {
+        "degrees": 10,
+        "scale": [0.03, 0.03, 0.03],
+        "translate": [0.8, 0.8, 0.8],
+        "applied_to": ["im", "gt"],
+        "dataset_type": ["training"]
+    }
+
+    # Write temporary config file for given test
+    file_config_updated = os.path.join(__tmp_dir__, "data_functional_testing", "config_3d_training.json")
+    with Path(file_config_updated).open(mode='w') as fp:
+        json.dump(context, fp, indent=4)
+
+    # Set output directory
+    __output_dir__ = Path(__tmp_dir__, 'results')
+
+    # Run ivadomed
+    ret = script_runner.run('ivadomed', '-c', f'{file_config_updated}',
+                            '--path-data', f'{__data_testing_dir__}',
+                            '--path-output', f'{__output_dir__}')
+    logger.debug(f"{ret.stdout}")
+    logger.debug(f"{ret.stderr}")
+    assert ret.success
+
+
+def teardown_function():
+    remove_tmp_dir()


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

#### In this PR:
This PR fixes #1213 where 3D training would fail when using data augmentation after the merge of PR #1169.
The bug was created by the "sample" (`stack_input` or `stack_gt`) being passed to transforms as _numpy arrays_ instead of _list_.

Because we don't have tests for training in 3D, I added `test_training_3d.py` to testing with 4 tests covering the following scenarios, all including transform (preprocessing and data augmentation):
* 3D 1-class single channel training
* 3D 2-class single channel training
* 3D 1-class multichannel training
* 3D 1-class multi-rater training

I also revised the other changes from PR #1169 and everything else seems correct, but I made some minor corrections on a few comments in `mri3d_subvolume_segmentation_dataset.py` for clarity.

#### To test this PR:

* Run a 3D training with "RandomAffine" in transformations on master branch --> you should have an error that looks like this one:
```
metadata[MetadataKW.ROTATION] = [angle, axes]
Traceback (most recent call last):
  File "/Applications/PyCharm CE.app/Contents/plugins/python-ce/helpers/pydev/_pydevd_bundle/pydevd_exec2.py", line 3, in Exec
    exec(exp, global_vars, local_vars)
  File "<input>", line 1, in <module>
TypeError: list indices must be integers or slices, not str
```
* Run the same training on this branch --> the training should start as expected.
* See an example of config file and error log in the original issue: https://github.com/ivadomed/ivadomed/issues/1213#issue-1494577149

#### Additional note:
I will open another issue (#1223) regarding the harmonization of `get_item `in `mri2d_segmentation_dataset.py` and `mri3d_subvolume_segmentation_dataset.py`.
Both are doing the same thing but some changes in implementations were done at 2 different times: PR #982 in 2D and PR #1169 in 3D. Because of this, there are some discrepancies in the order of the code or in the use of keywords that makes it hard to compare between 2D and 3D.

## Linked issues
Fixes #1213 
