### PR TITLE
Add flipping for proper visualization on wandb

### DIFF
--- a/ivadomed/visualize.py
+++ b/ivadomed/visualize.py
@@ -171,21 +171,21 @@ def save_img(writer, epoch, dataset_type, input_samples, gt_samples, preds, wand
         elif isinstance(input_samples, list):
             input_samples = input_samples[0]
 
-        grid_img = vutils.make_grid(input_samples,
+        grid_img = vutils.make_grid(torch.flip(input_samples, [2,3]),
                                     normalize=True,
                                     scale_each=True)
         writer.add_image(dataset_type + '/Input', grid_img, epoch)
         if wandb_tracking:
             wandb.log({dataset_type+"/Input": wandb.Image(grid_img)})
 
-        grid_img = vutils.make_grid(convert_labels_to_RGB(preds),
+        grid_img = vutils.make_grid(convert_labels_to_RGB(torch.flip(preds, [2,3])),
                                     normalize=True,
                                     scale_each=True)
         writer.add_image(dataset_type + '/Predictions', grid_img, epoch)
         if wandb_tracking:
             wandb.log({dataset_type+"/Predictions": wandb.Image(grid_img)})
 
-        grid_img = vutils.make_grid(convert_labels_to_RGB(gt_samples),
+        grid_img = vutils.make_grid(convert_labels_to_RGB(torch.flip(gt_samples, [2,3])),
                                     normalize=True,
                                     scale_each=True)
         writer.add_image(dataset_type + '/Ground Truth', grid_img, epoch)


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

As mentioned in #1272, the image slices plotted on WandB (or, Tensorboard) appear flipped by default, even without using any data augmentation. This leads to incorrect understanding of what we think the model is seeing as its input and therefore, forcing us to change our training strategies when it is not required. 

This PR brings a minor change in the code snippet used for visualization, particularly, the images are now flipped in the [2,3] axes in order for them to appear correctly on WandB. 

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Resolves #1272 
