### PR TITLE
Dependency maintenance (drop Py3.8, add Py3.11/3.12/3.13, update numpy/pandas to 2.0)

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Cache pip dependencies
         id: cache-pip-dependencies

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -66,7 +66,7 @@ jobs:
 
       matrix:
         os: [ "macos-latest", "windows-latest", "ubuntu-20.04" ]
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
         test-name:
           - integration-test
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -66,7 +66,7 @@ jobs:
 
       matrix:
         os: [ "macos-latest", "windows-latest", "ubuntu-latest" ]
-        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
         test-name:
           - integration-test
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [ "macos-latest", "windows-latest", "ubuntu-20.04" ]
+        os: [ "macos-latest", "windows-latest", "ubuntu-latest" ]
         python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
         test-name:
           - integration-test

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -66,7 +66,7 @@ jobs:
 
       matrix:
         os: [ "macos-latest", "windows-latest", "ubuntu-20.04" ]
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
         test-name:
           - integration-test
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -66,7 +66,7 @@ jobs:
 
       matrix:
         os: [ "macos-latest", "windows-latest", "ubuntu-20.04" ]
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
         test-name:
           - integration-test
 

--- a/.github/workflows/run_tests_dummy.yml
+++ b/.github/workflows/run_tests_dummy.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         # This list must be kept **in sync** with the Required Statuses in https://github.com/ivadomed/ivadomed/settings/branch_protection_rules/5051948
         os: [ "macos-latest", "windows-latest", "ubuntu-20.04" ]
-        python-version: [ 3.8 ]
+        python-version: [ 3.9 ]
         test-name:
           - integration-test
 

--- a/.github/workflows/run_tests_dummy.yml
+++ b/.github/workflows/run_tests_dummy.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         # This list must be kept **in sync** with the Required Statuses in https://github.com/ivadomed/ivadomed/settings/branch_protection_rules/5051948
-        os: [ "macos-latest", "windows-latest", "ubuntu-20.04" ]
+        os: [ "macos-latest", "windows-latest", "ubuntu-latest" ]
         python-version: [ 3.9 ]
         test-name:
           - integration-test

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-lts-latest
   tools:
     python: "3.10"
 

--- a/ivadomed/scripts/automate_training.py
+++ b/ivadomed/scripts/automate_training.py
@@ -102,8 +102,8 @@ def train_worker(config, thr_incr):
         raise
 
     # Save config file in output path
-    config_copy = open(config[ConfigKW.PATH_OUTPUT] + "/config_file.json", "w")
-    json.dump(config, config_copy, indent=4)
+    with open(Path(config[ConfigKW.PATH_OUTPUT]) / "config_file.json", "w") as config_copy:
+        json.dump(config, config_copy, indent=4)
 
     return config[ConfigKW.PATH_OUTPUT], best_training_dice, best_training_loss, best_validation_dice, \
         best_validation_loss

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,11 @@ tensorboard>=1.15.0
 tqdm>=4.30
 scipy
 torchio>=0.18.68
-torch>=1.8.1
+# - torch<2.6: In January 2025, PyTorch changed the default of `torch.load()` to `weights_only=True`, breaking the
+#              loading of some of our models. We can set `weights_only=False` to retain the old behavior, however
+#              there are additional calls to `torch.load()` within our dependencies as well, meaning that we need to
+#              wait until they update themselves (or become compatible with `weights_only=True`). Until then, we can
+#              pin torch to a version prior to this breaking change.
+torch>=1.8.1,<2.6
 torchvision>=0.9.1
 wandb>=0.12.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ imageio>=2.31.4
 joblib~=1.0
 matplotlib>=3.3.0
 nibabel~=5.2
+numpy<2.0
 # v1.16.2/v1.17.0 aren't built correctly for Windows:
 # https://github.com/onnx/onnx/issues/6267
 onnx<1.16.2

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         'Intended Audience :: Developers',
         'Programming Language :: Python :: 3',
     ],
-    python_requires='>=3.7,<3.11',
+    python_requires='>=3.7,<3.13',
     packages=find_packages(exclude=['docs', 'tests']),
     include_package_data=True,
     install_requires=requirements,

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         'Intended Audience :: Developers',
         'Programming Language :: Python :: 3',
     ],
-    python_requires='>=3.7,<3.13',
+    python_requires='>=3.7,<3.14',
     packages=find_packages(exclude=['docs', 'tests']),
     include_package_data=True,
     install_requires=requirements,


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

The purpose of this PR is twofold:

- Test Py3.11 and Py3.12 against `master`
- Retrigger the test suite on `master` to make sure that the Py3.8/Windows/onnx errors are present on master (and to debug which version of onnx the issue was introduced in).

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #1319.
