### PR TITLE
Harmonize get_item in MRI2D dataset and MRI3D dataset

### DIFF
--- a/ivadomed/keywords.py
+++ b/ivadomed/keywords.py
@@ -274,5 +274,7 @@ class SegmentationDatasetKW:
 class SegmentationPairKW:
     GT_METADATA = "gt_metadata"
     INPUT_METADATA = "input_metadata"
+    ROI_METADATA = "roi_metadata"
     GT = "gt"
     INPUT = "input"
+    ROI = "roi"

--- a/ivadomed/loader/mri3d_subvolume_segmentation_dataset.py
+++ b/ivadomed/loader/mri3d_subvolume_segmentation_dataset.py
@@ -105,6 +105,7 @@ class MRI3DSubVolumeSegmentationDataset(Dataset):
 
             if self.disk_cache:
                 # Write SegPair and ROIPair to disk cache with timestamp to avoid collisions
+                # 'self.handler' is now a list of a FILES instead of actual data to prevent using too much memory
                 path_cache_seg_pair = path_temp / f'seg_pair_{get_timestamp()}.pkl'
                 with path_cache_seg_pair.open(mode='wb') as f:
                     pickle.dump(seg_pair, f)
@@ -115,8 +116,6 @@ class MRI3DSubVolumeSegmentationDataset(Dataset):
                 self.handlers.append((path_cache_seg_pair, path_cache_roi_pair))
 
             else:
-                # self.handler is now a list of a FILES instead of actual data to prevent this list from taking up too much
-                # memory
                 self.handlers.append((seg_pair, roi_pair))
 
     def _prepare_indices(self):
@@ -158,35 +157,36 @@ class MRI3DSubVolumeSegmentationDataset(Dataset):
         return len(self.indexes)
 
     def __getitem__(self, subvolume_index: int) -> dict:
-        """Return the specific index pair subvolume (input, ground truth).
+        """Return the specific processed subvolume corresponding to index (input, ground truth and metadata).
 
         Args:
-            subvolume_index (int): Subvolume index.
+            subvolume_index (int): Subvolume (patch) index.
         """
 
-        # Get the tuple that defines the boundaries for the subsample
+        # CONTEXT
+        # All 3D models are trained with 3D subvolumes (patches):
+        #    * 'self.handlers' contains paired data for all preprocessed 3D volumes
+        #    * 'self.indexes' is a list of coordinates for all 3D subvolumes
+        #      e.g. [{'x_min': 0, 'x_max': 32, 'y_min': 0, 'y_max': 32, 'z_min': 0, 'z_max': 16, 'handler_index': 0},
+        #            {'x_min': 0, 'x_max': 32, 'y_min': 0, 'y_max': 32, 'z_min': 16, 'z_max': 32, 'handler_index': 0}]
+        #      where 'handler_index' is the index of the 3D volume from which the subvolume is extracted
+        # Note that ROI is not available for 3D models
+
+        # Extract coordinates and paired data for the subvolume
+        # Get subvolume coordinates from 'self.indexes'
         coord: dict = self.indexes[subvolume_index]
-        x_min = coord.get(SegmentationDatasetKW.X_MIN)
-        x_max = coord.get(SegmentationDatasetKW.X_MAX)
-        y_min = coord.get(SegmentationDatasetKW.Y_MIN)
-        y_max = coord.get(SegmentationDatasetKW.Y_MAX)
-        z_min = coord.get(SegmentationDatasetKW.Z_MIN)
-        z_max = coord.get(SegmentationDatasetKW.Z_MAX)
-
-        # Obtain tuple reference to the pairs of file references
-        tuple_seg_roi_pair: tuple = self.handlers[coord.get(SegmentationDatasetKW.HANDLER_INDEX)]
-
-        # Disk Cache handling, either, load the seg_pair, not using ROI pair here.
+        # Extract subvolume pair from 'self.handlers'
         # copy.deepcopy is used to have different coordinates for reconstruction for a given handler,
         # to allow a different rater at each iteration of training, and to clean transforms params from previous
         # transforms i.e. remove params from previous iterations so that the coming transforms are different
+        tuple_seg_roi_pair: tuple = self.handlers[coord.get(SegmentationDatasetKW.HANDLER_INDEX)]
         if self.disk_cache:
             with tuple_seg_roi_pair[0].open(mode='rb') as f:
                 seg_pair = pickle.load(f)
         else:
             seg_pair, _ = copy.deepcopy(tuple_seg_roi_pair)
 
-        # In case multiple raters
+        # In case of multiple raters
         if seg_pair[SegmentationPairKW.GT] and isinstance(seg_pair[SegmentationPairKW.GT][0], list):
             # Randomly pick a rater
             idx_rater = random.randint(0, len(seg_pair[SegmentationPairKW.GT][0]) - 1)
@@ -196,15 +196,17 @@ class MRI3DSubVolumeSegmentationDataset(Dataset):
                 seg_pair[SegmentationPairKW.GT][idx_class] = seg_pair[SegmentationPairKW.GT][idx_class][idx_rater]
                 seg_pair[SegmentationPairKW.GT_METADATA][idx_class] = seg_pair[SegmentationPairKW.GT_METADATA][idx_class][idx_rater]
 
-        if seg_pair[SegmentationPairKW.INPUT_METADATA]:
-            metadata_input = seg_pair[SegmentationPairKW.INPUT_METADATA]
-        else:
-            metadata_input = []
+        # Extract metadata from paired data
+        metadata_input = seg_pair[SegmentationPairKW.INPUT_METADATA] if seg_pair[SegmentationPairKW.INPUT_METADATA] is not None else []
+        metadata_gt = seg_pair[SegmentationPairKW.GT_METADATA] if seg_pair[SegmentationPairKW.GT_METADATA] is not None else []
 
-        if seg_pair[SegmentationPairKW.GT_METADATA]:
-            metadata_gt = seg_pair[SegmentationPairKW.GT_METADATA]
-        else:
-            metadata_gt = []
+        # Extract min/max coordinates
+        x_min = coord.get(SegmentationDatasetKW.X_MIN)
+        x_max = coord.get(SegmentationDatasetKW.X_MAX)
+        y_min = coord.get(SegmentationDatasetKW.Y_MIN)
+        y_max = coord.get(SegmentationDatasetKW.Y_MAX)
+        z_min = coord.get(SegmentationDatasetKW.Z_MIN)
+        z_max = coord.get(SegmentationDatasetKW.Z_MAX)
 
         # Extract subvolume and gt from coordinates
         stack_input = np.asarray(seg_pair[SegmentationPairKW.INPUT])[
@@ -212,7 +214,7 @@ class MRI3DSubVolumeSegmentationDataset(Dataset):
                       x_min:x_max,
                       y_min:y_max,
                       z_min:z_max
-            ]
+        ]
 
         if seg_pair[SegmentationPairKW.GT]:
             stack_gt = np.asarray(seg_pair[SegmentationPairKW.GT])[
@@ -243,7 +245,7 @@ class MRI3DSubVolumeSegmentationDataset(Dataset):
         shape_y = y_max - y_min
         shape_z = z_max - z_min
 
-        # add coordinates to metadata to reconstruct volume
+        # Add coordinates to metadata to reconstruct volume
         for metadata in metadata_input:
             metadata[MetadataKW.COORD] = [
                 x_min, x_max,
@@ -251,6 +253,7 @@ class MRI3DSubVolumeSegmentationDataset(Dataset):
                 z_min, z_max,
             ]
 
+        # Combine all processed data for a given subvolume in dictionary
         subvolumes = {
             SegmentationPairKW.INPUT: stack_input,
             SegmentationPairKW.GT: stack_gt,

--- a/ivadomed/loader/mri3d_subvolume_segmentation_dataset.py
+++ b/ivadomed/loader/mri3d_subvolume_segmentation_dataset.py
@@ -241,10 +241,6 @@ class MRI3DSubVolumeSegmentationDataset(Dataset):
         if stack_gt is not None and not self.soft_gt:
             stack_gt = imed_postpro.threshold_predictions(stack_gt, thr=0.5).astype(np.uint8)
 
-        shape_x = x_max - x_min
-        shape_y = y_max - y_min
-        shape_z = z_max - z_min
-
         # Add coordinates to metadata to reconstruct volume
         for metadata in metadata_input:
             metadata[MetadataKW.COORD] = [


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR fixes issue #1223 where there were some discrepancies in the order of the code or in the use of keywords between `get_item` in `mri2d_segmentation_dataset.py` and `mri3d_subvolume_segmentation_dataset.py`. Basically, both method do the same thing with slight differences (e.g. patch vs. no patch, roi vs. no roi) but they were hard to understand/compare due to the discrepancies, even with a fair knowledge of them.

This PR aims to:
* Harmonize the use of keywords
* Provide context and comments to describe the different steps in a similar fashion in both `get_item`
* Re-order the code so they are consistent and can be compared side-to-side
* Refactoring only, no change in implementation/behavior.

## Linked issues
Fixes #1223 
