### PR TITLE
Update dependencies (`pandas`, `numpy`, `onnx`)

### DIFF
--- a/dev/filtering_lesion.py
+++ b/dev/filtering_lesion.py
@@ -192,8 +192,8 @@ def plot_roc(thr_unc_lst, thr_pred_lst, res_dct, metric, fname_out):
 
 
 def run_inference(pred_folder, im_lst, thr_pred, gt_folder, target_suf, param_eval, unc_name=None, thr_unc=None):
-    # init df
-    df_results = pd.DataFrame()
+    # init df row list
+    df_lst = []
 
     # loop across images
     for fname_pref in im_lst:
@@ -236,8 +236,9 @@ def run_inference(pred_folder, im_lst, thr_pred, gt_folder, target_suf, param_ev
 
         # save results of this fname_pred
         results_pred['image_id'] = fname_pref.split('_')[0]
-        df_results = df_results.append(results_pred, ignore_index=True)
+        df_lst.append(results_pred)
 
+    df_results = pd.DataFrame(df_lst)
     return df_results
 
 

--- a/ivadomed/evaluation.py
+++ b/ivadomed/evaluation.py
@@ -37,8 +37,8 @@ def evaluate(bids_df, path_output, target_suffix, eval_params):
     if not path_results.is_dir():
         path_results.mkdir(parents=True)
 
-    # INIT DATA FRAME
-    df_results = pd.DataFrame()
+    # INIT DATA FRAME ROW LIST
+    df_lst = []
 
     # LIST PREDS
     subj_acq_lst = [f.name.split('_pred')[0] for f in path_preds.iterdir() if f.name.endswith('_pred.nii.gz')]
@@ -109,8 +109,9 @@ def evaluate(bids_df, path_output, target_suffix, eval_params):
 
         # SAVE RESULTS FOR THIS PRED
         results_pred['image_id'] = subj_acq
-        df_results = df_results.append(results_pred, ignore_index=True)
+        df_lst.append(results_pred)
 
+    df_results = pd.DataFrame(df_lst)
     df_results = df_results.set_index('image_id')
     df_results.to_csv(str(path_results.joinpath('evaluation_3Dmetrics.csv')))
 

--- a/ivadomed/scripts/visualize_and_compare_testing_models.py
+++ b/ivadomed/scripts/visualize_and_compare_testing_models.py
@@ -135,9 +135,7 @@ def visualize_and_compare_models(ofolders, metric="dice_class0", metadata=None):
     if len(ofolders) < 1:
         raise Exception('No folders were selected - Nothing to show')
 
-    columnNames = ["EvaluationModel", metric, 'subject']
-    df = pd.DataFrame([], columns=columnNames)
-
+    np_lst = []
     for folder in ofolders:
         result = pd.read_csv(str(Path(folder, 'results_eval', 'evaluation_3Dmetrics.csv')))
 
@@ -161,9 +159,12 @@ def visualize_and_compare_models(ofolders, metric="dice_class0", metadata=None):
 
             folders = [Path(folder).resolve().name] * len(scores)
             subject_id = result["image_id"]
-            combined = np.column_stack((folders, scores.astype(np.object, folders), subject_id)).T
-            singleFolderDF = pd.DataFrame(combined, columnNames).T
-            df = df.append(singleFolderDF, ignore_index=True)
+            combined = np.column_stack((folders, scores.astype(np.object, folders), subject_id))
+            np_lst.append(combined)
+
+    columnNames = ["EvaluationModel", metric, 'subject']
+    rows = np.vstack(np_lst)
+    df = pd.DataFrame(rows, columns=columnNames)
 
     nFolders = len(ofolders)
     combinedNumbers = list(itertools.combinations(range(nFolders), 2))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,9 @@ imageio>=2.31.4
 joblib~=1.0
 matplotlib>=3.3.0
 nibabel~=5.2
-onnx
+# v1.16.2/v1.17.0 aren't built correctly for Windows:
+# https://github.com/onnx/onnx/issues/6267
+onnx<1.16.2
 # 1.7.0>onnxruntime>=1.5.1 required `brew install libomp` on macOS.
 # So, pin to >=1.7.0 to avoid having to ask users to install libomp.
 # Avoid version 1.16.0 due to: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4225

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,7 @@ onnx
 # So, pin to >=1.7.0 to avoid having to ask users to install libomp.
 # Avoid version 1.16.0 due to: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4225
 onnxruntime>=1.7.0,!=1.16.0
-# `pandas==2.0` removed the `DataFrame.append` call, which we currently use in approx. 13 places (per PyCharm search)
-pandas>=1.1,<2.0
+pandas>=1.1
 pybids>=0.14.0,<0.15.6
 scikit-learn>=0.20.3
 scikit-image~=0.17


### PR DESCRIPTION
## Description

- `pandas<2.0`: Previously held back due to deprecated `df.append` calls. I've replaced the calls with `list.append` + `pd.Dataframe(list)` to avoid costly append/concatenation, as per https://stackoverflow.com/a/75956237.
- `numpy>=2.0`: This update is automatic, and comes with unpinning `pandas`. But, it's also the motivation for this PR in the first place, since it allows SCT to upgrade as well:
    - https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4535
- `onnx<1.16.2`: This is a Windows specific bug, see #1321.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #1317.
Fixes #1321.