### PR TITLE
Clarify testing output files

### DIFF
--- a/docs/source/tutorials/one_class_segmentation_2d_unet.rst
+++ b/docs/source/tutorials/one_class_segmentation_2d_unet.rst
@@ -541,7 +541,7 @@ Evaluate model
 
 
     The test image segmentations are stored in ``<PATH_TO_OUT_DIR>/pred_masks/`` and have the same name as the input image
-    with the suffix ``_pred``. To visualize the segmentation of a given subject, you can use any Nifti image viewer.
+    with the suffix ``_pred``. To visualize the segmentation of a given subject, you can use any NIfTI image viewer.
     For `FSLeyes <https://open.win.ox.ac.uk/pages/fsl/fsleyes/fsleyes/userdoc/>`_ users, this command will open the
     input image with the overlaid prediction (segmentation) for one of the test subject:
 
@@ -559,3 +559,6 @@ Evaluate model
 
     .. image:: https://raw.githubusercontent.com/ivadomed/doc-figures/main/tutorials/one_class_segmentation_2d_unet/sc_prediction.png
        :align: center
+
+
+Another set of test image segmentations are also present in ``<PATH_TO_OUT_DIR>/pred_masks/`` with the suffix ``_pred-TP-FP-FN`` when the ``evaluation_parameters:object_detection_metrics`` is set to ``true`` (Default: ``true``). These files include 3 possible values depending if each object detected in the prediction compared to the ground-truth is a True Positive (TP), False Positive (FP) or False Negative (FN). In NIfTI  files (``.nii.gz``), the respective values for TP, FP and FN are 1, 2 and 3.

--- a/docs/source/tutorials/two_class_microscopy_seg_2d_unet.rst
+++ b/docs/source/tutorials/two_class_microscopy_seg_2d_unet.rst
@@ -314,3 +314,6 @@ The ground truth segmentations and predictions of the axons and myelin are prese
 
 .. image:: https://raw.githubusercontent.com/ivadomed/doc-figures/main/tutorials/two_classes_microscopy_seg_2d_unet/axon_myelin_predictions.png
    :align: center
+
+
+Another set of test image segmentations are also present in ``<PATH_TO_OUT_DIR>/pred_masks/`` with the suffix ``_pred-TP-FP-FN`` when the ``evaluation_parameters:object_detection_metrics`` is set to ``true``. These files include 3 possible values depending if each object detected in the prediction compared to the ground-truth is a True Positive (TP), False Positive (FP) or False Negative (FN). In PNG files (``.png``), the respective values for TP, FP and FN are 85, 170 and 255.

--- a/ivadomed/evaluation.py
+++ b/ivadomed/evaluation.py
@@ -90,7 +90,7 @@ def evaluate(bids_df, path_output, target_suffix, eval_params):
             # SAVE PAINTED DATA, TP FP FN
             fname_paint = str(fname_pred).split('.nii.gz')[0] + '_TP-FP-FN.nii.gz'
             nib_painted = nib.Nifti1Image(
-                dataobj=data_painted,
+                dataobj=data_painted.astype(int),
                 affine=nib_pred.header.get_best_affine(),
                 header=nib_pred.header.copy()
             )

--- a/ivadomed/evaluation.py
+++ b/ivadomed/evaluation.py
@@ -88,7 +88,7 @@ def evaluate(bids_df, path_output, target_suffix, eval_params):
 
         if eval_params['object_detection_metrics']:
             # SAVE PAINTED DATA, TP FP FN
-            fname_paint = str(fname_pred).split('.nii.gz')[0] + '_painted.nii.gz'
+            fname_paint = str(fname_pred).split('.nii.gz')[0] + '_TP-FP-FN.nii.gz'
             nib_painted = nib.Nifti1Image(
                 dataobj=data_painted,
                 affine=nib_pred.header.get_best_affine(),
@@ -104,7 +104,7 @@ def evaluate(bids_df, path_output, target_suffix, eval_params):
                 imed_inference.pred_to_png(painted_list,
                                            target_list,
                                            str(path_preds.joinpath(subj_acq)),
-                                           suffix="_pred_painted.png",
+                                           suffix="_pred_TP-FP-FN.png",
                                            max_value=3) # painted data contain 3 float values [0.0, 1.0, 2.0, 3.0] corresponding to background, TP, FP and FN objects)
 
         # SAVE RESULTS FOR THIS PRED


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR aims to clarify the difference between output files `_pred` and `_pred_painted`:
* `_pred_painted` suffix is renamed `_pred-TP-FP-FN`
* Documentation about the output files are added to `One-class segmentation with 2D U-Net` and `Two-class microscopy segmentation with 2D U-Net` tutorials.
* Fix quantization of TP, FP and FN in NIfTI files by writing them as `int64` instead of `float64` (as reported in #611), i.e. values are really 1, 2 and 3 in `_pred-TP-FP-FN` files and not 0.9960784902796149, 2.000000118277967, etc.

## Linked issues
Fixes #1229
Related to #611 
