### PR TITLE
Clarify usage of --no-patch for 2D only

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -37,7 +37,7 @@ If not set via CLI, then you MUST specify this field in the configuration file.
 
 Please see section ``TUTORIALS`` to run this command on an example dataset.
 
-Additional optional flags with ``--segment`` command for models trained with 2D patches:
+Additional optional flags with ``--segment`` command for models trained with 2D patches (not available for 3D models):
 
     ``--no-patch``: 2D patches are not used while segmenting with models trained with patches. The ``--no-patch`` flag supersedes the
     ``--overlap-2d`` flag. This option may not be suitable with large images depending on computer RAM capacity.

--- a/ivadomed/inference.py
+++ b/ivadomed/inference.py
@@ -412,6 +412,13 @@ def segment_volume(folder_model: str, fname_images: list, gpu_id: int = 0, optio
     kernel_3D = bool(ConfigKW.MODIFIED_3D_UNET in context and context[ConfigKW.MODIFIED_3D_UNET][ModelParamsKW.APPLIED]) or \
                 not context[ConfigKW.DEFAULT_MODEL][ModelParamsKW.IS_2D]
 
+    if (options is not None) and (OptionKW.NO_PATCH in options) and kernel_3D:
+        logger.warning(f"The 'no-patch' option is provided but is not available for 3D models. "
+                       f"'no-patch' is ignored.")
+    if (options is not None) and (OptionKW.OVERLAP_2D in options) and kernel_3D:
+        logger.warning(f"The 'overlap-2d' option is provided but is not available for 3D models. "
+                       f"'overlap-2d' is ignored.")
+
     # Assign length_2D and stride_2D for 2D patching
     length_2D = context[ConfigKW.DEFAULT_MODEL][ModelParamsKW.LENGTH_2D] if \
         ModelParamsKW.LENGTH_2D in context[ConfigKW.DEFAULT_MODEL] else []
@@ -419,21 +426,21 @@ def segment_volume(folder_model: str, fname_images: list, gpu_id: int = 0, optio
         ModelParamsKW.STRIDE_2D in context[ConfigKW.DEFAULT_MODEL] else []
 
     is_2d_patch = bool(length_2D)
-    if (options is not None) and (OptionKW.NO_PATCH in options):
+    if (options is not None) and (OptionKW.NO_PATCH in options) and not kernel_3D:
         if is_2d_patch:
             is_2d_patch = not options.get(OptionKW.NO_PATCH)
             length_2D = []
             stride_2D = []
         else:
-            logger.warning(f"The 'no_patch' option is provided but the model has no 'length_2D' and "
-                               f"'stride_2D' parameters in its configuration file "
-                               f"'{fname_model_metadata.split('/')[-1]}'. 2D patching is ignored, the segmentation "
-                               f"'is done on the entire image without patches.")
-        if OptionKW.OVERLAP_2D in options:
-            logger.warning(f"The 'no_patch' option is provided along with the 'overlap_2D' option. "
+            logger.warning(f"The 'no-patch' option is provided but the model has no 'length_2D' and "
+                           f"'stride_2D' parameters in its configuration file "
+                           f"'{fname_model_metadata.split('/')[-1]}'. 2D patching is ignored, the segmentation "
+                           f"is done on the entire image without patches.")
+        if OptionKW.OVERLAP_2D in options and not kernel_3D:
+            logger.warning(f"The 'no-patch' option is provided along with the 'overlap-2D' option. "
                            f"2D patching is ignored, the segmentation is done on the entire image without patches.")
     else:
-        if (options is not None) and (OptionKW.OVERLAP_2D in options):
+        if (options is not None) and (OptionKW.OVERLAP_2D in options) and not kernel_3D:
             if (length_2D and stride_2D):
                 overlap_2D = options.get(OptionKW.OVERLAP_2D)
                 # Swap OverlapX and OverlapY resulting in an array in order [OverlapY, OverlapX]
@@ -442,7 +449,7 @@ def segment_volume(folder_model: str, fname_images: list, gpu_id: int = 0, optio
                 # Adjust stride_2D with overlap_2D
                 stride_2D = [x1 - x2 for (x1, x2) in zip(length_2D, overlap_2D)]
             else:
-                logger.warning(f"The 'overlap_2D' option is provided but the model has no 'length_2D' and "
+                logger.warning(f"The 'overlap-2d' option is provided but the model has no 'length_2D' and "
                                f"'stride_2D' parameters in its configuration file "
                                f"'{fname_model_metadata.split('/')[-1]}'. 2D patching is ignored, the segmentation "
                                f"is done on the entire image without patches.")

--- a/ivadomed/inference.py
+++ b/ivadomed/inference.py
@@ -436,7 +436,7 @@ def segment_volume(folder_model: str, fname_images: list, gpu_id: int = 0, optio
                            f"'stride_2D' parameters in its configuration file "
                            f"'{fname_model_metadata.split('/')[-1]}'. 2D patching is ignored, the segmentation "
                            f"is done on the entire image without patches.")
-        if OptionKW.OVERLAP_2D in options and not kernel_3D:
+        if OptionKW.OVERLAP_2D in options:
             logger.warning(f"The 'no-patch' option is provided along with the 'overlap-2D' option. "
                            f"2D patching is ignored, the segmentation is done on the entire image without patches.")
     else:


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR addresses 2 issues reported in #1255.
1. Explicitly mention that the options `--no-patch` and `--overlap-2d` don't apply to 3D models in `Usage` documentation page.
2. Add a warning in the terminal, when `--no-patch` and/or `--overlap-2d` are used with 3D models.

The PR also includes minor corrections to previous formatting.

## Linked issues
Related #1255 
