### PR TITLE
Fix 2D image conversion to 8 bit

### DIFF
--- a/ivadomed/loader/segmentation_pair.py
+++ b/ivadomed/loader/segmentation_pair.py
@@ -316,11 +316,13 @@ class SegmentationPair(object):
         # For '.png', '.tif', '.tiff', '.jpg' and 'jpeg' extentions
         # Read image as 8 bit grayscale in numpy array (behavior TBD in ivadomed for RGB, RBGA or higher bit depth)
         if "tif" in extension:
-            img = np.expand_dims(imageio.v2.imread(filename, format='tiff-pil'), axis=-1).astype(np.uint8)
+            img = np.expand_dims(imageio.v2.imread(filename, format='tiff-pil'), axis=-1)
             if len(img.shape) > 3:
-                img = np.expand_dims(imageio.v2.imread(filename, format='tiff-pil', as_gray=True), axis=-1).astype(np.uint8)
+                img = np.expand_dims(imageio.v2.imread(filename, format='tiff-pil', as_gray=True), axis=-1)
         else:
-            img = np.expand_dims(imageio.v2.imread(filename, as_gray=True), axis=-1).astype(np.uint8)
+            img = np.expand_dims(imageio.v2.imread(filename, as_gray=True), axis=-1)
+        
+        img = imageio.core.image_as_uint(img, bitdepth=8)
 
         # Binarize ground-truth values (0-255) to 0 and 1 in uint8 with threshold 0.5
         if is_gt:


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
IVADOMED's implentation of loading 2D images (eg histology) has a bug where if 16bit TIFs (maybe other formats too, only one tested) are loaded, 


<img width="797" alt="Screenshot 2023-06-15 at 8 50 10 PM" src="https://github.com/ivadomed/ivadomed/assets/1421029/1afe668d-0e7b-4fbb-97a1-ac098306edb5">

the image isn't properly converted to 8 bits and instead gets "cut off", 

<img width="797" alt="Screenshot 2023-06-15 at 8 40 46 PM" src="https://github.com/ivadomed/ivadomed/assets/1421029/fb9d2830-a33d-4524-984e-8a218cafe8dd">

This proposed fix should do the conversion properly and resolve this issue, which was first raised in AxonDeepSeg,


<img width="797" alt="Screenshot 2023-06-15 at 8 42 24 PM" src="https://github.com/ivadomed/ivadomed/assets/1421029/99655972-85e8-4597-99d1-207f4568a047">

## Linked issues
https://github.com/axondeepseg/axondeepseg/issues/737
