### PR TITLE
fix: update the default file for the log file

### DIFF
--- a/ivadomed/config/config_default.json
+++ b/ivadomed/config/config_default.json
@@ -4,7 +4,7 @@
     "path_output": "path_output",
     "model_name": "my_model",
     "debugging": false,
-    "log_file": "log",
+    "log_file": "logs.log",
     "object_detection_params": {
         "object_detection_path": null,
         "safety_factor": [1.0, 1.0, 1.0]


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer


#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
Although explicitly specifying the filename for `log_file` in the config file creates the desired file for logs including files with an extension, the default file created for logging is simply a file named log without any extension. This PR fixes this by updating the log file created by default.

**To test this PR**:
Just observe how the default log file created is named `logs.log`.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Fixes #1214
