### PR TITLE
Test upgrades for pinned dependencies to improve downstream compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,8 @@ onnx
 # So, pin to >=1.7.0 to avoid having to ask users to install libomp.
 # Avoid version 1.16.0 due to: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4225
 onnxruntime>=1.7.0,!=1.16.0
-pandas>=1.1
+# `pandas==2.0` removed the `DataFrame.append` call, which we currently use in approx. 13 places (per PyCharm search)
+pandas>=1.1,<2.0
 pybids>=0.14.0,<0.15.6
 scikit-learn>=0.20.3
 scikit-image~=0.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ onnx
 # So, pin to >=1.7.0 to avoid having to ask users to install libomp.
 # Avoid version 1.16.0 due to: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4225
 onnxruntime>=1.7.0,!=1.16.0
-pandas>=1.1,<1.5.0
+pandas>=1.1
 pybids>=0.14.0,<0.15.6
 scikit-learn>=0.20.3
 scikit-image~=0.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,3 @@
-# workarounds for pip 20.0.2's buggy dependency resolver
-# which doesn't account for cross-package constraints: https://pip.pypa.io/en/stable/user_guide/#changes-to-the-pip-dependency-resolver-in-20-3-2020
-# matplotlib pulls in the latest pyparsing, nibabel pulls in the latest packaging, and the two latests are in conflict.
-# > ERROR: packaging 21.2 has requirement pyparsing<3,>=2.0.2, but you'll have pyparsing 3.0.5 which is incompatible.
-# This forces the older pip, if the user has the older pip, to behave itself.
-# This is to specially support users on Ubuntu 20.04 LTS; when Ubuntu 22.04 LTS comes out, this can be removed.
-pyparsing<3,>=2.0.2
 csv-diff>=1.0
 loguru~=0.5
 imageio>=2.31.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ loguru~=0.5
 imageio>=2.31.4
 joblib~=1.0
 matplotlib>=3.3.0
-nibabel~=3.2
+nibabel~=5.2
 onnx
 # 1.7.0>onnxruntime>=1.5.1 required `brew install libomp` on macOS.
 # So, pin to >=1.7.0 to avoid having to ask users to install libomp.


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR stems from https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4319. In that issue, we discovered that ivadomed pins the `3.x` series of `nibabel` releases, while the current major version of the `nibabel` package is `5.x`. Disallowing newer versions of `nibabel` caused an incompatibility with the newest version of another package that SCT relies on (`dipy`). 

As a quick fix, SCT has pinned an older version of `dipy`. But, ideally, we would upgrade both `dipy` _and_ `nibabel`, which requires changes to `ivadomed`'s pinned dependencies.

I'm going to start by testing `nibabel==5.x`, and then move on to other dependencies that currently have some sort of upper bound, just to see the limits of what `ivadomed` can support.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Partially addresses https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4319.