### PR TITLE
Fix deprecated feature call due to newest imageio release

### DIFF
--- a/ivadomed/loader/segmentation_pair.py
+++ b/ivadomed/loader/segmentation_pair.py
@@ -318,9 +318,9 @@ class SegmentationPair(object):
         if "tif" in extension:
             img = np.expand_dims(imageio.v2.imread(filename, format='tiff-pil'), axis=-1).astype(np.uint8)
             if len(img.shape) > 3:
-                img = np.expand_dims(imageio.v2.imread(filename, format='tiff-pil', as_gray=True), axis=-1).astype(np.uint8)
+                img = np.expand_dims(imageio.v2.imread(filename, format='tiff-pil', mode='L'), axis=-1).astype(np.uint8)
         else:
-            img = np.expand_dims(imageio.v2.imread(filename, as_gray=True), axis=-1).astype(np.uint8)
+            img = np.expand_dims(imageio.v2.imread(filename, mode='L'), axis=-1).astype(np.uint8)
 
         # Binarize ground-truth values (0-255) to 0 and 1 in uint8 with threshold 0.5
         if is_gt:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 pyparsing<3,>=2.0.2
 csv-diff>=1.0
 loguru~=0.5
-imageio~=2.19
+imageio
 joblib~=1.0
 matplotlib>=3.3.0
 nibabel~=3.2


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

As of imageio==2.28.0 (April 24, 2023), the feature `as_gray=True` is deprecated when loading images. I've replaced it with their recommended substitute, `mode='L'`.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Resolves #1291 