### PR TITLE
chore: remove numpy related deprecations in support of v1.24.0 

### DIFF
--- a/ivadomed/uncertainty.py
+++ b/ivadomed/uncertainty.py
@@ -192,7 +192,7 @@ def structurewise_uncertainty(fname_lst, fname_hard, fname_unc_vox, fname_out):
                 if i_mc_label > 0:
                     data_tmp[mc_dict["mc_labeled"][i_mc][i_class] == i_mc_label] = 1.
 
-                data_class_obj_mc.append(data_tmp.astype(np.bool))
+                data_class_obj_mc.append(data_tmp.astype(bool))
 
             # COMPUTE IoU
             # Init intersection and union


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
numpy recently released its minor v1.24.0 which broke our tests primarily due to the usage of `np.bool` which has been deprecated in favour of python `bool`. There were several deprecations as part of the latest release including `np.int` in favour of `int`.

On a side note, this is another incident after #1194 broke our CI for similar reasons. We were caught unaware then and now again. This is a direct consequence of silencing deprecation warnings in #1122. As part of maintenance, I'd try to clean up most of these warnings in #1228 and undo the changes in #1194.

## Linked issues
Discovered in #1222 and for future reference related to #1191