### PR TITLE
Fix NormalizeInstance for uniform samples

### DIFF
--- a/ivadomed/transforms.py
+++ b/ivadomed/transforms.py
@@ -301,7 +301,12 @@ class NormalizeInstance(ImedTransform):
 
     @multichannel_capable
     def __call__(self, sample, metadata=None):
-        data_out = (sample - sample.mean()) / sample.std()
+        # if sample uniform: do mean-subtraction
+        if sample.std() < 1e-5:
+            data_out = (sample - sample.mean())
+        # else: normalize sample
+        else:
+            data_out = (sample - sample.mean()) / sample.std()
         return data_out, metadata
 
 

--- a/testing/unit_tests/test_transforms.py
+++ b/testing/unit_tests/test_transforms.py
@@ -238,6 +238,20 @@ def test_NormalizeInstance(im_seg):
     assert abs(do_tensor.mean() - 0.0) <= 1e-2
     assert abs(do_tensor.std() - 1.0) <= 1e-2
 
+    # Transform on Numpy - Uniform sample
+    im = np.ones(im[0].shape)
+    do_im, _ = transform(im.copy(), metadata_in)
+    # Check mean-substraction
+    assert abs(np.mean(do_im) - 0.0) <= 1e-2
+    assert abs(np.std(do_im)) < 1e-5
+
+    # Transform on Tensor - Uniform sample
+    tensor, metadata_tensor = NumpyToTensor()(im, metadata_in)
+    do_tensor, _ = transform(tensor, metadata_tensor)
+    # Check mean-subtraction
+    assert abs(do_tensor.mean() - 0.0) <= 1e-2
+    assert abs(do_tensor.std()) < 1e-5
+
 
 def _test_Crop(im_seg, crop_transform):
     im, seg = im_seg


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR fixes #1245 where an error would occur in `NormalizeInstance` when a sample was empty/uniform after data augmentation, because of the division by `std==0`.

After discussion and inspired by [previous work](https://github.com/ivadomed/ms-challenge-2021/blob/main/modeling/datasets.py#L293) by @naga-karthik, we decided on the following which is implemented in this PR:
* if std is very small, only do the mean-subtraction
* else, normalize as usual 

The PR also add tests for `NormalizeInstance` with a uniform sample (all 1s).

### To test the PR

* Train a 3D model with a config that generates errors on master, the training will stop at some points with the errors described in this [comment](https://github.com/ivadomed/ivadomed/issues/1245#issuecomment-1360271472).
* Switch to this branch, and there should be no errors.

To generate a faulty config, either:
1. Simulate empty patches:
    * With a `CenterCrop >> length_3D`, for example, `CenterCrop : [32, 32, 256]` with `length_3D: [32, 32, 32]`.
    * Note that this specific case will also be fixed with the 3D filter in PR #1164.
3. Simulate "near-empty" patches that will become empty after data augmentation:
    * With a more conservative CenterCrop, for example `CenterCrop : [32, 32, 96]`
    * But with an "excessive" data augmentation, for example `translate: [0.9, 0.9, 0.9]` in `RandomAffine`

For reference, I tested the PR on the `data_example_spinegeneric` dataset from the tutorials.

## Linked issues
Fixes #1245
