### PR TITLE
Match location of `object_detection` in the template config file and in the documentation

### DIFF
--- a/docs/source/configuration_file.rst
+++ b/docs/source/configuration_file.rst
@@ -139,45 +139,6 @@ When possible, the folder name will follow the following convention:
 
     {
         "$schema": "http://json-schema.org/draft-04/schema#",
-        "title": "object_detection_params",
-        "type": "dict",
-        "required": "false",
-        "options": {
-            "object_detection_path": {
-                "type": "string",
-                "$$description": [
-                    "Path to the object detection model. The folder,\n",
-                    "configuration file, and model need to have the same name\n",
-                    "(e.g. ``findcord_tumor/``, ``findcord_tumor/findcord_tumor.json``, and\n",
-                    "``findcord_tumor/findcord_tumor.onnx``, respectively). The model's prediction\n",
-                    "will be used to generate bounding boxes. Default: ``null``."
-                ]
-            },
-            "safety_factor": {
-                "type": "[int, int, int]",
-                "$$description": [
-                    "List of length 3 containing the factors to multiply each dimension of the\n",
-                    "bounding box. Ex: If the original bounding box has a size of 10x20x30 with\n",
-                    "a safety factor of [1.5, 1.5, 1.5], the final dimensions of the bounding box\n",
-                    "will be 15x30x45 with an unchanged center. Default: ``[1.0, 1.0, 1.0]``."
-                ]
-            }
-       }
-   }
-
-.. code-block:: JSON
-
-    {
-        "object_detection_params": {
-            "object_detection_path": null,
-            "safety_factor": [1.0, 1.0, 1.0]
-        }
-    }
-
-.. jsonschema::
-
-    {
-        "$schema": "http://json-schema.org/draft-04/schema#",
         "title": "log_file",
         "description": "Name of the file to be logged to, located within ``log_directory/``. Default: ``log``.",
         "type": "string"
@@ -962,6 +923,50 @@ Split Dataset
     .. line-block::
             The fraction of the dataset used as validation set will correspond to ``1 - train_fraction - test_fraction``.
             For example: ``1 - 0.6 - 0.2 = 0.2``.
+
+
+Cascaded Models
+---------------
+
+.. jsonschema::
+
+    {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": "object_detection_params",
+        "type": "dict",
+        "required": "false",
+        "options": {
+            "object_detection_path": {
+                "type": "string",
+                "$$description": [
+                    "Path to the object detection model. The folder,\n",
+                    "configuration file, and model need to have the same name\n",
+                    "(e.g. ``findcord_tumor/``, ``findcord_tumor/findcord_tumor.json``, and\n",
+                    "``findcord_tumor/findcord_tumor.onnx``, respectively). The model's prediction\n",
+                    "will be used to generate bounding boxes. Default: ``null``."
+                ]
+            },
+            "safety_factor": {
+                "type": "[int, int, int]",
+                "$$description": [
+                    "List of length 3 containing the factors to multiply each dimension of the\n",
+                    "bounding box. Ex: If the original bounding box has a size of 10x20x30 with\n",
+                    "a safety factor of [1.5, 1.5, 1.5], the final dimensions of the bounding box\n",
+                    "will be 15x30x45 with an unchanged center. Default: ``[1.0, 1.0, 1.0]``."
+                ]
+            }
+       }
+   }
+
+.. code-block:: JSON
+
+    {
+        "object_detection_params": {
+            "object_detection_path": null,
+            "safety_factor": [1.0, 1.0, 1.0]
+        }
+    }
+
 
 
 Training Parameters

--- a/docs/source/configuration_file.rst
+++ b/docs/source/configuration_file.rst
@@ -139,6 +139,45 @@ When possible, the folder name will follow the following convention:
 
     {
         "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": "object_detection_params",
+        "type": "dict",
+        "required": "false",
+        "options": {
+            "object_detection_path": {
+                "type": "string",
+                "$$description": [
+                    "Path to the object detection model. The folder,\n",
+                    "configuration file, and model need to have the same name\n",
+                    "(e.g. ``findcord_tumor/``, ``findcord_tumor/findcord_tumor.json``, and\n",
+                    "``findcord_tumor/findcord_tumor.onnx``, respectively). The model's prediction\n",
+                    "will be used to generate bounding boxes. Default: ``null``."
+                ]
+            },
+            "safety_factor": {
+                "type": "[int, int, int]",
+                "$$description": [
+                    "List of length 3 containing the factors to multiply each dimension of the\n",
+                    "bounding box. Ex: If the original bounding box has a size of 10x20x30 with\n",
+                    "a safety factor of [1.5, 1.5, 1.5], the final dimensions of the bounding box\n",
+                    "will be 15x30x45 with an unchanged center. Default: ``[1.0, 1.0, 1.0]``."
+                ]
+            }
+       }
+   }
+
+.. code-block:: JSON
+
+    {
+        "object_detection_params": {
+            "object_detection_path": null,
+            "safety_factor": [1.0, 1.0, 1.0]
+        }
+    }
+
+.. jsonschema::
+
+    {
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "title": "log_file",
         "description": "Name of the file to be logged to, located within ``log_directory/``. Default: ``log``.",
         "type": "string"
@@ -1425,49 +1464,6 @@ being used for the segmentation task).
             "stride_3D": [128, 128, 16],
             "attention": false,
             "n_filters": 8
-        }
-    }
-
-
-Cascaded Architecture Features
-------------------------------
-
-.. jsonschema::
-
-    {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "title": "object_detection_params",
-        "type": "dict",
-        "required": "false",
-        "options": {
-            "object_detection_path": {
-                "type": "string",
-                "$$description": [
-                    "Path to object detection model and the configuration file. The folder,\n",
-                    "configuration file, and model need to have the same name\n",
-                    "(e.g. ``findcord_tumor/``, ``findcord_tumor/findcord_tumor.json``, and\n",
-                    "``findcord_tumor/findcord_tumor.onnx``, respectively). The model's prediction\n",
-                    "will be used to generate bounding boxes. Default: ``null``."
-                ]
-            },
-            "safety_factor": {
-                "type": "[int, int, int]",
-                "$$description": [
-                    "List of length 3 containing the factors to multiply each dimension of the\n",
-                    "bounding box. Ex: If the original bounding box has a size of 10x20x30 with\n",
-                    "a safety factor of [1.5, 1.5, 1.5], the final dimensions of the bounding box\n",
-                    "will be 15x30x45 with an unchanged center. Default: ``[1.0, 1.0, 1.0]``."
-                ]
-            }
-       }
-   }
-
-.. code-block:: JSON
-
-    {
-        "object_detection_params": {
-            "object_detection_path": null,
-            "safety_factor": [1.0, 1.0, 1.0]
         }
     }
 

--- a/ivadomed/config/config.json
+++ b/ivadomed/config/config.json
@@ -4,10 +4,6 @@
     "path_output": "spineGeneric",
     "model_name": "my_model",
     "debugging": false,
-    "object_detection_params": {
-        "object_detection_path": null,
-        "safety_factor": [1.0, 1.0, 1.0]
-    },
     "wandb": {
         "wandb_api_key": "",
         "project_name": "my_project",
@@ -46,6 +42,10 @@
         "balance": null,
         "train_fraction": 0.6,
         "test_fraction": 0.2
+    },
+    "object_detection_params": {
+        "object_detection_path": null,
+        "safety_factor": [1.0, 1.0, 1.0]
     },
     "training_parameters": {
         "batch_size": 32,


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

The `object_detection` module in the config file is located here:

https://github.com/ivadomed/ivadomed/blob/fe4b6ad0a23db2b5b336b3e8b72cca9e5953bcd2/ivadomed/config/config.json#L7-L10

While in the doc it is much later, under the obscure "Cascaded Architecture Feature" section:
![image](https://user-images.githubusercontent.com/2482071/214753992-d3a837d6-9e7c-4832-8587-88d47883bb9e.png)

The goal of this PR is to match the location of this feature in both the template file and in the doc. My suggestion is to put it between `Split Dataset` and `Training Parameters`, ie: I find it logical that after talking about dataset split, we talk about the first model to be applied (if there is any), and _then_ we talk about the main model to train.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
