### PR TITLE
Test out newer versions of PyTorch (`torch>=2.0.0`) for compatibility with downstream projects (SCT, ADS)

### DIFF
--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -13,7 +13,6 @@ import pandas as pd
 import torch
 from loguru import logger
 from sklearn.model_selection import train_test_split
-from torch._six import string_classes
 from ivadomed import utils as imed_utils
 from ivadomed.keywords import SplitDatasetKW, LoaderParamsKW, ROIParamsKW, ContrastParamsKW
 import nibabel as nib
@@ -270,7 +269,7 @@ def imed_collate(batch: dict) -> dict | list | str | torch.Tensor:
         return torch.LongTensor(batch)
     elif isinstance(batch[0], float):
         return torch.DoubleTensor(batch)
-    elif isinstance(batch[0], string_classes):
+    elif isinstance(batch[0], str):
         return batch
     elif isinstance(batch[0], collections.abc.Mapping):
         return {key: imed_collate([d[key] for d in batch]) for key in batch[0]}

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,6 @@ tensorboard>=1.15.0
 tqdm>=4.30
 scipy
 torchio>=0.18.68
-torch==2.0.0
+torch>=1.8.1
 torchvision>=0.9.1
 wandb>=0.12.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,5 @@ tqdm>=4.30
 scipy
 torchio>=0.18.68
 torch==2.0.0
-torchvision>=0.9.1,<=0.12.0
+torchvision>=0.9.1
 wandb>=0.12.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ joblib~=1.0
 matplotlib>=3.3.0
 nibabel~=3.2
 onnx
-onnxruntime~=1.7
+onnxruntime>=1.7.0,<1.16.0
 pandas>=1.1,<1.5.0
 # We pin Pillow here because we're currently using an older version of `torch`, which in turn uses an
 # older version of `tensorboard`, which in turn uses a deprecated feature of Pillow.

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,10 @@ joblib~=1.0
 matplotlib>=3.3.0
 nibabel~=3.2
 onnx
-onnxruntime>=1.7.0,<1.16.0
+# 1.7.0>onnxruntime>=1.5.1 required `brew install libomp` on macOS.
+# So, pin to >=1.7.0 to avoid having to ask users to install libomp.
+# Avoid version 1.16.0 due to: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4225
+onnxruntime>=1.7.0,!=1.16.0
 pandas>=1.1,<1.5.0
 pybids>=0.14.0,<0.15.6
 scikit-learn>=0.20.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ imageio>=2.31.4
 joblib~=1.0
 matplotlib>=3.3.0
 nibabel~=3.2
+onnx
 onnxruntime~=1.7
 pandas>=1.1,<1.5.0
 # We pin Pillow here because we're currently using an older version of `torch`, which in turn uses an

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,10 +14,6 @@ nibabel~=3.2
 onnx
 onnxruntime>=1.7.0,<1.16.0
 pandas>=1.1,<1.5.0
-# We pin Pillow here because we're currently using an older version of `torch`, which in turn uses an
-# older version of `tensorboard`, which in turn uses a deprecated feature of Pillow.
-# Once we update `torch`, the deprecated call will be removed, and we can then unpin Pillow.
-Pillow<10.0.0
 pybids>=0.14.0,<0.15.6
 scikit-learn>=0.20.3
 scikit-image~=0.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,6 @@ tensorboard>=1.15.0
 tqdm>=4.30
 scipy
 torchio>=0.18.68
-torch>=1.8.1,<=1.11.0
+torch==2.0.0
 torchvision>=0.9.1,<=0.12.0
 wandb>=0.12.11


### PR DESCRIPTION
Because ivadomed's inference functionality is incorporated downstream in many of NeuroPoly's projects (e.g. SCT, ADS), it must "play nicely" with other packages installed into those downstream projects. 

One issue with this is that ivadomed currently pins a (relatively old) version of PyTorch, while many other deep learning packages use a newer version of PyTorch. Because of ivadomed's restriction, it often can't be installed into the same environments as other deep learning packages.

So, this PR tests out newer versions of torch (`>=2.0.0`), for the purposes of compatibility with libraries such as nnUnet, MONAI, etc.