### PR TITLE
chore: remove ubuntu-18.04 and python 3.7 from `run_tests` workflow

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -65,8 +65,8 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [ "macos-latest", "windows-latest", "ubuntu-20.04", "ubuntu-18.04" ]
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        os: [ "macos-latest", "windows-latest", "ubuntu-20.04" ]
+        python-version: [ '3.8', '3.9', '3.10' ]
         test-name:
           - integration-test
 

--- a/.github/workflows/run_tests_dummy.yml
+++ b/.github/workflows/run_tests_dummy.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         # This list must be kept **in sync** with the Required Statuses in https://github.com/ivadomed/ivadomed/settings/branch_protection_rules/5051948
-        os: [ "macos-latest", "windows-latest", "ubuntu-20.04", "ubuntu-18.04" ]
+        os: [ "macos-latest", "windows-latest", "ubuntu-20.04" ]
         python-version: [ 3.8 ]
         test-name:
           - integration-test


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [ivadomed's internal developer documentation](https://github.com/ivadomed/ivadomed/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/ivadomed/ivadomed/wiki/tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/ivadomed/ivadomed/wiki/documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
GHA stopped [support](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) for Ubuntu-18.04 LTS quite some time back. Since it is part of the requisite matrix test to merge a PR, it blocks #1296 and #1297. 

Moreover, removing python 3.7 as it reached EOL on 27 June 2023 (https://endoflife.date/python) primarily to reduce GHA workflow quota for future runs.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Partly unblocks #1296 and #1297 
